### PR TITLE
Fix formatting in all files

### DIFF
--- a/src/Ast/Expression.php
+++ b/src/Ast/Expression.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 

--- a/src/Ast/PhpDoc.php
+++ b/src/Ast/PhpDoc.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -1,15 +1,16 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator;
 
-use \Google\Generator\Collections\Vector;
-use \Google\Generator\Generation\GapicClientGenerator;
-use \Google\Generator\Generation\ServiceDetails;
-use \Google\Generator\Generation\SourceFileContext;
-use \Google\Generator\Utils\ProtoCatalog;
-use \Google\Generator\Utils\ProtoHelpers;
-use \Google\Generator\Utils\SourceCodeInfoHelper;
-use \Google\Protobuf\Internal\FileDescriptorSet;
+use Google\Generator\Collections\Vector;
+use Google\Generator\Generation\GapicClientGenerator;
+use Google\Generator\Generation\ServiceDetails;
+use Google\Generator\Generation\SourceFileContext;
+use Google\Generator\Utils\ProtoCatalog;
+use Google\Generator\Utils\ProtoHelpers;
+use Google\Generator\Utils\SourceCodeInfoHelper;
+use Google\Protobuf\Internal\FileDescriptorSet;
 
 class CodeGenerator
 {

--- a/src/Collections/Equality.php
+++ b/src/Collections/Equality.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Collections;
 

--- a/src/Collections/EqualityHelper.php
+++ b/src/Collections/EqualityHelper.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Collections;
 

--- a/src/Collections/Map.php
+++ b/src/Collections/Map.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Collections;
 

--- a/src/Collections/Set.php
+++ b/src/Collections/Set.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Collections;
 

--- a/src/Collections/Vector.php
+++ b/src/Collections/Vector.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Collections;
 

--- a/src/Main.php
+++ b/src/Main.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator;
 

--- a/src/Utils/ProtoCatalog.php
+++ b/src/Utils/ProtoCatalog.php
@@ -1,11 +1,12 @@
 <?php
+declare(strict_types=1);
 
 namespace Google\Generator\Utils;
 
-use \Google\Generator\Collections\Vector;
-use \Google\Generator\Collections\Map;
-use \Google\Generator\Utils\ProtoHelpers;
-use \Google\Protobuf\Internal\Descriptor;
+use Google\Generator\Collections\Vector;
+use Google\Generator\Collections\Map;
+use Google\Generator\Utils\ProtoHelpers;
+use Google\Protobuf\Internal\Descriptor;
 
 class ProtoCatalog
 {

--- a/src/Utils/ProtoHelpers.php
+++ b/src/Utils/ProtoHelpers.php
@@ -1,13 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Utils;
 
-use \Google\Generator\Collections\Vector;
-use \Google\Protobuf\Internal\CodedInputStream;
-use \Google\Protobuf\Internal\FileDescriptorProto;
-use \Google\Protobuf\Internal\GPBWire;
-use \Google\Protobuf\Internal\HasPublicDescriptorTrait;
-use \Google\Protobuf\Internal\Message;
+use Google\Generator\Collections\Vector;
+use Google\Protobuf\Internal\CodedInputStream;
+use Google\Protobuf\Internal\FileDescriptorProto;
+use Google\Protobuf\Internal\GPBWire;
+use Google\Protobuf\Internal\HasPublicDescriptorTrait;
+use Google\Protobuf\Internal\Message;
 
 class ProtoHelpers
 {

--- a/tests/Ast/ASTTest.php
+++ b/tests/Ast/ASTTest.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Tests\Ast;
 

--- a/tests/Ast/PhpDocTest.php
+++ b/tests/Ast/PhpDocTest.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Tests\Collections;
 

--- a/tests/Collections/MapTest.php
+++ b/tests/Collections/MapTest.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Tests\Collections;
 

--- a/tests/Collections/SetTest.php
+++ b/tests/Collections/SetTest.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Tests\Collections;
 

--- a/tests/Collections/VectorTest.php
+++ b/tests/Collections/VectorTest.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Google\Generator\Tests\Collections;
 


### PR DESCRIPTION
Place 'strict_types' declaration on its own line; and remove all leading backslashes in 'use' statements.