### PR TITLE
Remove Nette/PhpGenerator dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     },
     "require": {
         "google/protobuf": "^3.13",
-        "nette/php-generator": "^3.4",
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "require-dev": {

--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Google\Generator\Ast;
 
 use Google\Generator\Collections\Vector;
+use Google\Generator\Utils\Type;
 
 /** Base of the PHP code AST. */
 abstract class AST
@@ -43,13 +44,56 @@ abstract class AST
         }
     }
 
+    protected function clone(Callable $fnOnClone)
+    {
+        $clone = clone $this;
+        $fnOnClone($clone);
+        return $clone;
+    }
+
+    /**
+     * Create a PHP file.
+     *
+     * @param PhpClass $class The class to be contained within this file.
+     *
+     * @return PhpFile
+     */
+    public static function file(PhpClass $class): PhpFile
+    {
+        return new PhpFile($class);
+    }
+
+    /**
+     * Create a class.
+     *
+     * @param Type $type The type of the class to create.
+     *
+     * @return PhpClass
+     */
+    public static function class(Type $type): PhpClass
+    {
+        return new PhpClass($type);
+    }
+
+    /**
+     * Create a class constant.
+     *
+     * @param string $name The name of the constant.
+     *
+     * @return PhpConstant
+     */
+    public static function constant(string $name): PhpConstant
+    {
+        return new PhpConstant($name);
+    }
+
     /**
      * Create a block of PHP code.
-     * 
+     *
      * @param array $code The code to include in this block.
      *     Each item must be an AST instance or a Vector thereof.
      *     Null values will be ignored.
-     * 
+     *
      * @return AST
      */
     public static function block(...$code): AST
@@ -73,9 +117,9 @@ abstract class AST
 
     /**
      * Create a PHP variable.
-     * 
+     *
      * @param string $name The name of the variable, without leading '$'.
-     * 
+     *
      * @return Expression
      */
     public static function var(string $name): Expression
@@ -94,9 +138,9 @@ abstract class AST
 
     /**
      * Create a 'return' statement, returning the specified expression.
-     * 
+     *
      * @param Expression $expr Expression to return.
-     * 
+     *
      * @return AST
      */
     public static function return(Expression $expr): AST
@@ -115,9 +159,9 @@ abstract class AST
 
     /**
      * Create an array initializer expression.
-     * 
+     *
      * @param array $array The array content. Supports both associative and sequential arrays.
-     * 
+     *
      * @return Expression
      */
     public static function array(array $array): Expression
@@ -143,10 +187,10 @@ abstract class AST
 
     /**
      * Create an expression to access a class property or const.
-     * 
+     *
      * @param mixed $obj The object containing the accessee.
      * @param mixed $accessee The property or const being accessed.
-     * 
+     *
      * @return Expression
      */
     public static function access($obj, $accessee): Expression
@@ -166,10 +210,10 @@ abstract class AST
 
     /**
      * Create an expression to call a method. This method returns a Callable into which the args are passed.
-     * 
+     *
      * @param mixed $obj The object containing the method to call.
      * @param mixed $callee The method to call.
-     * 
+     *
      * @return Callable The returned Callable returns an Expression once called with callee args.
      */
     public static function call($obj, $callee): Callable
@@ -192,7 +236,7 @@ abstract class AST
     /**
      * Convert this AST to lines of text suitable for directlyincluding in the output PHP file.
      * The returned string will be mostly unformatted, so an extra formatting step will be required.
-     * 
+     *
      * @return string
      */
     public abstract function toCode(): string;

--- a/src/Ast/HasPhpDoc.php
+++ b/src/Ast/HasPhpDoc.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Google\Generator\Ast;
+
+trait HasPhpDoc
+{
+    /**
+     * Create a version of this ast element with PHP doc.
+     * 
+     * @param PhpDoc $phpDoc The PHP doc to use.
+     * 
+     * @return self
+     */
+    public function withPhpDoc(PhpDoc $phpDoc): self
+    {
+        return $this->clone(fn($clone) => $clone->phpDoc = $phpDoc);
+    }
+
+    protected function phpDocToCode(): string
+    {
+        return $this->phpDoc->toCode();
+    }
+}

--- a/src/Ast/PhpClass.php
+++ b/src/Ast/PhpClass.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Google\Generator\Ast;
+
+use Google\Generator\Collections\Set;
+use Google\Generator\Collections\Vector;
+use Google\Generator\Utils\ResolvedType;
+use Google\Generator\Utils\Type;
+
+/** A class definition. */
+final class PhpClass extends AST
+{
+    use HasPhpDoc;
+
+    public function __construct(Type $type)
+    {
+        $this->type = $type;
+        $this->traits = Set::new();
+        $this->members = Vector::new();
+    }
+
+    /** @var Type *Readonly* The type of this class. */
+    public Type $type;
+
+    /** @var Set *Readonly* Set of ResolvedType; the traits used by this class. */
+    public Set $traits;
+
+    /** @var Vector *Readonly* Vector of PhpClassMember; all members of this class. */
+    public Vector $members;
+
+    /**
+     * Create a class with an additional trait.
+     * 
+     * @param ResolvedType $trait Trait to add. Must be a type which is a trait.
+     * 
+     * @return PhpClass
+     */
+    public function withTrait(ResolvedType $trait): PhpClass
+    {
+        if (!$trait->type->isClass()) {
+            throw new \Exception('Only classes (traits) may be used as a trait.');
+        }
+        return $this->clone(fn($clone) => $clone->traits = $clone->traits->add($trait));
+    }
+
+    /**
+     * Create a class with an additional member.
+     * 
+     * @param PhpClassMember $member The member to add.
+     * 
+     * @return PhpClass
+     */
+    public function withMember(PhpClassMember $member): PhpClass
+    {
+        return $this->clone(fn($clone) => $clone->members = $clone->members->append($member));
+    }
+
+    public function toCode(): string
+    {
+        return
+            $this->phpDocToCode() .
+            "class {$this->type->name}\n" .
+            "{\n" .
+            $this->traits->toVector()->map(fn($x) => "use {$x->toCode()};\n")->join() .
+            (count($this->traits) >= 1 ? "\n" : '') .
+            $this->members->map(fn($x) => $x->toCode() . "\n")->join() .
+            "}\n";
+    }
+}

--- a/src/Ast/PhpClassMember.php
+++ b/src/Ast/PhpClassMember.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Google\Generator\Ast;
+
+/** A member of a class. */
+abstract class PhpClassMember extends AST
+{
+    use HasPhpDoc;
+}

--- a/src/Ast/PhpConstant.php
+++ b/src/Ast/PhpConstant.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Google\Generator\Ast;
+
+/** A constant within a class. */
+final class PhpConstant extends PhpClassMember
+{
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Create a constant with the specified value.
+     * 
+     * @param mixed $value The value of the constant.
+     * 
+     * @return PhpConstant
+     */
+    public function withValue($value): PhpConstant
+    {
+        return $this->clone(fn($clone) => $clone->value = $value);
+    }
+
+    public function toCode(): string
+    {
+        return
+            $this->phpDocToCode() .
+            "const {$this->name} = " . static::toPhp($this->value) . ';';
+    }
+}

--- a/src/Ast/PhpDoc.php
+++ b/src/Ast/PhpDoc.php
@@ -40,7 +40,6 @@ abstract class PhpDoc
                     }
                     return $result;
                 });
-                return $this->items->flatMap(fn($x) => $x->toLines($info)->append(''));
             }
         };
     }
@@ -148,10 +147,14 @@ abstract class PhpDoc
         };
     }
 
+    /**
+     * Add the @experimental tag to the PHP doc block.
+     *
+     * @return PhpDoc
+     */
     public static function experimental(): PhpDoc
     {
-        return new class extends PhpDoc
-        {
+        return new class extends PhpDoc {
             protected function toLines(Map $info): Vector
             {
                 return Vector::new(['@experimental']);
@@ -178,6 +181,13 @@ abstract class PhpDoc
     public function toCode(): string
     {
         $lines = $this->toLines(Map::new());
-        return $lines->join("\n");
+        if (count($lines) <= 1) {
+            return "/** {$lines->join()} */\n";
+        } else {
+            return
+                "/**\n" .
+                $lines->map(fn($x) => ' *' . (strlen($x) === 0 ? "\n" : " {$x}\n"))->join() .
+                " */\n";
+        }
     }
 }

--- a/src/Ast/PhpFile.php
+++ b/src/Ast/PhpFile.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Google\Generator\Ast;
+
+use Google\Generator\Collections\Set;
+
+final class PhpFile extends AST
+{
+    public function __construct(PhpClass $class)
+    {
+        $this->class = $class;
+        $this->uses = Set::new();
+    }
+
+    private Set $uses;
+
+    public function withUses(Set $uses)
+    {
+        return $this->clone(fn($clone) => $clone->uses = $uses);
+    }
+
+    public function toCode(): string
+    {
+        return
+            "<?php\n" .
+            "declare(strict_types=1);\n" .
+            "\n" .
+            "namespace {$this->class->type->getNamespace()};\n" .
+            "\n" .
+            $this->uses->toVector()->map(fn($x) => "use {$x->getFullname(true)};\n")->join() .
+            (count($this->uses) >= 1 ? "\n" : '') .
+            static::toPhp($this->class);
+    }
+}

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -7,6 +7,7 @@ use Google\Generator\Collections\Vector;
 use Google\Generator\Generation\GapicClientGenerator;
 use Google\Generator\Generation\ServiceDetails;
 use Google\Generator\Generation\SourceFileContext;
+use Google\Generator\Utils\Formatter;
 use Google\Generator\Utils\ProtoCatalog;
 use Google\Generator\Utils\ProtoHelpers;
 use Google\Generator\Utils\SourceCodeInfoHelper;
@@ -75,7 +76,9 @@ class CodeGenerator
             {
                 $serviceDetails = new ServiceDetails($catalog, $namespace, $fileDesc->getPackage(), $service);
                 $ctx = new SourceFileContext();
-                $code = GapicClientGenerator::Generate($ctx, $serviceDetails);
+                $file = GapicClientGenerator::Generate($ctx, $serviceDetails);
+                $code = $file->toCode();
+                $code = Formatter::format($code);
                 yield $code;
             }
             // TODO: Further files, as required.

--- a/src/Collections/Set.php
+++ b/src/Collections/Set.php
@@ -102,4 +102,14 @@ class Set implements \IteratorAggregate, \Countable, \ArrayAccess
             return new Set($map);
         }
     }
+
+    /**
+     * Convert this set to a vector. Order of elements is non-deterministic.
+     *
+     * @return Vector
+     */
+    public function toVector(): Vector
+    {
+        return Vector::new($this);
+    }
 }

--- a/src/Generation/ServiceDetails.php
+++ b/src/Generation/ServiceDetails.php
@@ -3,34 +3,31 @@ declare(strict_types=1);
 
 namespace Google\Generator\Generation;
 
-use \Google\Protobuf\Internal\ServiceDescriptorProto;
-use \Google\Generator\Utils\ProtoCatalog;
-use \Google\Generator\Utils\ProtoHelpers;
-use \Google\Generator\Utils\CustomOptions;
-use \Google\Generator\Utils\Helpers;
-use \Google\Generator\Collections\Vector;
+use Google\Generator\Collections\Vector;
+use Google\Generator\Utils\CustomOptions;
+use Google\Generator\Utils\Helpers;
+use Google\Generator\Utils\ProtoCatalog;
+use Google\Generator\Utils\ProtoHelpers;
+use Google\Generator\Utils\Type;
+use Google\Protobuf\Internal\ServiceDescriptorProto;
 
 class ServiceDetails {
     /** @var ProtoCatalog *Readonly* The proto-catalog containing all source protos. */
     public ProtoCatalog $catalog;
 
-    /** @var string *Readonly* The PHP namespace of this service client. */
-    public string $clientNamespace;
-
-    /** @var string *Readonly* The name of the service client class. */
-    public string $gapicClientClassName;
+    /** @var string *Readonly* The type of the service client class. */
+    public Type $gapicClientType;
 
     /** @var Vector *Readonly* Vector of strings; the documentation lines from the source proto. */
     public Vector $docLines;
 
-    /** @var string *Readonly* ... */
+    /** @var string *Readonly* The full name of the service. */
     public string $serviceName;
 
     public function __construct(ProtoCatalog $catalog, string $namespace, string $package, ServiceDescriptorProto $desc)
     {
         $this->catalog = $catalog;
-        $this->clientNamespace = "{$namespace}\Gapic";
-        $this->gapicClientClassName = "{$desc->getName()}GapicClient";
+        $this->gapicClientType = Type::fromName("{$namespace}\\Gapic\\{$desc->getName()}GapicClient");
         $this->docLines = $desc->leadingComments;
         $this->serviceName = "{$package}.{$desc->getName()}";
         // TODO: More details...

--- a/src/Generation/SourceFileContext.php
+++ b/src/Generation/SourceFileContext.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Google\Generator\Generation;
 
-use \Google\Generator\Collections\Set;
-use \Nette\PhpGenerator\PhpNamespace;
+use Google\Generator\Ast\PhpFile;
+use Google\Generator\Collections\Set;
+use Google\Generator\Utils\ResolvedType;
+use Google\Generator\Utils\Type;
 
 /** Track per-file data. */
 class SourceFileContext
@@ -42,23 +44,22 @@ class SourceFileContext
         if ($type->isClass()) {
             if ($type->getNamespace() !== $this->namespace) {
                 // No 'use' required if type is in the current namespace
-                $fullname = $type->getFullname();
-                $this->uses = $this->uses->add($fullname);
+                $this->uses = $this->uses->add($type);
             }
         }
-        return new ResolvedType($type->name);
+        return new ResolvedType($type, fn() => $type->name);
     }
 
     /**
-     * Add required 'use' statements to the source file.
-     * 
-     * @param PhpNamespace $namespace The namespace within the file that requires the 'use' statements.
+     * Finalize this source context; after this call there must be no further changes.
+     * The PhpFile passed in can be altered as necessary for this finalization.
+     *
+     * @param PhpFile $file The file being generared with this context.
+     *
+     * @return PhpFile
      */
-    public function addUses(PhpNamespace $namespace): void
+    public function finalize(PhpFile $file): PhpFile
     {
-        // TODO: Sort 'use' statements in canonical order.
-        foreach ($this->uses as $use) {
-            $namespace->addUse($use);
-        }
+        return $file->withUses($this->uses);
     }
 }

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Google\Generator;
+namespace Google\Generator\Utils;
 
 class Formatter
 {

--- a/src/Utils/ResolvedType.php
+++ b/src/Utils/ResolvedType.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Google\Generator\Generation;
+namespace Google\Generator\Utils;
 
 /**
  * Represent a resolved type, ready to use in code output.
@@ -9,21 +9,24 @@ namespace Google\Generator\Generation;
  */
 class ResolvedType
 {
-    /** @var string The type as is ready to use in code output. */
-    public string $typeName;
-
     /**
      * Construct a ResolvedType.
      * 
      * @param string $typeName The resolved name of the type.
      */
-    public function __construct(string $typeName)
+    public function __construct(Type $type, \Closure $fnToCode)
     {
-        $this->typeName = $typeName;
+        $this->type = $type;
+        $this->fnToCode = $fnToCode;
     }
 
-    public function __toString()
+    /** @var Type *Readonly* The type of this resolved-type. */
+    public Type $type;
+
+    private \Closure $fnToCode;
+
+    public function toCode(): string
     {
-        return $this->typeName;
+        return ($this->fnToCode)();
     }
 }

--- a/src/Utils/Type.php
+++ b/src/Utils/Type.php
@@ -1,14 +1,15 @@
 <?php
 declare(strict_types=1);
 
-namespace Google\Generator\Generation;
+namespace Google\Generator\Utils;
 
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\Descriptor;
+use Google\Generator\Collections\Equality;
 use Google\Generator\Collections\Vector;
 
 /** A fully-specified PHP type. */
-class Type
+class Type implements Equality
 {
     /**
      * Build a type from a class full-name.
@@ -64,8 +65,22 @@ class Type
      * 
      * @return string
      */
-    public function getFullname(): string
+    public function getFullname($omitLeadingBackslash = false): string
     {
-        return $this->isClass() ? "\\{$this->getNamespace()}\\{$this->name}" : $this->name;
+        return $this->isClass() ?
+            ($omitLeadingBackslash ? '' : '\\') . "{$this->getNamespace()}\\{$this->name}" :
+            $this->name;
+    }
+
+    // Equality methods
+
+    public function getHash(): int
+    {
+        return crc32($this->getFullname());
+    }
+
+    public function isEqualTo($other): bool
+    {
+        return $other instanceof Type && $this->getFullname() === $other->getFullname();
     }
 }

--- a/tests/Ast/PhpDocTest.php
+++ b/tests/Ast/PhpDocTest.php
@@ -18,7 +18,7 @@ final class PhpDocTest extends TestCase
                 'and finally, line 3'
             ]))
         )->toCode();
-        $this->assertEquals("Line 1\nLine 2\nand finally, line 3", $doc);
+        $this->assertEquals("/**\n * Line 1\n * Line 2\n * and finally, line 3\n */\n", $doc);
     }
 
     public function testText(): void
@@ -31,7 +31,7 @@ final class PhpDocTest extends TestCase
             )
         )->toCode();
         $this->assertEquals(
-            "Some text which will be formatted to a fixed line length of 80 characters, with\nauto line wrapping at that point :)",
+            "/**\n * Some text which will be formatted to a fixed line length of 80 characters, with\n * auto line wrapping at that point :)\n */\n",
             $doc);
     }
 
@@ -44,7 +44,7 @@ final class PhpDocTest extends TestCase
                 'two'
             ),
         )->toCode();
-        $this->assertEquals("one\ntwo", $doc);
+        $this->assertEquals("/**\n * one\n * two\n */\n", $doc);
     }
 
     public function testExperimental(): void
@@ -52,6 +52,6 @@ final class PhpDocTest extends TestCase
         $doc = PhpDoc::block(
             PhpDoc::experimental()
         )->toCode();
-        $this->assertEquals('@experimental', $doc);
+        $this->assertEquals("/** @experimental */\n", $doc);
     }
 }

--- a/tests/Collections/SetTest.php
+++ b/tests/Collections/SetTest.php
@@ -51,4 +51,13 @@ final class SetTest extends TestCase
         $s = $s->add(2);
         $this->assertCount(2, $s);
     }
+
+    public function testToVector(): void
+    {
+        $s = Set::new([1, 2]);
+        $v = $s->toVector();
+        $this->assertCount(2, $v);
+        $this->assertContains(1, $v);
+        $this->assertContains(2, $v);
+    }
 }

--- a/tests/ProtoTests/ProtoTest.php
+++ b/tests/ProtoTests/ProtoTest.php
@@ -10,7 +10,7 @@ final class ProtoTest extends TestCase
 {
     use ProtoTrait;
 
-    public function testCustomOptions(): void
+    public function testProtoBasic(): void
     {
         // TODO: Abstract out this form of testing, once we have more than just this one proto-based test.
 
@@ -42,7 +42,7 @@ use Google\ApiCore\GapicClientTrait;
  */
 class BasicGapicClient
 {
-    use \GapicClientTrait;
+    use GapicClientTrait;
 
     /** The name of the service. */
     const SERVICE_NAME = 'testing.basic.Basic';

--- a/tests/Utils/TypeTest.php
+++ b/tests/Utils/TypeTest.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace Google\Generator\Tests\Generation;
+namespace Google\Generator\Tests\Utils;
 
 use PHPUnit\Framework\TestCase;
 use Google\Generator\Collections\Vector;
-use Google\Generator\Generation\Type;
+use Google\Generator\Utils\Type;
 
 final class TypeTest extends TestCase
 {


### PR DESCRIPTION
Two reasons for this: (1) Nette contained a bug in handling 'use <trait>' statements; (2) Nette forced code to be converted from AST to text at an earlier stage than desirable. Therefore our custom AST has been expanded to cover the 'structural' PHP previously handled by Nette.