### PR TITLE
Generate two more test helpers

### DIFF
--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -400,6 +400,31 @@ abstract class AST
     }
 
     /**
+     * Create a binary operation expression.
+     *
+     * @param AST $lhs The left-hand side of the binary operation.
+     * @param string $op The operation to preform.
+     * @param mixed $rhs The right-hand side of the binary operation.
+     *
+     * @return Expression
+     */
+    public static function binaryOp(AST $lhs, string $op, $rhs): Expression
+    {
+        return new class($lhs, $op, $rhs) extends Expression {
+            public function __construct($lhs, $op, $rhs)
+            {
+                $this->lhs = $lhs;
+                $this->op = $op;
+                $this->rhs = $rhs;
+            }
+            public function toCode(): string
+            {
+                return static::toPhp($this->lhs) . " {$this->op} " . static::toPhp($this->rhs);
+            }
+        };
+    }
+
+    /**
      * Create an if statement.
      *
      * @param Expression $expr The conditional expression for the if statement.

--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Google\Generator\Generation;
 
+use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\ApiCore\Transport\TransportInterface;
@@ -57,7 +58,9 @@ class UnitTestsGenerator
     private function GenerateClass(): PhpClass
     {
         return AST::class($this->serviceDetails->unitTestsType, $this->ctx->type(Type::fromName(GeneratedTest::class)))
-            ->withMember($this->createTransport());
+            ->withMember($this->createTransport())
+            ->withMember($this->createCredentials())
+            ->withMember($this->createClient());
     }
 
     private function createTransport(): PhpClassMember
@@ -71,6 +74,42 @@ class UnitTestsGenerator
             ))
             ->withPhpDoc(PhpDoc::block(
                 PhpDoc::return($this->ctx->type(Type::fromName(TransportInterface::class)))
+            ));
+    }
+
+    private function createCredentials(): PhpClassMember
+    {
+        return AST::method('createCredentials')
+            ->withAccess(Access::PRIVATE)
+            ->withBody(AST::block(
+                AST::return(
+                    AST::call(
+                        AST::call(
+                            AST::call(AST::THIS, AST::method('getMockBuilder'))(
+                                AST::access($this->ctx->type(Type::fromName(CredentialsWrapper::class)), AST::CLS)),
+                            AST::method('disableOriginalConstructor'))(),
+                        AST::method('getMock'))()
+                )
+            ))
+            ->withPhpDoc(PhpDoc::block(
+                PhpDoc::return($this->ctx->type(Type::fromName(CredentialsWrapper::class)))
+            ));
+    }
+
+    private function createClient(): PhpClassMember
+    {
+        $options = AST::param($this->ctx->type(Type::array()), AST::var('options'), AST::array([]));
+        return AST::method('createClient')
+            ->withAccess(Access::PRIVATE)
+            ->withParams($options)
+            ->withBody(AST::block(
+                AST::binaryOp($options->var, '+=', AST::array([
+                    'credentials' => AST::call(AST::THIS, $this->createCredentials())()
+                ])),
+                AST::return(AST::new($this->ctx->type($this->serviceDetails->emptyClientType))($options->var))
+            ))
+            ->withPhpDoc(PhpDoc::block(
+                PhpDoc::return($this->ctx->type($this->serviceDetails->emptyClientType))
             ));
     }
 }

--- a/tests/ProtoTests/Basic/tests/BasicClientTest.php
+++ b/tests/ProtoTests/Basic/tests/BasicClientTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace testing\basic;
 
+use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\ApiCore\Transport\TransportInterface;
+use testing\basic\BasicClient;
 
 class BasicClientTest extends GeneratedTest
 {
@@ -14,5 +16,21 @@ class BasicClientTest extends GeneratedTest
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
+    }
+
+    /** @return CredentialsWrapper */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /** @return BasicClient */
+    private function createClient(array $options = [])
+    {
+        $options += [
+            'credentials' => $this->createCredentials(),
+        ];
+
+        return new BasicClient($options);
     }
 }


### PR DESCRIPTION
An example of a generated PHP test file: https://github.com/googleapis/google-cloud-php/blob/a879c61ac550cc12c501a8a822f6141a78653ff4/Dlp/tests/Unit/V2/DlpServiceClientTest.php