### PR TITLE
Add correct LRO example code in PhpDoc

### DIFF
--- a/src/Ast/Expression.php
+++ b/src/Ast/Expression.php
@@ -55,4 +55,10 @@ abstract class Expression extends AST implements \ArrayAccess
         throw new \Exception('Invalid operation.');
     }
 
+    // Allow a method-call as a shortcut for AST::call(...)
+
+    public function __call(string $name ,array $arguments): Expression
+    {
+        return AST::call($this, AST::method($name))(...$arguments);
+    }
 }

--- a/tests/ProtoTests/BasicLro/Gapic/BasicLroGapicClient.php
+++ b/tests/ProtoTests/BasicLro/Gapic/BasicLroGapicClient.php
@@ -25,7 +25,32 @@ use Testing\BasicLro\Request;
  * ```
  * $basicLroServiceClient = new BasicLroClient();
  * try {
- *     $basicLroServiceClient->method1();
+ *     $operationResponse = $basicLroServiceClient->method1();
+ *     $operationResponse->pollUntilComplete();
+ *     if ($operationResponse->operationSucceeded()) {
+ *         $result = $operationResponse->getResult();
+ *     // doSomethingWith($result)
+ *     } else {
+ *         $error = $operationResponse->getError();
+ *         // handleError($error)
+ *     }
+ * // Alternatively:
+ *     // start the operation, keep the operation name, and resume later
+ *     $operationResponse = $basicLroServiceClient->method1();
+ *     $operationName = $operationResponse->getName();
+ *     // ... do other work
+ *     $newOperationResponse = $basicLroServiceClient->resumeOperation($operationName, 'method1');
+ *     while (!$newOperationResponse->isDone()) {
+ *         // ... do other work
+ *         $newOperationResponse->reload();
+ *     }
+ *     if ($newOperationResponse->operationSucceeded()) {
+ *         $result = $newOperationResponse->getResult();
+ *     // doSomethingWith($result)
+ *     } else {
+ *         $error = $newOperationResponse->getError();
+ *         // handleError($error)
+ *     }
  * } finally {
  *     $basicLroServiceClient->close();
  * }
@@ -183,7 +208,32 @@ class BasicLroGapicClient
      * ```
      * $basicLroServiceClient = new BasicLroClient();
      * try {
-     *     $basicLroServiceClient->method1();
+     *     $operationResponse = $basicLroServiceClient->method1();
+     *     $operationResponse->pollUntilComplete();
+     *     if ($operationResponse->operationSucceeded()) {
+     *         $result = $operationResponse->getResult();
+     *     // doSomethingWith($result)
+     *     } else {
+     *         $error = $operationResponse->getError();
+     *         // handleError($error)
+     *     }
+     * // Alternatively:
+     *     // start the operation, keep the operation name, and resume later
+     *     $operationResponse = $basicLroServiceClient->method1();
+     *     $operationName = $operationResponse->getName();
+     *     // ... do other work
+     *     $newOperationResponse = $basicLroServiceClient->resumeOperation($operationName, 'method1');
+     *     while (!$newOperationResponse->isDone()) {
+     *         // ... do other work
+     *         $newOperationResponse->reload();
+     *     }
+     *     if ($newOperationResponse->operationSucceeded()) {
+     *         $result = $newOperationResponse->getResult();
+     *     // doSomethingWith($result)
+     *     } else {
+     *         $error = $newOperationResponse->getError();
+     *         // handleError($error)
+     *     }
      * } finally {
      *     $basicLroServiceClient->close();
      * }


### PR DESCRIPTION
There is an error in the code formatting of some generated comments; this will be fixed in a future PR.
See here for an example of LRO example code in PhpDoc: https://github.com/googleapis/google-cloud-php/blob/e14db65fe40c9dc89fd022496e5c2c63af69a47b/Redis/src/V1/Gapic/CloudRedisGapicClient.php#L601