### PR TITLE
Add further LRO test init code

### DIFF
--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -68,6 +68,8 @@ abstract class AST
             }
         } elseif (is_numeric($x)) {
             return strval($x);
+        } elseif (is_bool($x)) {
+            return $x ? 'true' : 'false';
         } elseif ($x instanceof PhpClassMember) {
             return $x->getName();
         } elseif ($x instanceof AST) {

--- a/tests/ProtoTests/BasicLro/Tests/BasicLroClientTest.php
+++ b/tests/ProtoTests/BasicLro/Tests/BasicLroClientTest.php
@@ -9,6 +9,7 @@ use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\ApiCore\Transport\TransportInterface;
+use Google\LongRunning\Operation;
 
 class BasicLroClientTest extends GeneratedTest
 {
@@ -43,6 +44,18 @@ class BasicLroClientTest extends GeneratedTest
             'transport' => $operationsTransport,
             'credentials' => $this->createCredentials(),
         ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/method1Test');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
     }
 
     /** @test */
@@ -54,5 +67,17 @@ class BasicLroClientTest extends GeneratedTest
             'transport' => $operationsTransport,
             'credentials' => $this->createCredentials(),
         ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/method1ExceptionTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
     }
 }

--- a/tests/ProtoTests/BasicLro/resources/basic_lro_client_config.json
+++ b/tests/ProtoTests/BasicLro/resources/basic_lro_client_config.json
@@ -1,0 +1,27 @@
+{
+  "interfaces": {
+    "testing.basiclro.BasicLro": {
+      "retry_codes": {
+        "no_retry_codes": []
+      },
+      "retry_params": {
+        "no_retry_params": {
+          "initial_retry_delay_millis": 0,
+          "retry_delay_multiplier": 0.0,
+          "max_retry_delay_millis": 0,
+          "initial_rpc_timeout_millis": 0,
+          "rpc_timeout_multiplier": 1.0,
+          "max_rpc_timeout_millis": 0,
+          "total_timeout_millis": 0
+        }
+      },
+      "methods": {
+        "Method1": {
+          "timeout_millis": 5000000,
+          "retry_codes_name": "no_retry_codes",
+          "retry_params_name": "no_retry_params"
+        }
+      }
+    }
+  }
+}

--- a/tests/ProtoTests/BasicLro/resources/basic_lro_descriptor_config.php
+++ b/tests/ProtoTests/BasicLro/resources/basic_lro_descriptor_config.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'interfaces' => [
+        'testing.basiclro.BasicLro' => [
+        ],
+    ],
+];


### PR DESCRIPTION
The LRO tests now require the resources files to be present. Future PRs will add more to these LRO tests.