### PR TITLE
Add proto fields, which become rpc args, to test

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -21,6 +21,7 @@ namespace Google\Generator\Generation;
 use Google\Generator\Ast\PhpMethod;
 use Google\Generator\Collections\Vector;
 use Google\Generator\Utils\CustomOptions;
+use Google\Generator\Utils\Helpers;
 use Google\Generator\Utils\ProtoHelpers;
 use Google\Generator\Utils\Type;
 use Google\Protobuf\Internal\FieldDescriptorProto;
@@ -28,8 +29,11 @@ use Google\Protobuf\Internal\GPBType;
 
 class FieldDetails
 {
-    /** @var string *Readonly* The name of this field. */
+    /** @var string *Readonly* The proto name of this field. */
     public string $name;
+
+    /** @var string *Readonly* The name of this field in camelCase. */
+    public string $camelName;
 
     /** @var Type *Readonly* The type of this field. */
     public Type $type;
@@ -50,6 +54,8 @@ class FieldDetails
     {
         $desc = $field->desc;
         $this->name = $desc->getName();
+        // Using explode/implode is how it's done internally in /Google/Protobuf/Internal/FieldDescriptor.
+        $this->camelName = Helpers::toCamelCase(implode('', array_map('ucwords', explode('_', $this->name))));
         switch ($field->getType()) {
             case GPBType::INT32: // 5
                 $this->type = Type::int();

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -43,12 +43,14 @@ class Formatter
             new \PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer(), // 1
             new \PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer(), // 0
             new \PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer(), // 0
-            new \PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer(), // -21
             new \PhpCsFixer\Fixer\Basic\BracesFixer(), // -25
             new \PhpCsFixer\Fixer\Import\OrderedImportsFixer(), // -30
             new \PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer(), // -31
             new \PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer(), // -50
         ];
+        // Fixer temporarily removed:
+        // new \PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer(), // -21
+        // TODO: Understand why this fixer causes too many blank line insertions in some cases.
 
         try
         {

--- a/tests/ProtoTests/Basic/Gapic/BasicGapicClient.php
+++ b/tests/ProtoTests/Basic/Gapic/BasicGapicClient.php
@@ -14,6 +14,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\Basic\Request;
+use Testing\Basic\RequestWithArgs;
 use Testing\Basic\Response;
 
 /**
@@ -172,7 +173,49 @@ class BasicGapicClient
     public function aMethod(array $optionalArgs = [])
     {
         $request = new Request();
-
         return $this->startCall('AMethod', Response::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Test including method args.
+     *
+     * Sample code:
+     * ```
+     * $basicServiceClient = new BasicClient();
+     * try {
+     *     $aString = '';
+     *     $basicServiceClient->methodWithArgs($aString);
+     * } finally {
+     *     $basicServiceClient->close();
+     * }
+     * ```
+     *
+     * @param mixed $aString      A required field...
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type int $anInt
+     *           ...and an optional field.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     *
+     * @return Response
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function methodWithArgs($aString, array $optionalArgs = [])
+    {
+        $request = new RequestWithArgs();
+        $request->setAString($aString);
+        if (isset($optionalArgs['anInt'])) {
+            $request->setAnInt($optionalArgs['anInt']);
+        }
+
+        return $this->startCall('MethodWithArgs', Response::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/ProtoTests/Basic/RequestWithArgs.php
+++ b/tests/ProtoTests/Basic/RequestWithArgs.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Testing\Basic;
+
+use Google\Protobuf\Internal\Message;
+
+// TODO: Use a real message, or a fake message with enough field handling to make future tests work.
+class RequestWithArgs extends Message
+{
+    public function __construct() { }
+
+    public function setAString($aString)
+    {
+        $this->aString = $aString;
+    }
+
+    public function getAString()
+    {
+        return $this->aString;
+    }
+}

--- a/tests/ProtoTests/Basic/Tests/BasicClientTest.php
+++ b/tests/ProtoTests/Basic/Tests/BasicClientTest.php
@@ -32,7 +32,6 @@ class BasicClientTest extends GeneratedTest
         $options += [
             'credentials' => $this->createCredentials(),
         ];
-
         return new BasicClient($options);
     }
 
@@ -79,6 +78,63 @@ class BasicClientTest extends GeneratedTest
         // Mock request
         try {
             $client->aMethod();
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+        }
+// Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function methodWithArgsTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new Response();
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $a_string = '';
+        $response = $client->methodWithArgs($a_string);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.basic.Basic/MethodWithArgs', $actualFuncCall);
+        $actualValue = $actualRequestObject->getAString();
+        $this->assertProtobufEquals($a_string, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function methodWithArgsExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $a_string = '';
+        try {
+            $client->methodWithArgs($a_string);
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());

--- a/tests/ProtoTests/Basic/basic.proto
+++ b/tests/ProtoTests/Basic/basic.proto
@@ -5,6 +5,7 @@ package testing.basic;
 // php_namespace option not included; to test generating namespace from proto package.
 
 import "google/api/client.proto";
+import "google/api/field_behavior.proto";
 
 // This is a basic service.
 service Basic {
@@ -13,9 +14,19 @@ service Basic {
 
   // Test summary text for AMethod
   rpc AMethod(Request) returns(Response);
+
+  // Test including method args.
+  rpc MethodWithArgs(RequestWithArgs) returns(Response);
 }
 
 message Request {
+}
+
+message RequestWithArgs {
+  // A required field...
+  string a_string = 1 [(google.api.field_behavior) = REQUIRED];
+  // ...and an optional field.
+  int32 an_int = 2;
 }
 
 message Response {

--- a/tests/ProtoTests/Basic/resources/basic_client_config.json
+++ b/tests/ProtoTests/Basic/resources/basic_client_config.json
@@ -20,6 +20,11 @@
           "timeout_millis": 5000000,
           "retry_codes_name": "no_retry_codes",
           "retry_params_name": "no_retry_params"
+        },
+        "MethodWithArgs": {
+          "timeout_millis": 5000000,
+          "retry_codes_name": "no_retry_codes",
+          "retry_params_name": "no_retry_params"
         }
       }
     }

--- a/tests/ProtoTests/BasicLro/Gapic/BasicLroGapicClient.php
+++ b/tests/ProtoTests/BasicLro/Gapic/BasicLroGapicClient.php
@@ -131,7 +131,6 @@ class BasicLroGapicClient
         $options = isset($this->descriptors[$methodName]['longRunning']) ? $this->descriptors[$methodName]['longRunning'] : [];
         $operation = new OperationResponse($operationName, $this->getOperationsClient(), $options);
         $operation->reload();
-
         return $operation;
     }
 
@@ -257,7 +256,6 @@ class BasicLroGapicClient
     public function method1(array $optionalArgs = [])
     {
         $request = new Request();
-
         return $this->startOperationsCall('Method1', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
 }

--- a/tests/ProtoTests/BasicLro/Tests/BasicLroClientTest.php
+++ b/tests/ProtoTests/BasicLro/Tests/BasicLroClientTest.php
@@ -31,7 +31,6 @@ class BasicLroClientTest extends GeneratedTest
         $options += [
             'credentials' => $this->createCredentials(),
         ];
-
         return new BasicLroClient($options);
     }
 


### PR DESCRIPTION
And remove one of the formatting fixers that was causing too many blank lines to be inserted; there is a TODO to understand why this is happening and fix it.