### PR TITLE
Trivial: Fix casings

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -90,7 +90,7 @@ class CodeGenerator
         // Generate files for each package.
         foreach ($byPackage as [$_, $singlePackageFileDescs]) {
             $namespaces = $singlePackageFileDescs
-                ->map(fn($x) => ProtoHelpers::GetNamespace($x))
+                ->map(fn($x) => ProtoHelpers::getNamespace($x))
                 ->distinct();
             if (count($namespaces) > 1) {
                 throw new \Exception('All files in the same package must have the same PHP namespace');

--- a/src/Main.php
+++ b/src/Main.php
@@ -30,7 +30,7 @@ $package = $opts['package'];
 
 // Generate PHP code.
 $year = (int)date('Y');
-$files = CodeGenerator::GenerateFromDescriptor($descBytes, $package, $year);
+$files = CodeGenerator::generateFromDescriptor($descBytes, $package, $year);
 foreach ($files as [$relativeFilename, $fileContent]) {
     // TODO: Later this won't just print out the generated file content.
     print("File: '{$relativeFilename}':\n");


### PR DESCRIPTION
PHP is case-insensitive for method/function names, but it's better if they are consistently camelCased :)