### PR TITLE
Align the empty client generation with monolith output.

### DIFF
--- a/integration_tests/SourceComparer.php
+++ b/integration_tests/SourceComparer.php
@@ -37,11 +37,13 @@ class SourceComparer
                     while ($monoPos < $monoLen &&
                         (static::isWhitespace($mono[$monoPos]) ||
                         ($inComment && $mono[$monoPos] === '*') ||
-                        substr($mono, $monoPos, 2) === ",\n")) $monoPos++;
+                        substr($mono, $monoPos, 2) === ",\n") ||
+                        (substr($mono, $monoPos - 1, 2) == '//' || substr($mono, $monoPos, 2) == '//')) $monoPos++;
                     while ($microPos < $microLen &&
                         (static::isWhitespace($micro[$microPos]) ||
                         ($inComment && $micro[$microPos] === '*') ||
-                        substr($micro, $microPos, 2) === ",\n")) $microPos++;
+                        substr($micro, $microPos, 2) === ",\n") ||
+                        (substr($micro, $microPos - 1, 2) == '//' || substr($micro, $microPos, 2) == '//')) $microPos++;
                 }
             }
             $c = $mono[$monoPos];

--- a/src/Generation/EmptyClientGenerator.php
+++ b/src/Generation/EmptyClientGenerator.php
@@ -44,7 +44,7 @@ class EmptyClientGenerator
         // Generate file content
         $file = AST::file($this->generateClass())
             ->withApacheLicense($this->ctx->licenseYear)
-            ->withGeneratedCodeWarning();
+            ->withGeneratedFromProtoCodeWarning($this->serviceDetails->filePath);
         // Finalize as required by the source-context; e.g. add top-level 'use' statements.
         return $this->ctx->finalize($file);
     }

--- a/tests/ProtoTests/Basic/out/src/BasicClient.php
+++ b/tests/ProtoTests/Basic/out/src/BasicClient.php
@@ -17,9 +17,12 @@
 
 /*
  * GENERATED CODE WARNING
- * This file was automatically generated - do not edit!
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/ProtoTests/Basic/basic.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
  */
-
 
 namespace Testing\Basic;
 

--- a/tests/ProtoTests/BasicBidiStreaming/out/src/BasicBidiStreamingClient.php
+++ b/tests/ProtoTests/BasicBidiStreaming/out/src/BasicBidiStreamingClient.php
@@ -17,9 +17,12 @@
 
 /*
  * GENERATED CODE WARNING
- * This file was automatically generated - do not edit!
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/ProtoTests/BasicBidiStreaming/basic-bidi-streaming.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
  */
-
 
 namespace Testing\BasicBidiStreaming;
 

--- a/tests/ProtoTests/BasicClientStreaming/out/src/BasicClientStreamingClient.php
+++ b/tests/ProtoTests/BasicClientStreaming/out/src/BasicClientStreamingClient.php
@@ -17,9 +17,12 @@
 
 /*
  * GENERATED CODE WARNING
- * This file was automatically generated - do not edit!
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/ProtoTests/BasicClientStreaming/basic-client-streaming.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
  */
-
 
 namespace Testing\BasicClientStreaming;
 

--- a/tests/ProtoTests/BasicLro/out/src/BasicLroClient.php
+++ b/tests/ProtoTests/BasicLro/out/src/BasicLroClient.php
@@ -17,9 +17,12 @@
 
 /*
  * GENERATED CODE WARNING
- * This file was automatically generated - do not edit!
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/ProtoTests/BasicLro/basic-lro.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
  */
-
 
 namespace Testing\BasicLro;
 

--- a/tests/ProtoTests/BasicPaginated/out/src/BasicPaginatedClient.php
+++ b/tests/ProtoTests/BasicPaginated/out/src/BasicPaginatedClient.php
@@ -17,9 +17,12 @@
 
 /*
  * GENERATED CODE WARNING
- * This file was automatically generated - do not edit!
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/ProtoTests/BasicPaginated/basic-paginated.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
  */
-
 
 namespace Testing\BasicPaginated;
 

--- a/tests/ProtoTests/BasicServerStreaming/out/src/BasicServerStreamingClient.php
+++ b/tests/ProtoTests/BasicServerStreaming/out/src/BasicServerStreamingClient.php
@@ -17,9 +17,12 @@
 
 /*
  * GENERATED CODE WARNING
- * This file was automatically generated - do not edit!
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/ProtoTests/BasicServerStreaming/basic-server-streaming.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
  */
-
 
 namespace Testing\BasicServerStreaming;
 


### PR DESCRIPTION
This fixes the file warning header comment; and allows multiline comments using multiple '//' lines to have their line-breaks in different places