### PR TITLE
Update basic test to include scopes

### DIFF
--- a/tests/ProtoTests/Basic/basic.proto
+++ b/tests/ProtoTests/Basic/basic.proto
@@ -11,8 +11,7 @@ import "google/api/field_behavior.proto";
 // This is a basic service.
 service Basic {
   option (google.api.default_host) = "basic.example.com";
-  // TODO: Understand why the monolithic doesn't appear to respect these scopes.
-  //option (google.api.oauth_scopes) = "scope1,scope2";
+  option (google.api.oauth_scopes) = "scope1,scope2";
 
   // Test summary text for AMethod
   rpc AMethod(Request) returns(Response) {

--- a/tests/ProtoTests/Basic/basic_service.yaml
+++ b/tests/ProtoTests/Basic/basic_service.yaml
@@ -1,0 +1,10 @@
+type: google.api.Service
+config_version: 3
+
+authentication:
+  rules:
+  - selector: 'testing.basic.Basic.*'
+    oauth:
+      canonical_scopes: |-
+        scope1,
+        scope2

--- a/tests/ProtoTests/Basic/out/src/Gapic/BasicGapicClient.php
+++ b/tests/ProtoTests/Basic/out/src/Gapic/BasicGapicClient.php
@@ -74,7 +74,10 @@ class BasicGapicClient
     const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
-    public static $serviceScopes = [];
+    public static $serviceScopes = [
+        'scope1',
+        'scope2',
+    ];
 
     private static function getClientDefaults()
     {


### PR DESCRIPTION
The monolith requires scopes to be defined in the service_config, it ignores scopes defined in the proto