### PR TITLE
Refactor unit-test generation to exactly match monolith

### DIFF
--- a/src/Collections/Vector.php
+++ b/src/Collections/Vector.php
@@ -48,24 +48,22 @@ class Vector implements \IteratorAggregate, \Countable, \ArrayAccess, Equality
      * Zip two Vectors, with optional mapping function. If the vectors are not the same
      * length, then the excess elements in the longer vector will be ignored.
      *
-     * @param Vector $a The first Vector to zip.
-     * @param Vector $b The second Vector to zip.
-     * @param ?Callable $fnMap The optional map function. This will be called with two
-     *     parameters, one element from each input vector; an optional third parameter
-     *     is the element index. If this function is omitted, then each element of the
-     *     output vector will contain an array of length two.
+     * Can take an arbitrary number of vectors to zip together, plus an optional map
+     * function as a final argument. This map function will be called with an argument
+     * from each zipped vector, plus an index argument.
      */
-    public static function zip(Vector $a, Vector $b, ?Callable $fnMap = null): Vector
+    public static function zip(...$args): Vector
     {
-        $count = min(count($a), count($b));
+        $fnMap = is_callable($args[count($args) - 1]) ? array_pop($args) : null;
+        $count = min(array_map(fn($x) => count($x), $args));
         $result = [];
-        if ($fnMap) {
+        if (!is_null($fnMap)) {
             for ($i = 0; $i < $count; $i++) {
-                $result[] = $fnMap($a[$i], $b[$i], $i);
+                $result[] = $fnMap(...(array_merge(array_map(fn($x) => $x[$i], $args), [$i])));
             }
         } else {
             for ($i = 0; $i < $count; $i++) {
-                $result[] = [$a[$i], $b[$i]];
+                $result[] = array_map(fn($x) => $x[$i], $args);
             }
         }
         return new Vector($result);

--- a/src/Generation/TestNameValueProducer.php
+++ b/src/Generation/TestNameValueProducer.php
@@ -1,0 +1,163 @@
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Generator\Generation;
+
+use Google\Generator\Ast\AST;
+use Google\Generator\Ast\Variable;
+use Google\Generator\Collections\Map;
+use Google\Generator\Collections\Set;
+use Google\Generator\Collections\Vector;
+use Google\Generator\Utils\Helpers;
+use Google\Generator\Utils\ProtoCatalog;
+use Google\Generator\Utils\Type;
+use Google\Protobuf\Internal\GPBType;
+
+class TestNameValueProducer
+{
+    public function __construct(ProtoCatalog $catalog, SourceFileContext $ctx)
+    {
+        $this->catalog = $catalog;
+        $this->ctx = $ctx;
+        $this->names = Set::new();
+        $this->values = Set::new();
+        $this->valuesByName = Map::new();
+    }
+
+    private ProtoCatalog $catalog;
+    private SourceFileContext $ctx;
+    private Set $names;
+    private Set $values;
+    private Map $valuesByName;
+
+    public function name(string $name): string
+    {
+        for ($i = 1; ; $i++) {
+            $n = $name . ($i === 1 ? '' : '_' . $i);
+            if (!$this->names[$n]) {
+                $this->names = $this->names->add($n);
+                return $n;
+            }
+        }
+    }
+
+    public function perField(Vector $fields): Vector
+    {
+        return $fields->map(fn($f) => new class($this, $f) {
+            public function __construct($prod, $f)
+            {
+                $this->field = $f;
+                $this->name = $prod->name($f->name);
+                $this->var = AST::var(Helpers::toCamelCase($this->name));
+                $this->value = $prod->value($f, $this->name);
+            }
+
+            public FieldDetails $field;
+            public string $name;
+            public Variable $var;
+            public $value;
+        });
+    }
+
+    // Reproduce exactly the Java test value generation:
+    // https://github.com/googleapis/gapic-generator/blob/e3501faea84f61be2f59bd49a7740a486a02fa6b/src/main/java/com/google/api/codegen/util/testing/StandardValueProducer.java
+    // https://github.com/googleapis/gapic-generator/blob/e3501faea84f61be2f59bd49a7740a486a02fa6b/src/main/java/com/google/api/codegen/util/testing/TestValueGenerator.java
+    // TODO(vNext): Make these more PHPish.
+
+    public function value(FieldDetails $field, ?string $nameOverride = null, ?bool $forceRepeated = null)
+    {
+        if ($forceRepeated === true || ($field->desc->desc->isRepeated() && $forceRepeated !== false)) {
+            return AST::array([]);
+        }
+
+        $name = $nameOverride ?? $field->desc->getName();
+
+        if (!isset($this->valuesByName[$name])) {
+            $allowDuplicateValue = in_array($field->desc->getType(), [GPBType::ENUM, GPBType::BOOL, GPBType::MESSAGE], true);
+            $value = $this->valueImpl($field, $name);
+            while ($this->values[$value] && !$allowDuplicateValue) {
+                $name = $name . '_1';
+                $value = $this->valueImpl($field, $name);
+            }
+            if (is_string($value)) {
+                $this->values = $this->values->add($value);
+                $this->valuesByName = $this->valuesByName->set($name, $value);
+            }
+        } else {
+            $value = $this->valuesByName[$name];
+        }
+        return is_string($value) ? AST::literal($this->valuesByName[$name]) : $value;
+    }
+
+    private function valueImpl(FieldDetails $field, string $name)
+    {
+        $javaHashCode = function() use($name) {
+            $javaHash = 0;
+            for ($i = 0; $i < strlen($name); $i++) {
+                $javaHash = (((31 * $javaHash) & 0xffffffff) + ord($name[$i])) & 0xffffffff;
+            }
+            return $javaHash > 0x7fffffff ? $javaHash -= 0x100000000 : $javaHash;
+        };
+
+        switch ($field->desc->getType()) {
+            case GPBType::DOUBLE: // 1
+            case GPBType::FLOAT: // 2
+                $v = (float)(int)($javaHashCode() / 10);
+                // See: https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#toString(double)
+                $vAbs = abs($v);
+                if ($vAbs >= 1e-3  && $vAbs < 1e7) {
+                    $s = sprintf('%.1F', $v);
+                } else {
+                    $s = sprintf('%.8E', $v);
+                    $s = str_replace('+', '', $s);
+                    while (strpos($s, '0E') !== false) {
+                        $s = str_replace('0E', 'E', $s);
+                    }
+                }
+                return strval($s);
+            case GPBType::INT64: // 3
+            case GPBType::UINT64: // 4
+            case GPBType::INT32: // 5
+            case GPBType::FIXED64: // 6
+            case GPBType::FIXED32: // 7
+            case GPBType::UINT32: //13
+            case GPBType::SFIXED32: // 15
+            case GPBType::SFIXED64: // 16
+            case GPBType::SINT32: // 17
+            case GPBType::SINT64: // 18
+                $javaHash = $javaHashCode($name);
+                return strval($javaHash === -0x80000000 ? 0 : abs($javaHash));
+            case GPBType::BOOL: // 8
+                return $javaHashCode($name) % 2 === 0 ? 'true' : 'false';
+            case GPBType::STRING: // 9
+                $javaHash = $javaHashCode($name);
+                $prefix = Helpers::toCamelCase($name);
+                return "'" . $prefix . $javaHash . "'";
+            case GPBType::MESSAGE: // 11
+                return AST::new($this->ctx->type(Type::fromField($this->catalog, $field->desc->desc, false)))();
+            case GPBType::BYTES: // 12
+                $v = $javaHashCode($name) & 0xff;
+                return "'" . strval($v <= 0x7f ? $v : $v - 0x100) . "'";
+            case GPBType::ENUM: // 14
+                $enumValueName = $this->catalog->enumsByFullname[$field->desc->desc->getEnumType()]->getValue()[0]->getName();
+                return AST::access($this->ctx->type(Type::fromField($this->catalog, $field->desc->desc)), AST::property($enumValueName));
+            default:
+                throw new \Exception("No testValue for type: {$field->desc->getType()}");
+        }
+    }
+}

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -66,7 +66,8 @@ class Formatter
             $code = $tokens->generateCode();
             return $code;
         } catch (\Throwable $ex) {
-            print("\nFailed to format code:\n{$code}\n");
+            $codeWithLineNumbers = Vector::new(explode("\n", $code))->map(fn($x, $i) => "{$i}: {$x}")->join("\n");
+            print("\nFailed to format code:\n{$codeWithLineNumbers}\n");
             throw $ex;
         }
     }

--- a/tests/Collections/VectorTest.php
+++ b/tests/Collections/VectorTest.php
@@ -43,6 +43,22 @@ final class VectorTest extends TestCase
             fn($a, $b) => "{$a}:{$b}"
         );
         $this->assertEquals(['1:a', '2:b'], $v->toArray());
+
+        $v = Vector::zip(
+            Vector::new([1, 2]),
+            Vector::new(['a', 'b']),
+            Vector::new(['A', 'B'])
+        );
+        $this->assertEquals([[1, 'a', 'A'], [2, 'b', 'B']], $v->toArray());
+
+        $v = Vector::zip(
+            Vector::new([1, 2, 3, 4]),
+            Vector::new(['a', 'b']),
+            Vector::new(['A']),
+            Vector::new([10, 11, 12]),
+            fn($a, $b, $c, $d) => "{$a}:{$b}:{$c}:{$d}"
+        );
+        $this->assertEquals(['1:a:A:10'], $v->toArray());
     }
 
     public function testZipIndex(): void
@@ -53,6 +69,14 @@ final class VectorTest extends TestCase
             fn($a, $b, $index) => "{$index}:{$a}:{$b}"
         );
         $this->assertEquals(['0:1:a', '1:2:b'], $v->toArray());
+
+        $v = Vector::zip(
+            Vector::new([1, 2]),
+            Vector::new(['a', 'b', 'c']),
+            Vector::new(['A', 'B', 'C', 'D']),
+            fn($a, $b, $c, $index) => "{$index}:{$a}:{$b}:{$c}"
+        );
+        $this->assertEquals(['0:1:a:A', '1:2:b:B'], $v->toArray());
     }
 
     public function testRange(): void

--- a/tests/ProtoTests/AllTypes/all-types.proto
+++ b/tests/ProtoTests/AllTypes/all-types.proto
@@ -13,25 +13,23 @@ import "google/longrunning/operations.proto";
 service AllTypes {
   option (google.api.default_host) = "alltypes.example.com";
 
-  rpc Method1(Request) returns(Response) {
+  rpc Method1(RequestAndResponse) returns(RequestAndResponse) {
     option (google.api.http) = {
       post: "/path:method1"
       body: "*"
     };
   }
 
-  rpc MethodLro(Request) returns(google.longrunning.Operation) {
+  rpc MethodLro(RequestAndResponse) returns(google.longrunning.Operation) {
     option (google.api.http) = {
       post: "/path:methodLro"
       body: "*"
     };
     option (google.longrunning.operation_info) = {
-      response_type: "LroResponse"
-      metadata_type: "LroMetadata"
+      response_type: "RequestAndResponse"
+      metadata_type: "RequestAndResponse"
     };
   }
-
-  // No need to test bidi or server streaming, as the request is not sent inline.
 
   rpc MethodPaginated(PaginatedRequest) returns(PaginatedResponse) {
     option (google.api.http) = {
@@ -40,7 +38,9 @@ service AllTypes {
     };
   }
 
-  rpc MethodServerStreaming(Request) returns(stream Response);
+  // No need to test bidi or server streaming, as the request is not sent inline.
+
+  rpc MethodServerStreaming(RequestAndResponse) returns(stream RequestAndResponse);
 }
 
 enum TopLevelEnum {
@@ -51,7 +51,7 @@ enum TopLevelEnum {
 message TopLevelMsg {
 }
 
-message Request {
+message RequestAndResponse {
   message NestedMsg {
   }
   enum NestedEnum {
@@ -158,15 +158,6 @@ message Request {
   repeated sint64 rep_req_sint64 = 418 [(google.api.field_behavior) = REQUIRED];
   repeated NestedMsg rep_req_nested_message = 420 [(google.api.field_behavior) = REQUIRED];
   repeated NestedEnum rep_req_nested_enum = 421 [(google.api.field_behavior) = REQUIRED];
-}
-
-message Response {
-}
-
-message LroResponse {
-}
-
-message LroMetadata {
 }
 
 message PaginatedRequest {


### PR DESCRIPTION
Variable-name and test-value generation has been refactored to exactly match monolith.