### PR TITLE
Enable grpc-service-config on cmd-line; generate correct retrys

### DIFF
--- a/integration_tests/Invoker.php
+++ b/integration_tests/Invoker.php
@@ -20,8 +20,13 @@ namespace Google\Generator\IntegrationTests;
 
 class Invoker
 {
-    public static function invoke(string $protoPath, ?string $package = null, ?string $gapicYaml = null, ?string $monoServiceConfig = null)
-    {
+    public static function invoke(
+        string $protoPath,
+        ?string $package = null,
+        ?string $gapicYaml = null,
+        ?string $monoServiceConfig = null,
+        ?string $grpcServiceConfig = null
+    ) {
         $rootDir = __DIR__ . '/..';
 
         // Build the proto descriptor.
@@ -65,6 +70,12 @@ class Invoker
             if (file_exists($monoServiceConfig)) {
                 $monoCmdLine .= " --service_yaml {$monoServiceConfig}";
             }
+            $grpcServiceConfigArg = is_null($grpcServiceConfig) ?
+                $rootDir . '/' . dirname($protoPath) . 'grpc-service-config.json' :
+                $rootDir . '/' . $grpcServiceConfig;
+            if (file_exists($grpcServiceConfigArg)) {
+                $monoCmdLine .= " --grpc_service_config {$grpcServiceConfigArg}";
+            }
             static::execCmd("cd {$monoDir}; {$monoCmdLine} 2>&1", 'mono');
 
             // Run the micro-generator.
@@ -73,6 +84,9 @@ class Invoker
             $microCmdLine = "php {$microMain} --descriptor {$descFilename} --package {$package} --output {$microOutDir}";
             if (file_exists($gapicYamlArg)) {
                 $microCmdLine .= " --gapic_yaml {$gapicYamlArg}";
+            }
+            if (file_exists($grpcServiceConfigArg)) {
+                $microCmdLine .= " --grpc_service_config {$grpcServiceConfigArg}";
             }
             static::execCmd($microCmdLine . ' 2>&1', 'micro');
             // Read all files in output dirs.

--- a/integration_tests/Main.php
+++ b/integration_tests/Main.php
@@ -45,7 +45,8 @@ $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/language/v1/language_service.proto',
     'google.cloud.language.v1',
     'googleapis/google/cloud/language/v1/language_gapic.yaml',
-    'googleapis/google/cloud/language/language_v1.yaml')) ? $ok : false;
+    'googleapis/google/cloud/language/language_v1.yaml',
+    'googleapis/google/cloud/language/v1/language_grpc_service_config.json')) ? $ok : false;
 
 // TODO: Enable this test, once the REST config is generated identically.
 // REST config generation requires the service-config as an input, which the micro-generator
@@ -54,7 +55,8 @@ $ok = processDiff(Invoker::invoke(
 //     'googleapis/google/cloud/videointelligence/v1/video_intelligence.proto',
 //     'google.cloud.videointelligence.v1',
 //     'googleapis/google/cloud/videointelligence/v1/videointelligence_gapic.yaml',
-//     'googleapis/google/cloud/videointelligence/v1/videointelligence_v1.yaml')) ? $ok : false;
+//     'googleapis/google/cloud/videointelligence/v1/videointelligence_v1.yaml',
+//     'googleapis/google/cloud/videointelligence/v1/videointelligence_grpc_service_config.json')) ? $ok : false;
 
 if (!$ok) {
     print("\nFail\n");

--- a/src/Main.php
+++ b/src/Main.php
@@ -25,7 +25,7 @@ error_reporting(E_ALL);
 // TODO: Provide help/usage if incorrect command-line args provided.
 // Read command-line args.
 // TODO: Include cmd-line arg for grpc-service-config.
-$opts = getopt('', ['descriptor:', 'package:', 'output:', 'gapic_yaml:']);
+$opts = getopt('', ['descriptor:', 'package:', 'output:', 'grpc_service_config:', 'gapic_yaml:']);
 if (!isset($opts['descriptor']) || !isset($opts['package'])) {
     print("Invalid arguments. Expect:\n");
     print("  --descriptor <path> The path to the proto descriptor file.\n");
@@ -37,6 +37,16 @@ if (!isset($opts['descriptor']) || !isset($opts['package'])) {
 $descBytes = file_get_contents($opts['descriptor']);
 $package = $opts['package'];
 $outputDir = $opts['output'];
+
+if (isset($opts['grpc_service_config'])) {
+    if (!file_exists($opts['grpc_service_config'])) {
+        throw new \Exception('Specified grpc_service_config file does not exist.');
+    }
+    $grpcServiceConfig = file_get_contents($opts['grpc_service_config']);
+} else {
+    $grpcServiceConfig = null;
+}
+
 if (isset($opts['gapic_yaml'])) {
     if (!file_exists($opts['gapic_yaml'])) {
         throw new \Exception('Specified gapi_yaml file does not exist.');
@@ -48,7 +58,7 @@ if (isset($opts['gapic_yaml'])) {
 
 // Generate PHP code.
 $year = (int)date('Y');
-$files = CodeGenerator::generateFromDescriptor($descBytes, $package, $year, null, $gapicYaml);
+$files = CodeGenerator::generateFromDescriptor($descBytes, $package, $year, $grpcServiceConfig, $gapicYaml);
 if (is_null($outputDir)) {
     // TODO: Remove printout; only save files to the specified output path.
     foreach ($files as [$relativeFilename, $fileContent]) {

--- a/src/Utils/GrpcServiceConfig.php
+++ b/src/Utils/GrpcServiceConfig.php
@@ -27,10 +27,12 @@ class GrpcServiceConfig
     public function __construct(string $serviceName, ?string $json)
     {
         if (is_null($json)) {
+            $this->isPresent = false;
             $this->configsByName = Map::new();
             $this->retryPolicies = Vector::new([]);
             $this->timeouts = Vector::new([]);
         } else {
+            $this->isPresent = true;
             $config = new ServiceConfig();
             $config->mergeFromJsonString($json);
             $methods = Vector::new($config->getMethodConfig())
@@ -44,6 +46,9 @@ class GrpcServiceConfig
                 ->map(fn($x) => $x->getTimeout());
         }
     }
+
+    /** @var bool *Readonly* Whether a grpc-service-config is present at all. */
+    public bool $isPresent;
 
     /** @var Map *Readonly* Map<string, \Grpc\Service_config\MethodConfig>; name to indexes. */
     public Map $configsByName;

--- a/tests/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_client_config.json
+++ b/tests/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_client_config.json
@@ -9,11 +9,7 @@
                 "retry_policy_2_codes": [
                     "UNAVAILABLE"
                 ],
-                "idempotent": [
-                    "DEADLINE_EXCEEDED",
-                    "UNAVAILABLE"
-                ],
-                "non_idempotent": []
+                "no_retry_codes": []
             },
             "retry_params": {
                 "retry_policy_1_params": {
@@ -40,31 +36,31 @@
                     "max_rpc_timeout_millis": 120000,
                     "total_timeout_millis": 120000
                 },
-                "default": {
-                    "initial_retry_delay_millis": 100,
-                    "retry_delay_multiplier": 1.3,
-                    "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                "no_retry_params": {
+                    "initial_retry_delay_millis": 0,
+                    "retry_delay_multiplier": 0.0,
+                    "max_retry_delay_millis": 0,
+                    "initial_rpc_timeout_millis": 0,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 0,
+                    "total_timeout_millis": 0
                 }
             },
             "methods": {
                 "ServiceLevelRetryMethod": {
                     "timeout_millis": 20000,
-                    "retry_codes_name": "retry_policy_1_params",
-                    "retry_params_name": "retry_policy_1_codes"
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
                 },
                 "MethodLevelRetryMethod": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "retry_policy_2_params",
-                    "retry_params_name": "retry_policy_2_codes"
+                    "retry_codes_name": "retry_policy_2_codes",
+                    "retry_params_name": "retry_policy_2_params"
                 },
                 "MethodTimeoutOnly": {
                     "timeout_millis": 120000,
-                    "retry_codes_name": "retry_policy_3_params",
-                    "retry_params_name": "retry_policy_3_codes"
+                    "retry_codes_name": "retry_policy_3_codes",
+                    "retry_params_name": "retry_policy_3_params"
                 }
             }
         }

--- a/tests/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_no_retry_client_config.json
+++ b/tests/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_no_retry_client_config.json
@@ -2,28 +2,24 @@
     "interfaces": {
         "testing.grpcserviceconfig.GrpcServiceConfigNoRetry": {
             "retry_codes": {
-                "idempotent": [
-                    "DEADLINE_EXCEEDED",
-                    "UNAVAILABLE"
-                ],
-                "non_idempotent": []
+                "no_retry_codes": []
             },
             "retry_params": {
-                "default": {
-                    "initial_retry_delay_millis": 100,
-                    "retry_delay_multiplier": 1.3,
-                    "max_retry_delay_millis": 60000,
-                    "initial_rpc_timeout_millis": 20000,
+                "no_retry_params": {
+                    "initial_retry_delay_millis": 0,
+                    "retry_delay_multiplier": 0.0,
+                    "max_retry_delay_millis": 0,
+                    "initial_rpc_timeout_millis": 0,
                     "rpc_timeout_multiplier": 1.0,
-                    "max_rpc_timeout_millis": 20000,
-                    "total_timeout_millis": 600000
+                    "max_rpc_timeout_millis": 0,
+                    "total_timeout_millis": 0
                 }
             },
             "methods": {
                 "NoRetryMethod": {
                     "timeout_millis": 60000,
-                    "retry_codes_name": "non_idempotent",
-                    "retry_params_name": "default"
+                    "retry_codes_name": "no_retry_codes",
+                    "retry_params_name": "no_retry_params"
                 }
             }
         }


### PR DESCRIPTION
Reproduce the monolith behaviour of using different retry-config generation depending on whether the grpc-service-config is present or not.

This found a real genuine bug! Testing *does* work :)