### PR TITLE
Fixes required for dataproc; and about to update monolith

### DIFF
--- a/integration_tests/Main.php
+++ b/integration_tests/Main.php
@@ -35,7 +35,8 @@ $ok = processDiff(Invoker::invoke('tests/ProtoTests/BasicServerStreaming/basic-s
 $ok = processDiff(Invoker::invoke('tests/ProtoTests/BasicClientStreaming/basic-client-streaming.proto')) ? $ok : false;
 $ok = processDiff(Invoker::invoke('tests/ProtoTests/ResourceNames/resource-names.proto')) ? $ok : false;
 $ok = processDiff(Invoker::invoke('tests/ProtoTests/ProtoDocs/proto-docs.proto')) ? $ok : false;
-$ok = processDiff(Invoker::invoke('tests/ProtoTests/RoutingHeaders/routing-headers.proto')) ? $ok : false;
+// TODO: Re-enable when monolith updated.
+// $ok = processDiff(Invoker::invoke('tests/ProtoTests/RoutingHeaders/routing-headers.proto')) ? $ok : false;
 $ok = processDiff(Invoker::invoke('tests/ProtoTests/Keywords/keywords.proto')) ? $ok : false;
 $ok = processDiff(Invoker::invoke('tests/ProtoTests/AllTypes/all-types.proto')) ? $ok : false;
 $ok = processDiff(Invoker::invoke(
@@ -99,6 +100,23 @@ $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/channel/v1/cloudchannel_v1.yaml',
     'googleapis/google/cloud/channel/v1/cloudchannel_grpc_service_config.json'
 )) ? $ok : false;
+// Inconsistent PHP namespace casing between monolith and micro.
+// Micro-generator gets PHP namespace from proto; monolith gets it from service config, which is missing for this API.
+// $ok = processDiff(Invoker::invoke(
+//     'googleapis/google/cloud/datacatalog/v1/*.proto googleapis/google/cloud/common_resources.proto',
+//     'google.cloud.datacatalog.v1',
+//     'googleapis/google/cloud/datacatalog/v1/datacatalog_gapic.yaml',
+//     'googleapis/google/cloud/datacatalog/v1/datacatalog_v1.yaml',
+//     'googleapis/google/cloud/datacatalog/v1/datacatalog_grpc_service_config.json'
+// )) ? $ok : false;
+// TODO: Re-enable when monolith updated.
+// $ok = processDiff(Invoker::invoke(
+//     'googleapis/google/cloud/dataproc/v1/*.proto googleapis/google/cloud/common_resources.proto',
+//     'google.cloud.dataproc.v1',
+//     'googleapis/google/cloud/dataproc/v1/dataproc_gapic.yaml',
+//     'googleapis/google/cloud/dataproc/v1/dataproc_v1.yaml',
+//     'googleapis/google/cloud/dataproc/v1/dataproc_grpc_service_config.json'
+// )) ? $ok : false;
 $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/language/v1/language_service.proto',
     'google.cloud.language.v1',

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -33,6 +33,16 @@ use Google\Rpc\Code;
 
 class ResourcesGenerator
 {
+    // TODO(vNext): Remove this; only required for monolith compatibility.
+    private static function ensureDecimal(string $s): string
+    {
+        if (strpos($s, '.') === false) {
+            return $s . '.0';
+        } else {
+            return $s;
+        }
+    }
+
     public static function generateDescriptorConfig(ServiceDetails $serviceDetails, GapicYamlConfig $gapicYamlConfig): string
     {
         $perMethod = function($method) use ($gapicYamlConfig) {
@@ -56,7 +66,7 @@ class ResourcesGenerator
                         'operationReturnType' => $method->lroResponseType->getFullname(),
                         'metadataReturnType' => $method->lroMetadataType->getFullname(),
                         'initialPollDelayMillis' => $initialPollDelayMillis,
-                        'pollDelayMultiplier' => $pollDelayMultiplier,
+                        'pollDelayMultiplier' => static::ensureDecimal($pollDelayMultiplier),
                         'maxPollDelayMillis' => $maxPollDelayMillis,
                         'totalPollTimeoutMillis' => $totalPollTimeoutMillis,
                     ])]);

--- a/tests/ProtoTests/ResourceNames/resource-names.proto
+++ b/tests/ProtoTests/ResourceNames/resource-names.proto
@@ -121,34 +121,81 @@ option (google.api.resource_definition) = {
 };
 
 option (google.api.resource_definition) = {
-  type: "resourcenames.example.com/Folder1",
+  type: "resourcenames.example.com/Folder1"
   pattern: "folders1/{folder1_id}"
 };
 
 option (google.api.resource_definition) = {
-  type: "resourcenames.example.com/Folder2",
+  type: "resourcenames.example.com/Folder2"
   pattern: "folders2/{folder2_id}"
 };
 
 // Test behaviour on multi-pattern child-type reference.
 option (google.api.resource_definition) = {
-  type: "resourcenames.example.com/FileMulti",
+  type: "resourcenames.example.com/FileMulti"
   pattern: "folders1/{folder1_id}/files/{file_id}"
   pattern: "folders2/{folder2_id}/files/{file_id}"
+};
+
+// Test behaviour on multi-pattern child-type reference with the (obsolete) history.
+// And use opposite order to FileMulti patterns.
+option (google.api.resource_definition) = {
+  type: "resourcenames.example.com/FileMultiHistory"
+  pattern: "folders2/{folder2_id}/files/{file_id}"
+  pattern: "folders1/{folder1_id}/files/{file_id}"
+  history: ORIGINALLY_SINGLE_PATTERN
 };
 
 // Test behaviour on multi-pattern child-type reference with wildcard.
 // No parent lookups are performed.
 option (google.api.resource_definition) = {
-  type: "resourcenames.example.com/FileMultiWildcard",
+  type: "resourcenames.example.com/FileMultiWildcard"
   pattern: "folders3/{folder3_id}/files/{file_id}"
   pattern: "*"
+};
+
+message Order1 {
+  option (google.api.resource) = {
+    type: "resourcenames.example.com/Order1"
+    pattern: "orders1/{order1_id}"
+  };
+  string name = 1;
+}
+
+option (google.api.resource_definition) = {
+  type: "resourcenames.example.com/Order2"
+  pattern: "orders2/{order2_id}"
+};
+
+message Order3 {
+  option (google.api.resource) = {
+    type: "resourcenames.example.com/Order3"
+    pattern: "orders3/{order3_id}"
+  };
+  string name = 1;
+}
+
+option (google.api.resource_definition) = {
+  type: "resourcenames.example.com/OrderTest1"
+  pattern: "orders1/{order1_id}/items/{item_id}"
+  pattern: "orders2/{order2_id}/items/{item_id}"
+};
+
+option (google.api.resource_definition) = {
+  type: "resourcenames.example.com/OrderTest2"
+  pattern: "orders2/{order2_id}/items/{item_id}"
+  pattern: "orders3/{order3_id}/items/{item_id}"
 };
 
 message FileLevelChildTypeRef {
     string folder_name = 1 [(google.api.resource_reference).child_type = "resourcenames.example.com/File"];
     string folder_multi_name = 2 [(google.api.resource_reference).child_type = "resourcenames.example.com/FileMulti"];
     string folder_multi_wildcard_name = 3 [(google.api.resource_reference).child_type = "resourcenames.example.com/FileMultiWildcard"];
+    string req_folder_name = 4 [(google.api.field_behavior) = REQUIRED, (google.api.resource_reference).child_type = "resourcenames.example.com/File"];
+    string req_folder_multi_name = 5 [(google.api.field_behavior) = REQUIRED, (google.api.resource_reference).child_type = "resourcenames.example.com/FileMulti"];
+    string req_folder_multi_name_history = 6 [(google.api.field_behavior) = REQUIRED, (google.api.resource_reference).child_type = "resourcenames.example.com/FileMultiHistory"];
+    string req_order_test1 = 7 [(google.api.field_behavior) = REQUIRED, (google.api.resource_reference).child_type = "resourcenames.example.com/OrderTest1"];
+    string req_order_test2 = 8 [(google.api.field_behavior) = REQUIRED, (google.api.resource_reference).child_type = "resourcenames.example.com/OrderTest2"];
 }
 
 // This isn't referenced anywhere, so should be ignored.

--- a/tests/ProtoTests/RoutingHeaders/routing-headers.proto
+++ b/tests/ProtoTests/RoutingHeaders/routing-headers.proto
@@ -29,6 +29,11 @@ service RoutingHeaders {
     // PHP orders alphabetical by field-name; test that here.
     option (google.api.http).get = "/{nest1.nest2.name=items/*}/child1/{name=items/*}/child2/{another_name=more_items/*/and_more/*}/child3";
   };
+
+  rpc OrderingMethod(OrderRequest) returns(Response) {
+    // Test ordering of placeholders
+    option (google.api.http).get = "/{a=a}/{c=c}/{aa=aa}/{b=b}/{d=d}/{a_id=a_id}/{b_id=b_id}/{e=e}";
+  }
 }
 
 message SimpleRequest {
@@ -45,6 +50,17 @@ message NestedRequest {
   Inner1 nest1 = 1;
   string name = 2;
   string another_name = 3;
+}
+
+message OrderRequest {
+  string a = 1;
+  string b = 2;
+  string d = 3;
+  string c = 4;
+  string a_id = 5;
+  string e = 6;
+  string b_id = 7;
+  string aa = 8;
 }
 
 message Response {


### PR DESCRIPTION
Dataproc revealed that the monolith has non-deterministic generation for placeholders; hence two integration tests currently removed. Next PR will be to update to latest monolith version which contains the fix; then to re-enable all tests