### PR TITLE
Add bazel build test; fix various issues

### DIFF
--- a/.github/workflows/bazel_example.yml
+++ b/.github/workflows/bazel_example.yml
@@ -1,0 +1,25 @@
+name: Bazel - build example pkg
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Install Bazel (latest version)
+      uses: abhinavsingh/setup-bazel@v3
+
+    - name: Build example package; all targets
+      run: |
+        cd bazel_example;
+        bazel build ...

--- a/bazel_example/WORKSPACE.bazel
+++ b/bazel_example/WORKSPACE.bazel
@@ -67,3 +67,6 @@ local_repository(
     name = "gapic_generator_php",
     path = "../",
 )
+
+load("@gapic_generator_php//:repositories.bzl", "gapic_generator_php_repositories")
+gapic_generator_php_repositories()

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -28,8 +28,8 @@ def gapic_generator_php_repositories():
         php,
         name = "php",
         prebuilt_phps = ["@gapic_generator_php//:rules_php_gapic/resources/php-7.4.15_linux_x86_64.tar.gz"],
-        urls = ["https://windows.php.net/downloads/releases/php-7.4.15-src.zip"],
-        strip_prefix = "php-7.4.15-src",
+        urls = ["https://www.php.net/distributions/php-7.4.15.tar.gz"],
+        strip_prefix = "php-7.4.15",
     )
     maybe(
         php_composer_install,

--- a/rules_php_gapic/php.bzl
+++ b/rules_php_gapic/php.bzl
@@ -19,9 +19,10 @@ def _php_binary_impl(ctx):
     # I don't understand why this is required:
     entry_point_relative = entry_point_relative[len("rules_php_gapic/"):]
     cmd = """
-cp -r {install_path} {out_dir_path}
+cp -rL {install_path} {out_dir_path}
 # Overwrite symlinks to .php files with actual files; PHP '__DIR__ ' fails on symlinks
-find {install_path} -name '*.php' | cpio -p {out_dir_path}
+# TODO: This doesn't work, hence the -L in the above cp. Ideally remove the -L and just copy .php files
+#find {install_path} -name '*.php' | cpio -p {out_dir_path}
     """.format(
         install_path = ctx.file.php_composer_install.path,
         out_dir_path = out_dir.path,
@@ -32,8 +33,9 @@ find {install_path} -name '*.php' | cpio -p {out_dir_path}
         command = cmd
     )
     run_sh = """#!/bin/bash
-$(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{php_short_path} \
-    $(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{out_short_path}/install/{entry_point}
+PHP="$(pwd)/$(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{php_short_path}"
+cd $(dirname $0)/run.sh.runfiles/$(basename $(pwd))/{out_short_path}/install
+$PHP ./{entry_point}
     """.format(
         php_short_path = ctx.file.php.short_path,
         out_short_path = out_dir.short_path,

--- a/rules_php_gapic/php_repo.bzl
+++ b/rules_php_gapic/php_repo.bzl
@@ -96,12 +96,12 @@ def _php_composer_install_impl(ctx):
     # The entire workspace is required, as the php entry-point may reference
     # arbitrary other files and directories within the workspace.
     # This copy is used during the execution of the PHP, as it has all files available.
-    _execute_and_check_result(ctx, ["cp", "-rHs",  "--preserve=links", str(ws_path), "install"])
+    _execute_and_check_result(ctx, ["cp", "-rHs",  "--preserve=links", str(ws_path), "."])
+    _execute_and_check_result(ctx, ["mv", "./" + ws_path.basename, "./install"])
     ctx.execute(["rm", "-rf", "./install/vendor"]) # This will fail if dir doesn't exist, so don't check
     php_path = ctx.path(ctx.attr.php)
     composer_path = ctx.path(ctx.attr.composer_phar)
-    #_execute_and_check_result(ctx, [php_path, composer_path, "install"], working_directory="./install/")
-    _execute_and_check_result(ctx, ["php", composer_path, "install"], working_directory="./install/")
+    _execute_and_check_result(ctx, [php_path, composer_path, "install"], working_directory="./install/")
     ctx.file("BUILD.bazel", """exports_files(["install"])""")
 
 php_composer_install = repository_rule(

--- a/src/Main.php
+++ b/src/Main.php
@@ -59,7 +59,12 @@ if ($argc === 1) {
     }
     $genRequest = new CodeGeneratorRequest();
     $genRequest->mergeFromString($protocRequest);
+    if ($genRequest->serializeToString() === (new CodeGeneratorRequest())->serializeToString()) {
+        // Nothing passed in; probably run from cmd-line and ^D (EOF) sent.
+        showUsageAndExit();
+    }
     $genResponse = new CodeGeneratorResponse();
+    $genResponse->setSupportedFeatures(Feature::FEATURE_PROTO3_OPTIONAL);
     try {
         $fileDescs = Vector::new($genRequest->getProtoFile())
             ->map(function($bytes) {
@@ -76,7 +81,6 @@ if ($argc === 1) {
             $file->setContent($fileContent);
             return $file;
         });
-        $genResponse->setSupportedFeatures(Feature::FEATURE_PROTO3_OPTIONAL);
         $genResponse->setFile($files->toArray());
     } catch (\Exception $e) {
         $genResponse->setError("Error from PHP gapic generator:\n" . $e->getMessage());


### PR DESCRIPTION
Update versions of dependencies
Add missing gapic_generator_php_repositories invocation in bazel workspace.
Fix PHP source location, if not using pre-built package.
Fix file copying when performing composer install.
Fix php runner.
Correctly exit generator if EOF (^D) sent to stdin.