### PR TITLE
Add support for specifying grpc config in bazel

### DIFF
--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -55,6 +55,7 @@ php_gapic_library(
     # TODO: Include config yaml files
     gapic_yaml = None,
     service_yaml = None,
+    grpc_service_config = ":example-grpc-service-config.json",
 )
 
 php_gapic_assembly_pkg(

--- a/bazel_example/example-grpc-service-config.json
+++ b/bazel_example/example-grpc-service-config.json
@@ -1,0 +1,20 @@
+{
+  "method_config": [
+    {
+      "name": [
+        {
+          "service": "example.Example",
+          "method": "ExampleMethod"
+        }
+      ],
+      "timeout": "942s",
+      "retry_policy": {
+        "max_attempts": 99,
+        "initial_backoff": "1s",
+        "max_backoff": "142s",
+        "backoff_multiplier": 1.0,
+        "retryable_status_codes": [ "UNAVAILABLE", "DEADLINE_EXCEEDED" ]
+      }
+    }
+  ]
+}

--- a/integration_tests/Invoker.php
+++ b/integration_tests/Invoker.php
@@ -82,8 +82,6 @@ class Invoker
             // Run the micro-generator via protoc.
             $microProtocOutDir = "{$rootOutDir}/micro_protoc";
             mkdir($microProtocOutDir); // protoc requires this directory to already exist.
-            $protocMicroCmdLine = $protocCmdLinePrefix .
-                " --plugin=protoc-gen-gapic={$rootDir}/integration_tests/run_protoc_plugin.sh --gapic_out={$microProtocOutDir}";
             $protocOpts = [];
             if (file_exists($gapicYamlArg)) {
                 $protocOpts[] = "gapic_yaml={$gapicYamlArg}";
@@ -94,9 +92,10 @@ class Invoker
             if (file_exists($grpcServiceConfigArg)) {
                 $protocOpts[] = "grpc_service_config={$grpcServiceConfigArg}";
             }
-            if (count($protocOpts) > 0) {
-                $protocMicroCmdLine .= " --gapic_opt=" . implode(',', $protocOpts);
-            }
+            // This matches how the bazel invocation of protoc provides options to the plugin.
+            $protocOpts = count($protocOpts) > 0 ? implode(',', $protocOpts) . ':' : '';
+            $protocMicroCmdLine = $protocCmdLinePrefix .
+                " --plugin=protoc-gen-gapic={$rootDir}/integration_tests/run_protoc_plugin.sh --gapic_out={$protocOpts}{$microProtocOutDir}";
             static::execCmd($protocMicroCmdLine . " {$input} 2>&1", 'protoc micro plugin');
 
             // Run the micro-generator standalone.

--- a/rules_php_gapic/BUILD.bazel
+++ b/rules_php_gapic/BUILD.bazel
@@ -18,5 +18,6 @@ php_binary(
     name = "php_gapic_generator_binary",
     php_composer_install = "@php_gapic_generator_composer_install//:install",
     entry_point = "src/Main.php",
+    working_directory_flag_name = "side_loaded_root_dir",
     visibility = ["//visibility:public"],
 )

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -103,6 +103,7 @@ class CodeGenerator
             throw new \Exception('No packages specified to build');
         }
         // Generate files for each package.
+        $result = [];
         foreach ($byPackage as [$_, $singlePackageFileDescs]) {
             $namespaces = $singlePackageFileDescs
                 ->map(fn($x) => ProtoHelpers::getNamespace($x))
@@ -110,9 +111,11 @@ class CodeGenerator
             if (count($namespaces) > 1) {
                 throw new \Exception('All files in the same package must have the same PHP namespace');
             }
-            yield from static::generatePackage(
-                $catalog, $namespaces[0], $singlePackageFileDescs, $licenseYear, $grpcServiceConfigJson, $gapicYaml, $serviceYaml);
+            foreach (static::generatePackage($catalog, $namespaces[0], $singlePackageFileDescs, $licenseYear, $grpcServiceConfigJson, $gapicYaml, $serviceYaml) as $file) {
+                $result[] = $file;
+            }
         }
+        return $result;
     }
 
     private static function generatePackage(

--- a/src/Main.php
+++ b/src/Main.php
@@ -49,7 +49,7 @@ $year = 2020;
 
 // When running as a protoc plugin, an optional root directory may be passed in to set the
 // root location of the side-loaded configuration files:
-// - grpc sevrice config json
+// - grpc service config json
 // - service yaml
 // - gapic yaml
 // This is required when running under bazel, as the PHP working directory has to be different to the


### PR DESCRIPTION
Allow config-file working directory to be specified on the cmd-line, which i  required when running from bazel.
Return generated files as an array rather than as a generator, to ease debugging.
Update prebuilt PHP to include bcmaths, as required by the proto JSON parser.