### PR TITLE
Include service and gapic yaml in example

### DIFF
--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -23,6 +23,7 @@ proto_library(
     deps = [
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/longrunning:operations_proto",
     ],
 )
 
@@ -52,9 +53,8 @@ php_gapic_library(
         ":example_php_proto",
         ":example_php_grpc",
     ],
-    # TODO: Include config yaml files
-    gapic_yaml = None,
-    service_yaml = None,
+    gapic_yaml = ":example-gapic.yaml",
+    service_yaml = ":example-service.yaml",
     grpc_service_config = ":example-grpc-service-config.json",
 )
 

--- a/bazel_example/example-gapic.yaml
+++ b/bazel_example/example-gapic.yaml
@@ -1,0 +1,15 @@
+type: com.google.api.codegen.ConfigProto
+config_schema_version: 2.0.0
+language_settings:
+  php:
+    package_name: Example
+
+interfaces:
+- name: example.Example
+  methods:
+  - name: LroMethod
+    long_running:
+      initial_poll_delay_millis: 42042
+      poll_delay_multiplier: 1.5
+      max_poll_delay_millis: 45000
+      total_poll_timeout_millis: 86400000

--- a/bazel_example/example-service.yaml
+++ b/bazel_example/example-service.yaml
@@ -1,0 +1,7 @@
+type: google.api.Service
+config_version: 3
+
+backend:
+  rules:
+  - selector: 'example.Example.ExampleMethodRetryServiceYaml'
+    deadline: 4242.0

--- a/bazel_example/example.proto
+++ b/bazel_example/example.proto
@@ -18,11 +18,24 @@ package example;
 
 import "google/api/client.proto";
 import "google/api/resource.proto";
+import "google/longrunning/operations.proto";
 
 service Example {
-    option (google.api.default_host) = "example.com";
+  option (google.api.default_host) = "example.com";
 
-    rpc ExampleMethod(Request) returns(Response);
+  // An example method; retry specified in example-grpc-service-config.json
+  rpc ExampleMethod(Request) returns(Response);
+
+  // An example method; retry specified in example-service-config.yaml
+  rpc ExampleMethodRetryServiceYaml(Request) returns(Response);
+
+  // An example Long Running Operation method
+  rpc LroMethod(Request) returns(google.longrunning.Operation) {
+    option (google.longrunning.operation_info) = {
+      response_type: "LroResponse"
+      metadata_type: "LroMetadata"
+    };
+  }
 }
 
 option (google.api.resource_definition) = {
@@ -31,9 +44,15 @@ option (google.api.resource_definition) = {
 };
 
 message Request {
-    string name = 1 [(google.api.resource_reference).type = "example.com/AResource"];
-    optional int32 number = 2;
+  string name = 1 [(google.api.resource_reference).type = "example.com/AResource"];
+  optional int32 number = 2;
 }
 
 message Response {
+}
+
+message LroResponse {
+}
+
+message LroMetadata {
 }


### PR DESCRIPTION
And update the example to use features of both these config files.
A future PR will ensure the yaml configs are passed through bazel correctly.