### PR TITLE
Fix building php from source

### DIFF
--- a/bazel_example/WORKSPACE.bazel
+++ b/bazel_example/WORKSPACE.bazel
@@ -59,8 +59,8 @@ switched_rules_by_language(name = "com_google_googleapis_imports", gapic = True)
 # Use the following to use the bazel rules defined in github.
 #http_archive(
 #    name = "gapic_generator_php",
-#    urls = ["https://github.com/googleapis/gapic-generator-php/archive/master.zip"],
-#    strip_prefix = "gapic-generator-php-master",
+#    urls = ["https://github.com/googleapis/gapic-generator-php/archive/v1.0.0-beta01.zip"],
+#    strip_prefix = "gapic-generator-php-1.0.0-beta01",
 #)
 # Use the following to use the bazel rules defined locally, rather than fetched from github.
 local_repository(

--- a/rules_php_gapic/php.bzl
+++ b/rules_php_gapic/php.bzl
@@ -31,8 +31,21 @@ cp -rL {install_path} {out_dir_path}
         outputs = [out_dir],
         command = cmd
     )
-    # This changes directory to the PHP src install path before running php.
-    # Without this the php code fails to execute.
+    # PHP is run via this "run.sh" script, which changes directory required by php.
+    # Optionally the _bazel_ working directory can be passed as a cmd-line flag to
+    # the php process.
+    # This is required as php does not differentiate between a source working directory
+    # and a "run-time" working directory; however some tooling (e.g. bazel) requires this
+    # conceptual separation.
+    # The working directory is changed in this script (cd ...) to where php expects, which
+    # means php can find its sources (ie *.php files) successfully. The bazel working directory
+    # is optionally passed to the script, so the script can find further resources (if required).
+    #
+    # Note that debugging issues with php running via this script can be painful, especially if
+    # running within another process, for example protoc; especially again when issues may only
+    # occur when running in CI (e.g. github actions).
+    # One useful debugging technique is to redirect stdout and/or stderr of the php process i
+    # this script to a file; then dump the file contents afterwards.
     if ctx.attr.working_directory_flag_name:
         working_directory_flag = '--{name} "$WD"'.format(name=ctx.attr.working_directory_flag_name)
     else:

--- a/rules_php_gapic/php_repo.bzl
+++ b/rules_php_gapic/php_repo.bzl
@@ -63,7 +63,15 @@ exports_files(glob(include = ["bin/*", "lib/**"], exclude_directories = 0))
     )
     _execute_and_check_result(
         ctx,
-        ["./configure", "--enable-static", "--without-pear", "--without-iconv", "--prefix=%s" % root_path.realpath],
+        ["./configure",
+            "--enable-static",
+            "--without-pear",
+            "--without-iconv",
+            "--enable-mbstring",
+            "--disable-mbregex",
+            "--with-openssl",
+            "--enable-bcmath",
+            "--prefix=%s" % root_path.realpath],
         working_directory = srcs_dir,
         quiet = False,
     )


### PR DESCRIPTION
Note that this is difficult to test; I've run this locally and in CI
with the pre-built php disabled to ensure that the built-from-sources
version of php works as expected.

Also update example to point to beta01 release of the generator rather than head.
And add comment explaining how php is executed within bazel.