### PR TITLE
Fix bazel issues

### DIFF
--- a/rules_php_gapic/php_repo.bzl
+++ b/rules_php_gapic/php_repo.bzl
@@ -109,7 +109,7 @@ def _php_composer_install_impl(ctx):
     ctx.execute(["rm", "-rf", "./install/vendor"]) # This will fail if dir doesn't exist, so don't check
     php_path = ctx.path(ctx.attr.php)
     composer_path = ctx.path(ctx.attr.composer_phar)
-    _execute_and_check_result(ctx, [php_path, composer_path, "install"], working_directory="./install/")
+    _execute_and_check_result(ctx, [php_path, "-n", composer_path, "install"], working_directory="./install/")
     ctx.file("BUILD.bazel", """exports_files(["install"])""")
 
 php_composer_install = repository_rule(


### PR DESCRIPTION
Copy files, but exclude git and bazel directories, which can cause recursiveness.
Call php without ini file, and with an increased memory limit.