### PR TITLE
fix(grpc_config): Round retry_delay_multiplier for determinstic tests [ggphp]

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+# Pre-commit Git checks.
+# Set up:
+#  ln -s .githooks/pre-commit .git/hooks/pre-commit
+
+# Constants.
+BOLD="\e[1m"
+UNSET="\e[0m"
+WHITE="\e[97m"
+RED="\e[91m"
+BACK_MAGENTA="\e[45m"
+BACK_BLUE="\e[44m"
+BACK_RED="\e[41m"
+BACK_GREEN="\e[42m"
+
+# Methods.
+function echo_error {
+  ERR_MSG=$1
+  HELP_MSG=$2
+  echo -e "$BOLD $BACK_BLUE $WHITE Precommit:\t $BACK_RED Changes NOT committed. $UNSET"
+  echo -e "$BOLD $BACK_BLUE $WHITE Precommit:\t $BACK_RED $WHITE $ERR_MSG $BACK_BLUE $HELP_MSG $UNSET"
+}
+
+function echo_status {
+  STATUS_MSG=$1
+  echo -e "$BOLD $BACK_BLUE $WHITE Precommit:\t $STATUS_MSG $UNSET"
+}
+
+function echo_success {
+  echo -e "$BOLD $BACK_BLUE $WHITE Precommit:\t $BACK_GREEN $WHITE SUCCESS. $UNSET All checks passed!"
+}
+
+function header_check_preparation {
+  echo_status "Setting up license check environment"
+  export GOPATH=$(go env GOPATH)
+  if [ $? -ne 0 ];
+  then
+      echo_status "Please install Go first, instructions can be found here: https://golang.org/doc/install."
+  else
+      export ENV_PATH=$(echo $PATH)
+      if [[ $ENV_PATH != *$GOPATH* ]];
+      then
+        echo_status "GOPATH is not in the system path, adding it now."
+        export PATH=$GOPATH/bin:$PATH
+      fi
+      which addlicense
+      if [ $? -ne 0 ];
+      then
+        echo_status "addlicense tool is not yet installed, downloading it now."
+        go get -u github.com/google/addlicense
+      fi
+  fi
+}
+
+# Check only the staged files.
+NUM_TOTAL_FILES_CHANGED=$(git diff --cached --name-only | wc -l)
+NUM_PHP_FILES_CHANGED=$(git diff --cached --name-only "*.php" | wc -l)
+NUM_UNIT_GOLDEN_FILES_CHANGED=$(git diff --cached --name-only "tests/ProtoTests/*/*.php" | wc -l)
+NUM_BAZEL_FILES_CHANGED=$(git diff --cached --name-only "*BUILD.bazel" | wc -l)
+
+if [ $NUM_TOTAL_FILES_CHANGED -le 0 ]
+then
+  echo_error "No new files to commit." ""
+  exit 1
+fi
+
+
+if [ -x /usr/lib/git-core/google_hook ]; then
+  /usr/lib/git-core/google_hook pre-commit "$@"
+fi
+
+# TODO(miraleung): Add a linter check here.
+
+# Check unit tests.
+if [ $NUM_PHP_FILES_CHANGED -gt 0 ] || [ $NUM_UNIT_GOLDEN_FILES_CHANGED -gt 0 ]
+then
+  echo_status "Checking unit tests..."
+  ./vendor/bin/phpunit --bootstrap tests/autoload.php tests
+  TEST_STATUS=$?
+  if [ $TEST_STATUS != 0 ]
+  then
+    echo_error "Tests failed." "Please fix them and try again."
+    exit 1
+  fi
+fi
+
+: << 'END'
+# Uncomment when integration tests can run more quickly.
+# Check integration tests.
+if [ $NUM_PHP_FILES_CHANGED -gt 0 ] \
+  || [ $NUM_INTEGRATION_BAZEL_FILES_CHANGED -gt 0 ]
+then
+  echo_status "Checking integration tests..."
+  php Main.php
+  TEST_STATUS=$?
+  if [ $TEST_STATUS != 0 ]
+  then
+    echo_error "Tests failed." "Please fix them and try again."
+    exit 1
+  fi
+fi
+END
+
+# Check and fix Bazel format.
+if [ $NUM_BAZEL_FILES_CHANGED -gt 0 ]
+then
+  for FILE in $(find ./ -name BUILD.bazel)
+  do
+    buildifier --lint=fix $FILE
+  done
+fi
+
+: << 'END'
+# Uncomment when we can identify which files need a license header.
+# Check Apache License header for source files.
+if [ $NUM_PHP_FILES_CHANGED -gt 0 ]
+then
+  echo_status "Checking Apache License Header ..."
+  header_check_preparation
+  addlicense -c "Google LLC" -l apache -check $(find $PWD/src/ -type f -name '*.php')
+  CHECK_STATUS=$?
+  if [ $CHECK_STATUS != 0 ]
+  then
+    echo_error "License header check failed." "Please ensure that all source files have a license header."
+    exit 1
+  fi
+fi
+END
+
+echo_success

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -216,7 +216,7 @@ class ResourcesGenerator
                     $retryParams = $retryParams->append([
                         $paramsName, Vector::new([
                             ['initial_retry_delay_millis', is_null($policy) ? 0 : $durationToMillis($policy->getInitialBackoff())],
-                            ['retry_delay_multiplier', is_null($policy) ? 0 : round($policy->getBackoffMultiplier(), 1)],
+                            ['retry_delay_multiplier', is_null($policy) ? 0 : round($policy->getBackoffMultiplier(), 5)],
                             ['max_retry_delay_millis', is_null($policy) ? 0 : $durationToMillis($policy->getMaxBackoff())],
                             ['initial_rpc_timeout_millis', $timeout],
                             ['rpc_timeout_multiplier', 1.0],

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -216,7 +216,7 @@ class ResourcesGenerator
                     $retryParams = $retryParams->append([
                         $paramsName, Vector::new([
                             ['initial_retry_delay_millis', is_null($policy) ? 0 : $durationToMillis($policy->getInitialBackoff())],
-                            ['retry_delay_multiplier', is_null($policy) ? 0 : $policy->getBackoffMultiplier()],
+                            ['retry_delay_multiplier', is_null($policy) ? 0 : round($policy->getBackoffMultiplier(), 1)],
                             ['max_retry_delay_millis', is_null($policy) ? 0 : $durationToMillis($policy->getMaxBackoff())],
                             ['initial_rpc_timeout_millis', $timeout],
                             ['rpc_timeout_multiplier', 1.0],


### PR DESCRIPTION
Running the tests locally for the first time, I got the failure below. This fix prevents such cases from occurring on different machines.

```
1) Google\Generator\Tests\ProtoTests\ProtoTest::testGrpcServiceConfig
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
                 },\n
                 "retry_policy_2_params": {\n
                     "initial_retry_delay_millis": 1000,\n
-                    "retry_delay_multiplier": 1.1,\n
+                    "retry_delay_multiplier": 1.100000023841858,\n
                     "max_retry_delay_millis": 10000,\n
                     "initial_rpc_timeout_millis": 11000,\n
                     "rpc_timeout_multiplier": 1.0,\n
@@ @@
                 },\n
                 "retry_policy_3_params": {\n
                     "initial_retry_delay_millis": 2000,\n
-                    "retry_delay_multiplier": 1.2,\n
+                    "retry_delay_multiplier": 1.2000000476837158,\n
                     "max_retry_delay_millis": 20000,\n
                     "initial_rpc_timeout_millis": 22000,\n
                     "rpc_timeout_multiplier": 1.0,\n


```