### PR TITLE
Fix generated file layout; fix resource-names

### DIFF
--- a/integration_tests/Invoker.php
+++ b/integration_tests/Invoker.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 
 namespace Google\Generator\IntegrationTests;
 
+use Google\Generator\Collections\Vector;
+
 class Invoker
 {
     public static function invoke(
@@ -35,7 +37,9 @@ class Invoker
         $descFilename = stream_get_meta_data($descRes)['uri'];
         $protobuf = "{$rootDir}/protobuf/src/";
         $googleapis = "{$rootDir}/googleapis/";
-        $input = "{$rootDir}/{$protoPath}";
+        $input = Vector::new(explode(' ', $protoPath)) // Assumes paths don't contain spaces
+            ->map(fn($path) => "{$rootDir}/{$path}")
+            ->join(' ');
         $protocCmdLinePrefix = "{$protoc} --include_imports --include_source_info --experimental_allow_proto3_optional " .
             "-o {$descFilename}  -I {$googleapis} -I {$protobuf} -I {$rootDir}";
         static::execCmd($protocCmdLinePrefix . " {$input} 2>&1", 'protoc');

--- a/integration_tests/Main.php
+++ b/integration_tests/Main.php
@@ -120,7 +120,7 @@ $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/dialogflow/v2/dialogflow_v2.yaml',
     'googleapis/google/cloud/dialogflow/v2/dialogflow_grpc_service_config.json'
 )) ? $ok : false;
-// // TODO: googleapis/google/cloud/dialogflow/cx/v3/ has wrong capitalization somewhere, so monolith crashes
+// TODO: googleapis/google/cloud/dialogflow/cx/v3/ has wrong capitalization somewhere, so monolith crashes
 // $ok = processDiff(Invoker::invoke(
 //     'googleapis/google/cloud/dialogflow/cx/v3/*.proto googleapis/google/cloud/common_resources.proto',
 //     'google.cloud.dialogflow.cx.v3',
@@ -155,6 +155,14 @@ $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/vision/v1/vision_gapic.yaml',
     'googleapis/google/cloud/vision/v1/vision_v1.yaml',
     'googleapis/google/cloud/vision/v1/vision_grpc_service_config.json'
+)) ? $ok : false;
+
+$ok = processDiff(Invoker::invoke(
+    'googleapis/google/ads/googleads/v6/**/*.proto',
+    'google.ads.googleads.v6',
+    'googleapis/google/ads/googleads/v6/googleads_gapic.yaml',
+    'googleapis/google/ads/googleads/v6/googleads_v6.yaml',
+    'googleapis/google/ads/googleads/v6/googleads_grpc_service_config.json'//,
 )) ? $ok : false;
 
 if (!$ok) {

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -61,7 +61,7 @@ class CodeGenerator
         $descSet->mergeFromString($descBytes);
         $fileDescs = Vector::new($descSet->getFile());
         $filesToGenerate = $fileDescs
-            ->filter(fn($x) => $x->getPackage() === $package)
+            ->filter(fn($x) => substr($x->getPackage(), 0, strlen($package)) === $package)
             ->map(fn($x) => $x->getName());
         yield from static::generate($fileDescs, $filesToGenerate, $licenseYear, $grpcServiceConfigJson, $gapicYaml, $serviceYaml);
     }
@@ -127,8 +127,10 @@ class CodeGenerator
         ?string $gapicYaml,
         ?string $serviceYaml
     ) {
-        $version = Helpers::nsVersion($namespace);
-        $version = is_null($version) ? '' : $version . '/';
+        $version = Helpers::nsVersionAndSuffixPath($namespace);
+        if ($version !== '') {
+            $version .= '/';
+        }
         // $fileDescs: Vector<FileDescriptorProto>
         foreach ($fileDescs as $fileDesc)
         {

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -127,6 +127,9 @@ class CodeGenerator
         ?string $gapicYaml,
         ?string $serviceYaml
     ) {
+        // Look for a version string, "Vn..." as a part of the namespace.
+        // If found, then the output directories for src and tests use it,
+        // as can be seen in the 'yield ...' code below.
         $version = Helpers::nsVersionAndSuffixPath($namespace);
         if ($version !== '') {
             $version .= '/';

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -147,7 +147,7 @@ class ResourcesGenerator
     public static function generateRestConfig(ServiceDetails $serviceDetails, ServiceYamlConfig $serviceYamlConfig): string
     {
         $allInterfaces = $serviceDetails->methods
-            ->filter(fn($method) => !is_null($method->httpRule))
+            ->filter(fn($method) => !is_null($method->httpRule) && !$method->isStreaming())
             ->map(fn($method) => [$serviceDetails->serviceName, $method->name, $method->httpRule])
             ->concat($serviceYamlConfig->httpRules->map(fn($x) => [
                 Vector::new(explode('.', $x->getSelector()))->skipLast(1)->join('.'),

--- a/src/Generation/ServiceDetails.php
+++ b/src/Generation/ServiceDetails.php
@@ -150,6 +150,7 @@ class ServiceDetails {
             }
             $msgsSeen = $msgsSeen->add($msg->desc->getFullname());
             // Only top-level resource-defs are included; matches monolith behaviour.
+            // TODO(vNext): Decide if this behaviour is correct, posibly modify.
             $messageResourceDef = $level === 0 ?
                 ProtoHelpers::getCustomOption($msg, CustomOptions::GOOGLE_API_RESOURCEDEFINITION, ResourceDescriptor::class) :
                 null;
@@ -164,6 +165,7 @@ class ServiceDetails {
                 ->filter(fn($x) => $x->getChildType() !== '')
                 ->flatMap(fn($x) => $catalog->parentResourceByChildType->get($x->getChildType(), Vector::new([])));
             // Recurse one level down into message fields; matches monolith behaviour.
+            // TODO(vNext): Decide if this behaviour is correct, posibly modify.
             if ($level === 0) {
                 $nestedDefs = $fields
                     ->filter(fn($f) => $f->getType() === GPBType::MESSAGE)

--- a/src/Generation/ServiceDetails.php
+++ b/src/Generation/ServiceDetails.php
@@ -28,6 +28,8 @@ use Google\Generator\Utils\Helpers;
 use Google\Generator\Utils\ProtoCatalog;
 use Google\Generator\Utils\ProtoHelpers;
 use Google\Generator\Utils\Type;
+use Google\Protobuf\Internal\GPBType;
+use Google\Protobuf\Internal\DescriptorProto;
 use Google\Protobuf\Internal\FileDescriptorProto;
 use Google\Protobuf\Internal\ServiceDescriptorProto;
 
@@ -108,9 +110,10 @@ class ServiceDetails {
         $this->gapicClientType = Type::fromName("{$namespace}\\Gapic\\{$desc->getName()}GapicClient");
         $this->emptyClientType = Type::fromName("{$namespace}\\{$desc->getName()}Client");
         $this->grpcClientType = Type::fromName("{$namespace}\\{$desc->getName()}GrpcClient");
-        $nsVersion = Helpers::nsVersion($namespace);
-        $unitTestNs = is_null($nsVersion) ? "{$namespace}\\Tests\\Unit" :
-            substr($namespace, 0, strlen($namespace) - strlen($nsVersion) - 1) . '\\Tests\\Unit\\' . $nsVersion;
+        $nsVersionAndSuffix = Helpers::nsVersionAndSuffixPath($namespace);
+        $unitTestNs = $nsVersionAndSuffix === '' ?
+            "{$namespace}\\Tests\\Unit" :
+            substr($namespace, 0, -strlen($nsVersionAndSuffix)) . 'Tests\\Unit\\' . str_replace('/', '\\', $nsVersionAndSuffix);
         $this->unitTestsType = Type::fromName("{$unitTestNs}\\{$desc->getName()}ClientTest");
         $this->docLines = $desc->leadingComments;
         $this->serviceName = "{$package}.{$desc->getName()}";
@@ -139,22 +142,41 @@ class ServiceDetails {
         // Resource-names
         // Wildcard patterns are ignored.
         // A resource-name which has just a single wild-card pattern is ignored.
-        $messageResourceDefs = $this->methods
-            ->map(fn($x) => ProtoHelpers::getCustomOption($x->inputMsg, CustomOptions::GOOGLE_API_RESOURCEDEFINITION, ResourceDescriptor::class))
-            ->filter(fn($x) => !is_null($x));
-        $resourceRefs = $this->methods
-            ->flatMap(fn($x) => $x->allFields)
-            ->map(fn($x) => ProtoHelpers::getCustomOption($x->desc, CustomOptions::GOOGLE_API_RESOURCEREFERENCE, ResourceReference::class))
-            ->filter(fn($x) => !is_null($x));
-        $typeRefResourceDefs = $resourceRefs
-            ->filter(fn($x) => $x->getType() !== '' && $x->getType() !== '*')
-            ->map(fn($x) => $catalog->resourcesByType[$x->getType()]);
-        $childTypeRefResourceDefs = $resourceRefs
-            ->filter(fn($x) => $x->getChildType() !== '')
-            ->flatMap(fn($x) => $catalog->parentResourceByChildType->get($x->getChildType(), Vector::new([])));
-        $resourceDefs = $messageResourceDefs
-            ->concat($typeRefResourceDefs)
-            ->concat($childTypeRefResourceDefs)
+        $msgsSeen = Set::new();
+        $gatherMsgResDefs = null;
+        $gatherMsgResDefs = function(DescriptorProto $msg, int $level) use(&$gatherMsgResDefs, &$msgsSeen, $catalog): Vector {
+            if ($msgsSeen[$msg->desc->getFullname()]) {
+                return Vector::new([]);
+            }
+            $msgsSeen = $msgsSeen->add($msg->desc->getFullname());
+            // Only top-level resource-defs are included; matches monolith behaviour.
+            $messageResourceDef = $level === 0 ?
+                ProtoHelpers::getCustomOption($msg, CustomOptions::GOOGLE_API_RESOURCEDEFINITION, ResourceDescriptor::class) :
+                null;
+            $fields = Vector::new($msg->getField());
+            $resourceRefs = $fields
+                ->map(fn($x) => ProtoHelpers::getCustomOption($x->desc, CustomOptions::GOOGLE_API_RESOURCEREFERENCE, ResourceReference::class))
+                ->filter(fn($x) => !is_null($x));
+            $typeRefResourceDefs = $resourceRefs
+                ->filter(fn($x) => $x->getType() !== '' && $x->getType() !== '*')
+                ->map(fn($x) => $catalog->resourcesByType[$x->getType()]);
+            $childTypeRefResourceDefs = $resourceRefs
+                ->filter(fn($x) => $x->getChildType() !== '')
+                ->flatMap(fn($x) => $catalog->parentResourceByChildType->get($x->getChildType(), Vector::new([])));
+            // Recurse one level down into message fields; matches monolith behaviour.
+            if ($level === 0) {
+                $nestedDefs = $fields
+                    ->filter(fn($f) => $f->getType() === GPBType::MESSAGE)
+                    ->map(fn($f) => $catalog->msgsByFullname[$f->desc->getMessageType()])
+                    ->flatMap(fn($nestedMsg) => $gatherMsgResDefs($nestedMsg, $level + 1));
+            } else {
+                $nestedDefs = Vector::new([]);
+            }
+            return $typeRefResourceDefs->concat($childTypeRefResourceDefs)->append($messageResourceDef)->concat($nestedDefs);
+        };
+        $resourceDefs = $this->methods
+            ->flatMap(fn($x) => $gatherMsgResDefs($x->inputMsg, 0))
+            ->filter(fn($x) => !is_null($x))
             ->map(fn($res) => new ResourceDetails($res));
         $this->resourceParts = $resourceDefs
             ->filter(fn($x) => $x->patterns->any())

--- a/src/Main.php
+++ b/src/Main.php
@@ -154,7 +154,7 @@ function readOptions($opts, $sideLoadedRootDir = null) {
             }
             return $path;
         } else {
-            return $sideLoadedRootDir . '/' . $path;
+            return is_null($sideLoadedRootDir) ? $path : ($sideLoadedRootDir . '/' . $path);
         }
     };
     if (isset($opts['grpc_service_config'])) {

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -18,6 +18,8 @@ declare(strict_types=1);
 
 namespace Google\Generator\Utils;
 
+use Google\Generator\Collections\Vector;
+
 class Helpers
 {
     public static function toSnakeCase(string $s)
@@ -33,21 +35,19 @@ class Helpers
         return strtolower($s[0]) . substr($s, 1);
     }
 
-    public static function nsVersion(string $namespace): ?string
+    public static function nsVersionAndSuffixPath(string $namespace): string
     {
-        $parts = explode('\\', $namespace);
-        if (count($parts) > 1) {
-            $v = $parts[count($parts) - 1];
-            // Detected as a 'version' if it starts with 'v' or 'V', followed by a digit.
-            // Any other characters are allowed to follow.
-            if (strtoupper(substr($v, 0, 1)) === 'V')
-            {
-                $num = substr($v, 1, 1);
-                if (strlen($num) === 1 && ctype_digit($num)) {
-                    return $v;
+        // Extract version and suffix from the namespace by looking for a version in the namespace.
+        // E.g. ".../V6/Services" returns "V6/Services".
+        // A version is heuristically detected by [v|V] followed by at least one digit.
+        // Return empty string if no version part found.
+        return Vector::new(explode('\\', $namespace))
+            ->skipWhile(function ($s){
+                if (strlen($s) < 2 || strtoupper(substr($s, 0, 1)) != 'V') {
+                    return true;
                 }
-            }
-        }
-        return null;
+                return !ctype_digit(substr($s, 1, 1));
+            })
+            ->join('/');
     }
 }


### PR DESCRIPTION
Fix file layout of generated code when there are files/namespaces beneath the top-level.
Fix the selection of which resource-name helpers to include in a generated client.
And add adsv6 to the integration test.