### PR TITLE
[ggphp] chore(engx): Lower-case invoked methods in ProtoTest

### DIFF
--- a/tests/Unit/ProtoTests/ProtoTest.php
+++ b/tests/Unit/ProtoTests/ProtoTest.php
@@ -44,7 +44,7 @@ final class ProtoTest extends TestCase
         $serviceYaml = $this->loadConfig("{$protoDirName}/{$baseName}_service.yaml");
 
         // Use the fixed year 2020 for test generation, so tests won't fail in the future.
-        $codeIterator = CodeGenerator::GenerateFromDescriptor($descBytes, $package, 2020, $grpcServiceConfigJson, $gapicYaml, $serviceYaml);
+        $codeIterator = CodeGenerator::generateFromDescriptor($descBytes, $package, 2020, $grpcServiceConfigJson, $gapicYaml, $serviceYaml);
 
         foreach ($codeIterator as [$relativeFilename, $code]) {
             $filename = __DIR__ . '/' . dirname($protoPath) . '/out/' . $relativeFilename;


### PR DESCRIPTION
For codebase consistency.