### PR TITLE
[ggphp] fix(lint): Add full PSR2 linting rules, fix linter comment un-indentation

### DIFF
--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -290,7 +290,6 @@ class UnitTestsGenerator
                     ($this->assertEquals)(AST::access($status, AST::property('code')), $ex->instanceCall(AST::method('getCode'))()),
                     ($this->assertEquals)($expectedExceptionMessage, $ex->instanceCall(AST::method('getMessage'))()),
                 ),
-                // TODO: Fix formatted error (wrong indent) in this comment.
                 '// Call popReceivedCalls to ensure the stub is exhausted',
                 $transport->instanceCall(AST::method('popReceivedCalls'))(),
                 ($this->assertTrue)($transport->instanceCall(AST::method('isExhausted'))()),

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -35,20 +35,53 @@ class Formatter
      */
     public static function format(string $code): string
     {
-        // Fixers must be in priority order; the priority is the number in the comment.
-        // More fixers can be added as required to achieve the formatting we desire.
+        $psr2SingleClassElementPerStatementFixer =
+          new \PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer;
+        $psr2SingleClassElementPerStatementFixer->configure(['elements' => ['property']]);
+        $psr2MethodArgumentSpaceFixer =
+          new \PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
+        $psr2MethodArgumentSpaceFixer->configure(['on_multiline' => 'ensure_fully_multiline']);
+        // Same rules as in PSR2.
         $fixers = [
-            new \PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer(), // 55
-            new \PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer(), // 50
-            new \PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer(), // 26
-            new \PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer(), // 1
-            new \PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer(), // 0
-            new \PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer(), // 0
-            new \PhpCsFixer\Fixer\Basic\BracesFixer(), // -25
-            new \PhpCsFixer\Fixer\Import\OrderedImportsFixer(), // -30
-            new \PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer(), // -31
-            new \PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer(), // -50
+          new \PhpCsFixer\Fixer\Basic\EncodingFixer(), // 100, PSR2
+          new \PhpCsFixer\Fixer\PhpTag\FullOpeningTagFixer(), // 98, PSR2
+
+          // No priority provided.
+          new \PhpCsFixer\Fixer\Casing\ConstantCaseFixer(),
+          new \PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer(),
+          new \PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer(),
+          new \PhpCsFixer\Fixer\PhpTag\NoClosingTagFixer(),
+          new \PhpCsFixer\Fixer\ControlStructure\SwitchCaseSpaceFixer(),
+          new \PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer(),
+
+          // Ordered.
+          $psr2SingleClassElementPerStatementFixer,  // 56, PSR2
+          new \PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer(), // 55
+          new \PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer(), // 50, PSR2
+          new \PhpCsFixer\Fixer\FunctionNotation\NoSpacesAfterFunctionNameFixer(), // 2, PSR2
+          new \PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer(), // 2
+          new \PhpCsFixer\Fixer\Whitespace\NoSpacesInsideParenthesisFixer(), // 2, PSR2
+          new \PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer(), // 1, Critical to preserving sample code.
+          new \PhpCsFixer\Fixer\Import\SingleImportPerStatementFixer(), // 1, PSR2
+          new \PhpCsFixer\Fixer\ControlStructure\ElseifFixer(), // 0, PSR2
+          new \PhpCsFixer\Fixer\Whitespace\LineEndingFixer(), // 0, PSR2
+          new \PhpCsFixer\Fixer\Whitespace\NoTrailingWhitespaceFixer(), // 0, PSR2,
+          new \PhpCsFixer\Fixer\Comment\NoTrailingWhitespaceInCommentFixer(), // 0, PSR2
+          new \PhpCsFixer\Fixer\ControlStructure\NoBreakCommentFixer(), // 0, PSR2
+          new \PhpCsFixer\Fixer\PhpTag\LinebreakAfterOpeningTagFixer(), // 0
+          new \PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer(), // 0
+          new \PhpCsFixer\Fixer\ControlStructure\SwitchCaseSemicolonToColonFixer(), // 0, PSR2
+          new \PhpCsFixer\Fixer\Import\SingleLineAfterImportsFixer(), // -11, PSR2
+          new \PhpCsFixer\Fixer\Comment\SingleLineCommentStyleFixer(), // -19
+          new \PhpCsFixer\Fixer\NamespaceNotation\BlankLineAfterNamespaceFixer(), // -20, PSR2
+          new \PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer(), // -20
+          new \PhpCsFixer\Fixer\Basic\BracesFixer(), // -25, PSR2
+          $psr2MethodArgumentSpaceFixer, // -30, PSR2
+          new \PhpCsFixer\Fixer\Import\OrderedImportsFixer(), // -30
+          new \PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer(), // -31
+          new \PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer(), // -50, PSR2 (must run last)
         ];
+
         // Fixer temporarily removed:
         // new \PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer(), // -21
         // TODO: Understand why this fixer causes too many blank line insertions in some cases.
@@ -61,6 +94,10 @@ class Formatter
             foreach ($fixers as $fixer) {
                 $fixer->fix($fakeFile, $tokens);
             }
+            // This must run last, otherwise it collapses comments immediately succeeding blocks that may have semicolons.
+            $semicolonFixer = new \PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer();
+            $semicolonFixer->fix($fakeFile, $tokens);
+
 
             $code = $tokens->generateCode();
             // TODO(vNext): Remove this call.

--- a/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
@@ -88,7 +88,7 @@ use Google\Protobuf\Timestamp;
  *         $error = $operationResponse->getError();
  *         // handleError($error)
  *     }
- * // Alternatively:
+ *     // Alternatively:
  *     // start the operation, keep the operation name, and resume later
  *     $operationResponse = $assetServiceClient->exportAssets($parent, $outputConfig);
  *     $operationName = $operationResponse->getName();
@@ -336,7 +336,6 @@ class AssetServiceGapicClient
             } catch (ValidationException $ex) {
                 // Swallow the exception to continue trying other path templates
             }
-        
         }
 
         throw new ValidationException("Input did not match any known format. Input: $formattedName");
@@ -462,7 +461,7 @@ class AssetServiceGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $assetServiceClient->exportAssets($parent, $outputConfig);
      *     $operationName = $operationResponse->getName();
@@ -897,9 +896,8 @@ class AssetServiceGapicClient
      *         foreach ($page as $element) {
      *             // doSomethingWith($element);
      *         }
-     *
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Iterate through all elements
      *     $pagedResponse = $assetServiceClient->searchAllResources($scope);
      *     foreach ($pagedResponse->iterateAllElements() as $element) {
@@ -1043,9 +1041,8 @@ class AssetServiceGapicClient
      *         foreach ($page as $element) {
      *             // doSomethingWith($element);
      *         }
-     *
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Iterate through all elements
      *     $pagedResponse = $assetServiceClient->searchAllIamPolicies($scope);
      *     foreach ($pagedResponse->iterateAllElements() as $element) {
@@ -1227,7 +1224,7 @@ class AssetServiceGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $assetServiceClient->analyzeIamPolicyLongrunning($analysisQuery, $outputConfig);
      *     $operationName = $operationResponse->getName();

--- a/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
+++ b/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Google\Cloud\Asset\Tests\Unit\V1;
 
 use Google\Cloud\Asset\V1\AssetServiceClient;
@@ -207,7 +206,7 @@ class AssetServiceClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -265,9 +264,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -333,9 +332,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -393,9 +392,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -451,9 +450,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -515,9 +514,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -572,9 +571,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -640,9 +639,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -708,9 +707,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -768,9 +767,9 @@ class AssetServiceClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -889,7 +888,7 @@ class AssetServiceClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());

--- a/tests/Integration/goldens/redis/src/V1/Gapic/CloudRedisGapicClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Gapic/CloudRedisGapicClient.php
@@ -92,7 +92,7 @@ use Google\Protobuf\GPBEmpty;
  *         $error = $operationResponse->getError();
  *         // handleError($error)
  *     }
- * // Alternatively:
+ *     // Alternatively:
  *     // start the operation, keep the operation name, and resume later
  *     $operationResponse = $cloudRedisClient->createInstance($formattedParent, $instanceId, $instance);
  *     $operationName = $operationResponse->getName();
@@ -278,7 +278,6 @@ class CloudRedisGapicClient
             } catch (ValidationException $ex) {
                 // Swallow the exception to continue trying other path templates
             }
-        
         }
 
         throw new ValidationException("Input did not match any known format. Input: $formattedName");
@@ -407,7 +406,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->createInstance($formattedParent, $instanceId, $instance);
      *     $operationName = $operationResponse->getName();
@@ -492,7 +491,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->updateInstance($updateMask, $instance);
      *     $operationName = $operationResponse->getName();
@@ -577,7 +576,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->importInstance($name, $inputConfig);
      *     $operationName = $operationResponse->getName();
@@ -654,7 +653,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->exportInstance($name, $outputConfig);
      *     $operationName = $operationResponse->getName();
@@ -726,7 +725,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->failoverInstance($formattedName);
      *     $operationName = $operationResponse->getName();
@@ -803,7 +802,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->deleteInstance($formattedName);
      *     $operationName = $operationResponse->getName();
@@ -876,9 +875,8 @@ class CloudRedisGapicClient
      *         foreach ($page as $element) {
      *             // doSomethingWith($element);
      *         }
-     *
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Iterate through all elements
      *     $pagedResponse = $cloudRedisClient->listInstances($formattedParent);
      *     foreach ($pagedResponse->iterateAllElements() as $element) {
@@ -999,7 +997,7 @@ class CloudRedisGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $cloudRedisClient->upgradeInstance($formattedName, $redisVersion);
      *     $operationName = $operationResponse->getName();

--- a/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
+++ b/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Google\Cloud\Redis\Tests\Unit\V1;
 
 use Google\Cloud\Redis\V1\CloudRedisClient;
@@ -226,7 +225,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -373,7 +372,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -520,7 +519,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -667,7 +666,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -810,7 +809,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -927,7 +926,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -995,9 +994,9 @@ class CloudRedisClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -1079,9 +1078,9 @@ class CloudRedisClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -1226,7 +1225,7 @@ class CloudRedisClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());

--- a/tests/Integration/goldens/speech/src/V1/Gapic/SpeechGapicClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Gapic/SpeechGapicClient.php
@@ -270,7 +270,7 @@ class SpeechGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $speechClient->longRunningRecognize($config, $audio);
      *     $operationName = $operationResponse->getName();
@@ -338,7 +338,7 @@ class SpeechGapicClient
      *     foreach ($stream->closeWriteAndReadAll() as $element) {
      *         // doSomethingWith($element);
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Write requests individually, making read() calls if
      *     // required. Call closeWrite() once writes are complete, and read the
      *     // remaining responses from the server.

--- a/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
+++ b/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Google\Cloud\Speech\Tests\Unit\V1;
 
 use Google\Cloud\Speech\V1\SpeechClient;
@@ -131,9 +130,9 @@ class SpeechClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -252,7 +251,7 @@ class SpeechClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -342,7 +341,7 @@ class SpeechClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }

--- a/tests/Integration/goldens/videointelligence/src/V1/Gapic/VideoIntelligenceServiceGapicClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Gapic/VideoIntelligenceServiceGapicClient.php
@@ -64,7 +64,7 @@ use Google\LongRunning\Operation;
  *         $error = $operationResponse->getError();
  *         // handleError($error)
  *     }
- * // Alternatively:
+ *     // Alternatively:
  *     // start the operation, keep the operation name, and resume later
  *     $operationResponse = $videoIntelligenceServiceClient->annotateVideo($features);
  *     $operationName = $operationResponse->getName();
@@ -243,7 +243,7 @@ class VideoIntelligenceServiceGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $videoIntelligenceServiceClient->annotateVideo($features);
      *     $operationName = $operationResponse->getName();

--- a/tests/Integration/goldens/videointelligence/tests/Unit/V1/VideoIntelligenceServiceClientTest.php
+++ b/tests/Integration/goldens/videointelligence/tests/Unit/V1/VideoIntelligenceServiceClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Google\Cloud\VideoIntelligence\Tests\Unit\V1;
 
 use Google\Cloud\VideoIntelligence\V1\VideoIntelligenceServiceClient;
@@ -195,7 +194,7 @@ class VideoIntelligenceServiceClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());

--- a/tests/Unit/ProtoTests/Basic/out/tests/Unit/BasicClientTest.php
+++ b/tests/Unit/ProtoTests/Basic/out/tests/Unit/BasicClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Testing\Basic\Tests\Unit;
 
 use Testing\Basic\BasicClient;
@@ -116,9 +115,9 @@ class BasicClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -178,9 +177,9 @@ class BasicClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Gapic/BasicBidiStreamingGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Gapic/BasicBidiStreamingGapicClient.php
@@ -63,7 +63,7 @@ use Testing\BasicBidiStreaming\Response;
  *     foreach ($stream->closeWriteAndReadAll() as $element) {
  *         // doSomethingWith($element);
  *     }
- * // Alternatively:
+ *     // Alternatively:
  *     // Write requests individually, making read() calls if
  *     // required. Call closeWrite() once writes are complete, and read the
  *     // remaining responses from the server.
@@ -206,7 +206,7 @@ class BasicBidiStreamingGapicClient
      *     foreach ($stream->closeWriteAndReadAll() as $element) {
      *         // doSomethingWith($element);
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Write requests individually, making read() calls if
      *     // required. Call closeWrite() once writes are complete, and read the
      *     // remaining responses from the server.
@@ -266,7 +266,7 @@ class BasicBidiStreamingGapicClient
      *     foreach ($stream->closeWriteAndReadAll() as $element) {
      *         // doSomethingWith($element);
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Write requests individually, making read() calls if
      *     // required. Call closeWrite() once writes are complete, and read the
      *     // remaining responses from the server.

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/tests/Unit/BasicBidiStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/tests/Unit/BasicBidiStreamingClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Testing\BasicBidiStreaming\Tests\Unit;
 
 use Testing\BasicBidiStreaming\BasicBidiStreamingClient;
@@ -159,7 +158,7 @@ class BasicBidiStreamingClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -247,7 +246,7 @@ class BasicBidiStreamingClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/tests/Unit/BasicClientStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/tests/Unit/BasicClientStreamingClientTest.php
@@ -1,1 +1,67 @@
-<?php // IGNORE
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+namespace Testing\BasicClientStreaming\Tests\Unit;
+
+use Google\ApiCore\ApiException;
+use Google\ApiCore\BidiStream;
+use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\LongRunning\OperationsClient;
+use Google\ApiCore\ServerStream;
+use Google\ApiCore\Testing\GeneratedTest;
+use Google\ApiCore\Testing\MockTransport;
+use Google\LongRunning\GetOperationRequest;
+use Google\Protobuf\Any;
+use Google\Protobuf\GPBEmpty;
+use Google\Rpc\Code;
+use PHPUnit\Framework\TestCase;
+use Testing\BasicClientStreaming\BasicClientStreamingGrpcClient;
+use stdClass;
+
+/**
+ * @group basicclientstreaming
+ *
+ * @group gapic
+ */
+class BasicClientStreamingClientTest extends GeneratedTest
+{
+    /** @return TransportInterface */
+    private function createTransport($deserialize = null)
+    {
+        return new MockTransport($deserialize);
+    }
+
+    /** @return CredentialsWrapper */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /** @return BasicClientStreamingClient */
+    private function createClient(array $options = [])
+    {
+        $options += [
+            'credentials' => $this->createCredentials(),
+        ];
+        return new BasicClientStreamingClient($options);
+    }
+}

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Gapic/BasicLroGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Gapic/BasicLroGapicClient.php
@@ -61,7 +61,7 @@ use Testing\BasicLro\Request;
  *         $error = $operationResponse->getError();
  *         // handleError($error)
  *     }
- * // Alternatively:
+ *     // Alternatively:
  *     // start the operation, keep the operation name, and resume later
  *     $operationResponse = $basicLroClient->method1();
  *     $operationName = $operationResponse->getName();
@@ -239,7 +239,7 @@ class BasicLroGapicClient
      *         $error = $operationResponse->getError();
      *         // handleError($error)
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // start the operation, keep the operation name, and resume later
      *     $operationResponse = $basicLroClient->method1();
      *     $operationName = $operationResponse->getName();

--- a/tests/Unit/ProtoTests/BasicLro/out/tests/Unit/BasicLroClientTest.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/tests/Unit/BasicLroClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Testing\BasicLro\Tests\Unit;
 
 use Testing\BasicLro\BasicLroClient;
@@ -176,7 +175,7 @@ class BasicLroClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stubs are exhausted
+        // Call popReceivedCalls to ensure the stubs are exhausted
         $transport->popReceivedCalls();
         $operationsTransport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
@@ -228,9 +227,9 @@ class BasicLroClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -280,9 +279,9 @@ class BasicLroClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Gapic/BasicPaginatedGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Gapic/BasicPaginatedGapicClient.php
@@ -60,9 +60,8 @@ use Testing\BasicPaginated\Response;
  *         foreach ($page as $element) {
  *             // doSomethingWith($element);
  *         }
- *
  *     }
- * // Alternatively:
+ *     // Alternatively:
  *     // Iterate through all elements
  *     $pagedResponse = $basicPaginatedClient->methodPaginated($aField, $pageToken, $partOfRequestA);
  *     foreach ($pagedResponse->iterateAllElements() as $element) {
@@ -190,9 +189,8 @@ class BasicPaginatedGapicClient
      *         foreach ($page as $element) {
      *             // doSomethingWith($element);
      *         }
-     *
      *     }
-     * // Alternatively:
+     *     // Alternatively:
      *     // Iterate through all elements
      *     $pagedResponse = $basicPaginatedClient->methodPaginated($aField, $pageToken, $partOfRequestA);
      *     foreach ($pagedResponse->iterateAllElements() as $element) {

--- a/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/BasicPaginatedClientTest.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/BasicPaginatedClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Testing\BasicPaginated\Tests\Unit;
 
 use Testing\BasicPaginated\BasicPaginatedClient;
@@ -147,9 +146,9 @@ class BasicPaginatedClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/tests/Unit/BasicServerStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/tests/Unit/BasicServerStreamingClientTest.php
@@ -20,7 +20,6 @@
  * This file was automatically generated - do not edit!
  */
 
-
 namespace Testing\BasicServerStreaming\Tests\Unit;
 
 use Testing\BasicServerStreaming\BasicServerStreamingClient;
@@ -135,7 +134,7 @@ class BasicServerStreamingClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
@@ -201,7 +200,7 @@ class BasicServerStreamingClientTest extends GeneratedTest
             $this->assertEquals($status->code, $ex->getCode());
             $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
-// Call popReceivedCalls to ensure the stub is exhausted
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }

--- a/tests/Unit/ProtoTests/GoldenUpdateMain.php
+++ b/tests/Unit/ProtoTests/GoldenUpdateMain.php
@@ -74,7 +74,7 @@ while ($selection < 0 || $selection > sizeof(array_keys(UNIT_TESTS))) {
 if ($selection !== 0) {
     updateGolden($selection);
 } else {
-    foreach (array_keys($unitTest) as $testIndex) {
+    foreach (array_keys(UNIT_TESTS) as $testIndex) {
         updateGolden($testIndex);
         print("\n");
     }

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Gapic/GrpcServiceConfigWithRetry1GapicClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Gapic/GrpcServiceConfigWithRetry1GapicClient.php
@@ -1,1 +1,453 @@
-IGNORE
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/Unit/ProtoTests/GrpcServiceConfig/grpc-service-config1.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
+ */
+
+namespace Testing\GrpcServiceConfig\Gapic;
+
+use Google\ApiCore\ApiException;
+use Google\ApiCore\Call;
+use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\LongRunning\OperationsClient;
+use Google\ApiCore\OperationResponse;
+use Google\ApiCore\PathTemplate;
+use Google\ApiCore\RequestParamsHeaderDescriptor;
+use Google\ApiCore\RetrySettings;
+use Google\ApiCore\Transport\TransportInterface;
+use Google\ApiCore\ValidationException;
+use Google\Auth\FetchAuthTokenInterface;
+use Google\LongRunning\Operation;
+use Testing\GrpcServiceConfig\GrpcServiceConfigWithRetry1GrpcClient;
+use Testing\GrpcServiceConfig\LroMetadata;
+use Testing\GrpcServiceConfig\LroResponse;
+use Testing\GrpcServiceConfig\Request1;
+use Testing\GrpcServiceConfig\Response1;
+
+/**
+ * Service Description:
+ *
+ * This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * ```
+ * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+ * try {
+ *     $response = $grpcServiceConfigWithRetry1Client->method1A();
+ * } finally {
+ *     $grpcServiceConfigWithRetry1Client->close();
+ * }
+ * ```
+ *
+ * @experimental
+ */
+class GrpcServiceConfigWithRetry1GapicClient
+{
+    use GapicClientTrait;
+
+    /** The name of the service. */
+    const SERVICE_NAME = 'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1';
+
+    /** The default address of the service. */
+    const SERVICE_ADDRESS = 'grpcserviceconfig.example.com';
+
+    /** The default port of the service. */
+    const DEFAULT_SERVICE_PORT = 443;
+
+    /** The name of the code generator, to be included in the agent header. */
+    const CODEGEN_NAME = 'gapic';
+
+    /** The default scopes required by the service. */
+    public static $serviceScopes = [];
+
+    private $operationsClient;
+
+    private static function getClientDefaults()
+    {
+        return [
+            'serviceName' => self::SERVICE_NAME,
+            'serviceAddress' => self::SERVICE_ADDRESS . ':' . self::DEFAULT_SERVICE_PORT,
+            'clientConfig' => __DIR__ . '/../resources/grpc_service_config_with_retry1_client_config.json',
+            'descriptorsConfigPath' => __DIR__ . '/../resources/grpc_service_config_with_retry1_descriptor_config.php',
+            'gcpApiConfigPath' => __DIR__ . '/../resources/grpc_service_config_with_retry1_grpc_config.json',
+            'credentialsConfig' => [
+                'defaultScopes' => self::$serviceScopes,
+            ],
+            'transportConfig' => [
+                'rest' => [
+                    'restClientConfigPath' => __DIR__ . '/../resources/grpc_service_config_with_retry1_rest_client_config.php',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Return an OperationsClient object with the same endpoint as $this.
+     *
+     * @return OperationsClient
+     *
+     * @experimental
+     */
+    public function getOperationsClient()
+    {
+        return $this->operationsClient;
+    }
+
+    /**
+     * Resume an existing long running operation that was previously started by a long
+     * running API method. If $methodName is not provided, or does not match a long
+     * running API method, then the operation can still be resumed, but the
+     * OperationResponse object will not deserialize the final response.
+     *
+     * @param string $operationName The name of the long running operation
+     * @param string $methodName    The name of the method used to start the operation
+     *
+     * @return OperationResponse
+     *
+     * @experimental
+     */
+    public function resumeOperation($operationName, $methodName = null)
+    {
+        $options = isset($this->descriptors[$methodName]['longRunning']) ? $this->descriptors[$methodName]['longRunning'] : [];
+        $operation = new OperationResponse($operationName, $this->getOperationsClient(), $options);
+        $operation->reload();
+        return $operation;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param array $options {
+     *     Optional. Options for configuring the service API wrapper.
+     *
+     *     @type string $serviceAddress
+     *           The address of the API remote host. May optionally include the port, formatted
+     *           as "<uri>:<port>". Default 'grpcserviceconfig.example.com:443'.
+     *     @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials
+     *           The credentials to be used by the client to authorize API calls. This option
+     *           accepts either a path to a credentials file, or a decoded credentials file as a
+     *           PHP array.
+     *           *Advanced usage*: In addition, this option can also accept a pre-constructed
+     *           {@see \Google\Auth\FetchAuthTokenInterface} object or
+     *           {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these
+     *           objects are provided, any settings in $credentialsConfig will be ignored.
+     *     @type array $credentialsConfig
+     *           Options used to configure credentials, including auth token caching, for the
+     *           client. For a full list of supporting configuration options, see
+     *           {@see \Google\ApiCore\CredentialsWrapper::build()} .
+     *     @type bool $disableRetries
+     *           Determines whether or not retries defined by the client configuration should be
+     *           disabled. Defaults to `false`.
+     *     @type string|array $clientConfig
+     *           Client method configuration, including retry settings. This option can be either
+     *           a path to a JSON file, or a PHP array containing the decoded JSON data. By
+     *           default this settings points to the default client config file, which is
+     *           provided in the resources folder.
+     *     @type string|TransportInterface $transport
+     *           The transport used for executing network requests. May be either the string
+     *           `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.
+     *           *Advanced usage*: Additionally, it is possible to pass in an already
+     *           instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note
+     *           that when this object is provided, any settings in $transportConfig, and any
+     *           $serviceAddress setting, will be ignored.
+     *     @type array $transportConfig
+     *           Configuration options that will be used to construct the transport. Options for
+     *           each supported transport type should be passed in a key for that transport. For
+     *           example:
+     *           $transportConfig = [
+     *               'grpc' => [...],
+     *               'rest' => [...],
+     *           ];
+     *           See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and
+     *           {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the
+     *           supported options.
+     * }
+     *
+     * @throws ValidationException
+     *
+     * @experimental
+     */
+    public function __construct(array $options = [])
+    {
+        $clientOptions = $this->buildClientOptions($options);
+        $this->setClientOptions($clientOptions);
+        $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * try {
+     *     $response = $grpcServiceConfigWithRetry1Client->method1A();
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Testing\GrpcServiceConfig\Response1
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function method1A(array $optionalArgs = [])
+    {
+        $request = new Request1();
+        return $this->startCall('Method1A', Response1::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * try {
+     *     $operationResponse = $grpcServiceConfigWithRetry1Client->method1BLro();
+     *     $operationResponse->pollUntilComplete();
+     *     if ($operationResponse->operationSucceeded()) {
+     *         $result = $operationResponse->getResult();
+     *     // doSomethingWith($result)
+     *     } else {
+     *         $error = $operationResponse->getError();
+     *         // handleError($error)
+     *     }
+     *     // Alternatively:
+     *     // start the operation, keep the operation name, and resume later
+     *     $operationResponse = $grpcServiceConfigWithRetry1Client->method1BLro();
+     *     $operationName = $operationResponse->getName();
+     *     // ... do other work
+     *     $newOperationResponse = $grpcServiceConfigWithRetry1Client->resumeOperation($operationName, 'method1BLro');
+     *     while (!$newOperationResponse->isDone()) {
+     *         // ... do other work
+     *         $newOperationResponse->reload();
+     *     }
+     *     if ($newOperationResponse->operationSucceeded()) {
+     *         $result = $newOperationResponse->getResult();
+     *     // doSomethingWith($result)
+     *     } else {
+     *         $error = $newOperationResponse->getError();
+     *         // handleError($error)
+     *     }
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\ApiCore\OperationResponse
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function method1BLro(array $optionalArgs = [])
+    {
+        $request = new Request1();
+        return $this->startOperationsCall('Method1BLro', $optionalArgs, $request, $this->getOperationsClient())->wait();
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * try {
+     *     $response = $grpcServiceConfigWithRetry1Client->method1CServiceLevelRetry();
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Testing\GrpcServiceConfig\Response1
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function method1CServiceLevelRetry(array $optionalArgs = [])
+    {
+        $request = new Request1();
+        return $this->startCall('Method1CServiceLevelRetry', Response1::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * try {
+     *     $response = $grpcServiceConfigWithRetry1Client->method1DTimeoutOnlyRetry();
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Testing\GrpcServiceConfig\Response1
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function method1DTimeoutOnlyRetry(array $optionalArgs = [])
+    {
+        $request = new Request1();
+        return $this->startCall('Method1DTimeoutOnlyRetry', Response1::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * try {
+     *     // Read all responses until the stream is complete
+     *     $stream = $grpcServiceConfigWithRetry1Client->method1ServerStreaming();
+     *     foreach ($stream->readAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type int $timeoutMillis
+     *           Timeout to use for this call.
+     * }
+     *
+     * @return \Google\ApiCore\ServerStream
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function method1ServerStreaming(array $optionalArgs = [])
+    {
+        $request = new Request1();
+        return $this->startCall('Method1ServerStreaming', Response1::class, $optionalArgs, $request, Call::SERVER_STREAMING_CALL);
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * try {
+     *     $request = new Request1();
+     *     // Write all requests to the server, then read all responses until the
+     *     // stream is complete
+     *     $requests = [
+     *         $request,
+     *     ];
+     *     $stream = $grpcServiceConfigWithRetry1Client->method1BidiStreaming();
+     *     $stream->writeAll($requests);
+     *     foreach ($stream->closeWriteAndReadAll() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     *     // Alternatively:
+     *     // Write requests individually, making read() calls if
+     *     // required. Call closeWrite() once writes are complete, and read the
+     *     // remaining responses from the server.
+     *     $requests = [
+     *         $request,
+     *     ];
+     *     $stream = $grpcServiceConfigWithRetry1Client->method1BidiStreaming();
+     *     foreach ($requests as $request) {
+     *         $stream->write($request);
+     *         // if required, read a single response from the stream
+     *         $element = $stream->read();
+     *         // doSomethingWith($element)
+     *     }
+     *     $stream->closeWrite();
+     *     $element = $stream->read();
+     *     while (!is_null($element)) {
+     *         // doSomethingWith($element)
+     *         $element = $stream->read();
+     *     }
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type int $timeoutMillis
+     *           Timeout to use for this call.
+     * }
+     *
+     * @return \Google\ApiCore\BidiStream
+     *
+     * @throws ApiException if the remote call fails
+     *
+     * @experimental
+     */
+    public function method1BidiStreaming(array $optionalArgs = [])
+    {
+        return $this->startCall('Method1BidiStreaming', Response1::class, $optionalArgs, null, Call::BIDI_STREAMING_CALL);
+    }
+}

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/GrpcServiceConfigWithRetry1Client.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/GrpcServiceConfigWithRetry1Client.php
@@ -1,1 +1,36 @@
-IGNORE
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/tests/Unit/ProtoTests/GrpcServiceConfig/grpc-service-config1.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
+ */
+
+namespace Testing\GrpcServiceConfig;
+
+use Testing\GrpcServiceConfig\Gapic\GrpcServiceConfigWithRetry1GapicClient;
+
+/** {@inheritdoc} */
+class GrpcServiceConfigWithRetry1Client extends GrpcServiceConfigWithRetry1GapicClient
+{
+    // This class is intentionally empty, and is intended to hold manual additions to
+    // the generated {@see GrpcServiceConfigWithRetry1GapicClient} class.
+}

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_descriptor_config.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_descriptor_config.php
@@ -1,1 +1,28 @@
-IGNORE
+<?php
+
+return [
+    'interfaces' => [
+        'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1' => [
+            'Method1BLro' => [
+                'longRunning' => [
+                    'operationReturnType' => '\Testing\GrpcServiceConfig\LroResponse',
+                    'metadataReturnType' => '\Testing\GrpcServiceConfig\LroMetadata',
+                    'initialPollDelayMillis' => '500',
+                    'pollDelayMultiplier' => '1.5',
+                    'maxPollDelayMillis' => '5000',
+                    'totalPollTimeoutMillis' => '300000',
+                ],
+            ],
+            'Method1ServerStreaming' => [
+                'grpcStreaming' => [
+                    'grpcStreamingType' => 'ServerStreaming',
+                ],
+            ],
+            'Method1BidiStreaming' => [
+                'grpcStreaming' => [
+                    'grpcStreamingType' => 'BidiStreaming',
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/tests/Unit/GrpcServiceConfigWithRetry1ClientTest.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/tests/Unit/GrpcServiceConfigWithRetry1ClientTest.php
@@ -1,1 +1,493 @@
-<?php // IGNORE
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+namespace Testing\GrpcServiceConfig\Tests\Unit;
+
+use Testing\GrpcServiceConfig\GrpcServiceConfigWithRetry1Client;
+use Google\ApiCore\ApiException;
+use Google\ApiCore\BidiStream;
+use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\LongRunning\OperationsClient;
+use Google\ApiCore\ServerStream;
+use Google\ApiCore\Testing\GeneratedTest;
+use Google\ApiCore\Testing\MockTransport;
+use Google\LongRunning\GetOperationRequest;
+use Google\LongRunning\Operation;
+use Google\Protobuf\Any;
+use Google\Protobuf\GPBEmpty;
+use Google\Rpc\Code;
+use PHPUnit\Framework\TestCase;
+use Testing\GrpcServiceConfig\GrpcServiceConfigWithRetry1GrpcClient;
+use Testing\GrpcServiceConfig\LroResponse;
+use Testing\GrpcServiceConfig\Request1;
+use Testing\GrpcServiceConfig\Response1;
+use stdClass;
+
+/**
+ * @group grpcserviceconfig
+ *
+ * @group gapic
+ */
+class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
+{
+    /** @return TransportInterface */
+    private function createTransport($deserialize = null)
+    {
+        return new MockTransport($deserialize);
+    }
+
+    /** @return CredentialsWrapper */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /** @return GrpcServiceConfigWithRetry1Client */
+    private function createClient(array $options = [])
+    {
+        $options += [
+            'credentials' => $this->createCredentials(),
+        ];
+        return new GrpcServiceConfigWithRetry1Client($options);
+    }
+
+    /** @test */
+    public function method1ATest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new Response1();
+        $transport->addResponse($expectedResponse);
+        $response = $client->method1A();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.grpcserviceconfig.GrpcServiceConfigWithRetry1/Method1A', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1AExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->method1A();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1BLroTest()
+    {
+        $operationsTransport = $this->createTransport();
+        $operationsClient = new OperationsClient([
+            'serviceAddress' => '',
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
+        ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/method1BLroTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
+        $expectedResponse = new LroResponse();
+        $anyResponse = new Any();
+        $anyResponse->setValue($expectedResponse->serializeToString());
+        $completeOperation = new Operation();
+        $completeOperation->setName('operations/method1BLroTest');
+        $completeOperation->setDone(true);
+        $completeOperation->setResponse($anyResponse);
+        $operationsTransport->addResponse($completeOperation);
+        $response = $client->method1BLro();
+        $this->assertFalse($response->isDone());
+        $this->assertNull($response->getResult());
+        $apiRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($apiRequests));
+        $operationsRequestsEmpty = $operationsTransport->popReceivedCalls();
+        $this->assertSame(0, count($operationsRequestsEmpty));
+        $actualApiFuncCall = $apiRequests[0]->getFuncCall();
+        $actualApiRequestObject = $apiRequests[0]->getRequestObject();
+        $this->assertSame('/testing.grpcserviceconfig.GrpcServiceConfigWithRetry1/Method1BLro', $actualApiFuncCall);
+        $expectedOperationsRequestObject = new GetOperationRequest();
+        $expectedOperationsRequestObject->setName('operations/method1BLroTest');
+        $response->pollUntilComplete([
+            'initialPollDelayMillis' => 1,
+        ]);
+        $this->assertTrue($response->isDone());
+        $this->assertEquals($expectedResponse, $response->getResult());
+        $apiRequestsEmpty = $transport->popReceivedCalls();
+        $this->assertSame(0, count($apiRequestsEmpty));
+        $operationsRequests = $operationsTransport->popReceivedCalls();
+        $this->assertSame(1, count($operationsRequests));
+        $actualOperationsFuncCall = $operationsRequests[0]->getFuncCall();
+        $actualOperationsRequestObject = $operationsRequests[0]->getRequestObject();
+        $this->assertSame('/google.longrunning.Operations/GetOperation', $actualOperationsFuncCall);
+        $this->assertEquals($expectedOperationsRequestObject, $actualOperationsRequestObject);
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+    }
+
+    /** @test */
+    public function method1BLroExceptionTest()
+    {
+        $operationsTransport = $this->createTransport();
+        $operationsClient = new OperationsClient([
+            'serviceAddress' => '',
+            'transport' => $operationsTransport,
+            'credentials' => $this->createCredentials(),
+        ]);
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+            'operationsClient' => $operationsClient,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+        // Mock response
+        $incompleteOperation = new Operation();
+        $incompleteOperation->setName('operations/method1BLroTest');
+        $incompleteOperation->setDone(false);
+        $transport->addResponse($incompleteOperation);
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $operationsTransport->addResponse(null, $status);
+        $response = $client->method1BLro();
+        $this->assertFalse($response->isDone());
+        $this->assertNull($response->getResult());
+        $expectedOperationsRequestObject = new GetOperationRequest();
+        $expectedOperationsRequestObject->setName('operations/method1BLroTest');
+        try {
+            $response->pollUntilComplete([
+                'initialPollDelayMillis' => 1,
+            ]);
+            // If the pollUntilComplete() method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stubs are exhausted
+        $transport->popReceivedCalls();
+        $operationsTransport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+        $this->assertTrue($operationsTransport->isExhausted());
+    }
+
+    /** @test */
+    public function method1CServiceLevelRetryTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new Response1();
+        $transport->addResponse($expectedResponse);
+        $response = $client->method1CServiceLevelRetry();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.grpcserviceconfig.GrpcServiceConfigWithRetry1/Method1CServiceLevelRetry', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1CServiceLevelRetryExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->method1CServiceLevelRetry();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1DTimeoutOnlyRetryTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new Response1();
+        $transport->addResponse($expectedResponse);
+        $response = $client->method1DTimeoutOnlyRetry();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.grpcserviceconfig.GrpcServiceConfigWithRetry1/Method1DTimeoutOnlyRetry', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1DTimeoutOnlyRetryExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->method1DTimeoutOnlyRetry();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1ServerStreamingTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new Response1();
+        $transport->addResponse($expectedResponse);
+        $expectedResponse2 = new Response1();
+        $transport->addResponse($expectedResponse2);
+        $expectedResponse3 = new Response1();
+        $transport->addResponse($expectedResponse3);
+        // Mock request
+        $serverStream = $client->method1ServerStreaming();
+        $this->assertInstanceOf(ServerStream::class, $serverStream);
+        $responses = iterator_to_array($serverStream->readAll());
+        $expectedResponses = [];
+        $expectedResponses[] = $expectedResponse;
+        $expectedResponses[] = $expectedResponse2;
+        $expectedResponses[] = $expectedResponse3;
+        $this->assertEquals($expectedResponses, $responses);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.grpcserviceconfig.GrpcServiceConfigWithRetry1/Method1ServerStreaming', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1ServerStreamingExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->setStreamingStatus($status);
+        $this->assertTrue($transport->isExhausted());
+        // Mock request
+        $serverStream = $client->method1ServerStreaming();
+        $results = $serverStream->readAll();
+        try {
+            iterator_to_array($results);
+            // If the close stream method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1BidiStreamingTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new Response1();
+        $transport->addResponse($expectedResponse);
+        $expectedResponse2 = new Response1();
+        $transport->addResponse($expectedResponse2);
+        $expectedResponse3 = new Response1();
+        $transport->addResponse($expectedResponse3);
+        // Mock request
+        $request = new Request1();
+        $request2 = new Request1();
+        $request3 = new Request1();
+        $bidi = $client->method1BidiStreaming();
+        $this->assertInstanceOf(BidiStream::class, $bidi);
+        $bidi->write($request);
+        $responses = [];
+        $responses[] = $bidi->read();
+        $bidi->writeAll([
+            $request2,
+            $request3,
+        ]);
+        foreach ($bidi->closeWriteAndReadAll() as $response) {
+            $responses[] = $response;
+        }
+
+        $expectedResponses = [];
+        $expectedResponses[] = $expectedResponse;
+        $expectedResponses[] = $expectedResponse2;
+        $expectedResponses[] = $expectedResponse3;
+        $this->assertEquals($expectedResponses, $responses);
+        $createStreamRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($createStreamRequests));
+        $streamFuncCall = $createStreamRequests[0]->getFuncCall();
+        $streamRequestObject = $createStreamRequests[0]->getRequestObject();
+        $this->assertSame('/testing.grpcserviceconfig.GrpcServiceConfigWithRetry1/Method1BidiStreaming', $streamFuncCall);
+        $this->assertNull($streamRequestObject);
+        $callObjects = $transport->popCallObjects();
+        $this->assertSame(1, count($callObjects));
+        $bidiCall = $callObjects[0];
+        $writeRequests = $bidiCall->popReceivedCalls();
+        $expectedRequests = [];
+        $expectedRequests[] = $request;
+        $expectedRequests[] = $request2;
+        $expectedRequests[] = $request3;
+        $this->assertEquals($expectedRequests, $writeRequests);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function method1BidiStreamingExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->setStreamingStatus($status);
+        $this->assertTrue($transport->isExhausted());
+        $bidi = $client->method1BidiStreaming();
+        $results = $bidi->closeWriteAndReadAll();
+        try {
+            iterator_to_array($results);
+            // If the close stream method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+}


### PR DESCRIPTION
It appears that PHP-CS-Fixer treated certain blocks as though there were semicolons at the end, like the snippet below. Running the semicolon fixer after all the other fixers solved this issue.
```
@@ -116,9 +115,9 @@ class BasicClientTest extends GeneratedTest
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($expectedExceptionMessage , $ex->getMessage());
-        }
-// Call popReceivedCalls to ensure the stub is exhausted
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        };
+        // Call popReceivedCalls to ensure the stub is exhausted
         $transport->popReceivedCalls();
         $this->assertTrue($transport->isExhausted());
     }
```

CC @fiboknacky