### PR TITLE
[ggphp] fix(mono): Remove sample_code_init_fields usage from test codegen

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -159,7 +159,7 @@ class CodeGenerator
                 yield ["src/{$version}{$serviceDetails->emptyClientType->name}.php", $code];
                 // Unit tests.
                 $ctx = new SourceFileContext($serviceDetails->unitTestsType->getNamespace(), $licenseYear);
-                $file = UnitTestsGenerator::generate($ctx, $serviceDetails, $gapicYamlConfig);
+                $file = UnitTestsGenerator::generate($ctx, $serviceDetails);
                 $code = $file->toCode();
                 $code = Formatter::format($code);
                 // TODO(vNext): Remove these non-standard 'use' ordering.

--- a/src/Generation/GapicClientExamplesGenerator.php
+++ b/src/Generation/GapicClientExamplesGenerator.php
@@ -31,7 +31,7 @@ class GapicClientExamplesGenerator
         $this->gapicYamlConfig = $gapicYamlConfig;
         // Create a separate context, as this code isn't part of the generated client.
         $this->ctx = new SourceFileContext('');
-        $this->prod = new TestNameValueProducer($serviceDetails->catalog, $this->ctx, $gapicYamlConfig);
+        $this->prod = new TestNameValueProducer($serviceDetails->catalog, $this->ctx);
     }
 
     private ServiceDetails $serviceDetails;

--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -35,7 +35,6 @@ use Google\Generator\Ast\PhpFile;
 use Google\Generator\Ast\PhpMethod;
 use Google\Generator\Collections\Map;
 use Google\Generator\Collections\Vector;
-use Google\Generator\Utils\GapicYamlConfig;
 use Google\Generator\Utils\Type;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
@@ -44,14 +43,13 @@ use Google\Rpc\Code;
 
 class UnitTestsGenerator
 {
-    public static function generate(SourceFileContext $ctx, ServiceDetails $serviceDetails, GapicYamlConfig $gapicYamlConfig): PhpFile
+    public static function generate(SourceFileContext $ctx, ServiceDetails $serviceDetails): PhpFile
     {
-        return (new UnitTestsGenerator($ctx, $serviceDetails, $gapicYamlConfig))->generateImpl();
+        return (new UnitTestsGenerator($ctx, $serviceDetails))->generateImpl();
     }
 
     private SourceFileContext $ctx;
     private ServiceDetails $serviceDetails;
-    private GapicYamlConfig $gapicYamlConfig;
     private $assertTrue;
     private $assertFalse;
     private $assertEquals;
@@ -61,11 +59,10 @@ class UnitTestsGenerator
     private $assertInstanceOf;
     private $fail;
 
-    private function __construct(SourceFileContext $ctx, ServiceDetails $serviceDetails, GapicYamlConfig $gapicYamlConfig)
+    private function __construct(SourceFileContext $ctx, ServiceDetails $serviceDetails)
     {
         $this->ctx = $ctx;
         $this->serviceDetails = $serviceDetails;
-        $this->gapicYamlConfig = $gapicYamlConfig;
         $this->assertTrue = AST::call(AST::THIS, AST::method('assertTrue'));
         $this->assertFalse = AST::call(AST::THIS, AST::method('assertFalse'));
         $this->assertEquals = AST::call(AST::THIS, AST::method('assertEquals'));
@@ -208,7 +205,7 @@ class UnitTestsGenerator
 
     private function testSuccessCaseNormal(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $transport = AST::var('transport');
         $client = AST::var('client');
         $expectedResponse = AST::var('expectedResponse');
@@ -256,7 +253,7 @@ class UnitTestsGenerator
 
     private function testExceptionalCaseNormal(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $transport = AST::var('transport');
         $client = AST::var('client');
         $status = AST::var('status');
@@ -299,7 +296,7 @@ class UnitTestsGenerator
 
     private function testSuccessCaseLro(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $expectedResponse = AST::var('expectedResponse');
         $anyResponse = AST::var('anyResponse');
         $completeOperation = AST::var('completeOperation');
@@ -372,7 +369,7 @@ class UnitTestsGenerator
 
     private function testExceptionalCaseLro(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $status = AST::var('status');
         $expectedExceptionMessage = AST::var('expectedExceptionMessage');
         [$requestPerField, $requestCallArgs] = $prod->perFieldRequest($method);
@@ -453,7 +450,7 @@ class UnitTestsGenerator
 
     private function testSuccessCasePaginated(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $transport = AST::var('transport');
         $client = AST::var('client');
         $expectedResponse = AST::var('expectedResponse');
@@ -511,7 +508,7 @@ class UnitTestsGenerator
 
     private function testSuccessCaseBidiStreaming(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $transport = AST::var('transport');
         $client = AST::var('client');
         $expectedResponseList = Vector::range(1, 3)->map(fn ($i) => AST::var('expectedResponse' . ($i === 1 ? '' : $i)));
@@ -626,7 +623,7 @@ class UnitTestsGenerator
     private function testSuccessCaseServerStreaming(MethodDetails $method): PhpMethod
     {
         // TODO: Support resource-names in request args.
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $transport = AST::var('transport');
         $client = AST::var('client');
         $expectedResponseList = Vector::range(1, 3)->map(fn ($i) => AST::var('expectedResponse' . ($i === 1 ? '' : $i)));
@@ -686,7 +683,7 @@ class UnitTestsGenerator
 
     private function testExceptionalCaseServerStreaming(MethodDetails $method): PhpMethod
     {
-        $prod = new TestNameValueProducer($method->catalog, $this->ctx, $this->gapicYamlConfig);
+        $prod = new TestNameValueProducer($method->catalog, $this->ctx);
         $transport = AST::var('transport');
         $client = AST::var('client');
         $status = AST::var('status');

--- a/tests/Integration/Main.php
+++ b/tests/Integration/Main.php
@@ -146,6 +146,8 @@ $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/language/language_v1.yaml',
     'googleapis/google/cloud/language/v1/language_grpc_service_config.json'
 )) ? $ok : false;
+/*
+// Commented-out due to sample_code_init_fields usage in unit tests.
 $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/videointelligence/v1/video_intelligence.proto',
     'google.cloud.videointelligence.v1',
@@ -153,6 +155,7 @@ $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/videointelligence/v1/videointelligence_v1.yaml',
     'googleapis/google/cloud/videointelligence/v1/videointelligence_grpc_service_config.json'
 )) ? $ok : false;
+ */
 $ok = processDiff(Invoker::invoke(
     'googleapis/google/cloud/vision/v1/*.proto googleapis/google/cloud/common_resources.proto',
     'google.cloud.vision.v1',


### PR DESCRIPTION
Impacts only a small handful of APIs: `videointelligence`, `speech`, `kms`, `pubsub`, `redis`. Unit tests will differ from the monolith as follows.

```
-----
mono:
    $status->details = 'internal error';
    $expectedExceptionMessage = json_encode(['message' => 'internal error', 'code' => Code::DATA_LOSS, 'status' => 'DATA_LOSS', 'details' => []], JSON_PRETTY_PRINT);
    $operationsTransport->addResponse(null, $status);
    // Mock request
    $featuresElement = Feature::LABEL_DETECTION;
    $features = [$featuresElement];
    $inputUri = 'gs://cloud-samples-data/video/cat.mp4';
    $response = $client->annotateVideo($features, ['inputUri' => $inputUri]);
    $this->assertFalse($response->isDone());
----- 'E' -> '='
micro:
    $status->details = 'internal error';
    $expectedExceptionMessage = json_encode(['message' => 'internal error', 'code' => Code::DATA_LOSS, 'status' => 'DATA_LOSS', 'details' => []], JSON_PRETTY_PRINT);
    $operationsTransport->addResponse(null, $status);
    // Mock request
    $features = [];
    $response = $client->annotateVideo($features);
    $this->assertFalse($response->isDone());
    $this->assertNull($response->getResult());
    $expectedOperationsRequestObject = new GetOperationRequest();
-----
-----
mono:
    $completeOperation->setDone(true);
    $completeOperation->setResponse($anyResponse);
    $operationsTransport->addResponse($completeOperation);
    // Mock request
    $featuresElement = Feature::LABEL_DETECTION;
    $features = [$featuresElement];
    $inputUri = 'gs://cloud-samples-data/video/cat.mp4';
    $response = $client->annotateVideo($features, ['inputUri' => $inputUri]);
    $this->assertFalse($response->isDone());
----- 'E' -> '='
micro:
    $completeOperation->setDone(true);
    $completeOperation->setResponse($anyResponse);
    $operationsTransport->addResponse($completeOperation);
    // Mock request
    $features = [];
    $response = $client->annotateVideo($features);
    $this->assertFalse($response->isDone());
    $this->assertNull($response->getResult());
    $apiRequests = $transport->popReceivedCalls();
-----
```