### PR TITLE
[ggp] fix(client): Generate requestParams descriptor for RPCs with 2+ routing headers

### DIFF
--- a/tests/Integration/goldens/container/BUILD.bazel
+++ b/tests/Integration/goldens/container/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "goldens_files",
+    srcs = glob([
+        "*/**/*.php",
+        "*/**/*.json",
+    ]),
+)

--- a/tests/Integration/goldens/container/src/V1/ClusterManagerClient.php
+++ b/tests/Integration/goldens/container/src/V1/ClusterManagerClient.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/google/container/v1/cluster_service.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
+ */
+
+namespace Google\Cloud\Container\V1;
+
+use Google\Cloud\Container\V1\Gapic\ClusterManagerGapicClient;
+
+/** {@inheritdoc} */
+class ClusterManagerClient extends ClusterManagerGapicClient
+{
+    // This class is intentionally empty, and is intended to hold manual additions to
+    // the generated {@see ClusterManagerGapicClient} class.
+}

--- a/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
+++ b/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
@@ -1,0 +1,2570 @@
+<?php
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was generated from the file
+ * https://github.com/google/googleapis/blob/master/google/container/v1/cluster_service.proto
+ * and updates to that file get reflected here through a refresh process.
+ *
+ * @experimental
+ */
+
+namespace Google\Cloud\Container\V1\Gapic;
+
+use Google\ApiCore\ApiException;
+use Google\ApiCore\CredentialsWrapper;
+
+use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\RequestParamsHeaderDescriptor;
+use Google\ApiCore\RetrySettings;
+use Google\ApiCore\Transport\TransportInterface;
+use Google\ApiCore\ValidationException;
+use Google\Auth\FetchAuthTokenInterface;
+use Google\Cloud\Container\V1\AddonsConfig;
+use Google\Cloud\Container\V1\CancelOperationRequest;
+use Google\Cloud\Container\V1\Cluster;
+use Google\Cloud\Container\V1\ClusterUpdate;
+use Google\Cloud\Container\V1\CompleteIPRotationRequest;
+use Google\Cloud\Container\V1\CreateClusterRequest;
+use Google\Cloud\Container\V1\CreateNodePoolRequest;
+use Google\Cloud\Container\V1\DeleteClusterRequest;
+use Google\Cloud\Container\V1\DeleteNodePoolRequest;
+use Google\Cloud\Container\V1\GetClusterRequest;
+use Google\Cloud\Container\V1\GetJSONWebKeysRequest;
+use Google\Cloud\Container\V1\GetJSONWebKeysResponse;
+
+use Google\Cloud\Container\V1\GetNodePoolRequest;
+use Google\Cloud\Container\V1\GetOperationRequest;
+use Google\Cloud\Container\V1\GetServerConfigRequest;
+use Google\Cloud\Container\V1\ListClustersRequest;
+use Google\Cloud\Container\V1\ListClustersResponse;
+use Google\Cloud\Container\V1\ListNodePoolsRequest;
+use Google\Cloud\Container\V1\ListNodePoolsResponse;
+use Google\Cloud\Container\V1\ListOperationsRequest;
+use Google\Cloud\Container\V1\ListOperationsResponse;
+use Google\Cloud\Container\V1\ListUsableSubnetworksRequest;
+use Google\Cloud\Container\V1\ListUsableSubnetworksResponse;
+use Google\Cloud\Container\V1\MaintenancePolicy;
+use Google\Cloud\Container\V1\MasterAuth;
+use Google\Cloud\Container\V1\NetworkPolicy;
+use Google\Cloud\Container\V1\NodeManagement;
+use Google\Cloud\Container\V1\NodePool;
+use Google\Cloud\Container\V1\NodePool\UpgradeSettings;
+use Google\Cloud\Container\V1\NodePoolAutoscaling;
+use Google\Cloud\Container\V1\Operation;
+use Google\Cloud\Container\V1\RollbackNodePoolUpgradeRequest;
+use Google\Cloud\Container\V1\ServerConfig;
+use Google\Cloud\Container\V1\SetAddonsConfigRequest;
+use Google\Cloud\Container\V1\SetLabelsRequest;
+use Google\Cloud\Container\V1\SetLegacyAbacRequest;
+use Google\Cloud\Container\V1\SetLocationsRequest;
+use Google\Cloud\Container\V1\SetLoggingServiceRequest;
+use Google\Cloud\Container\V1\SetMaintenancePolicyRequest;
+use Google\Cloud\Container\V1\SetMasterAuthRequest;
+use Google\Cloud\Container\V1\SetMasterAuthRequest\Action;
+use Google\Cloud\Container\V1\SetMonitoringServiceRequest;
+use Google\Cloud\Container\V1\SetNetworkPolicyRequest;
+use Google\Cloud\Container\V1\SetNodePoolAutoscalingRequest;
+use Google\Cloud\Container\V1\SetNodePoolManagementRequest;
+use Google\Cloud\Container\V1\SetNodePoolSizeRequest;
+use Google\Cloud\Container\V1\StartIPRotationRequest;
+use Google\Cloud\Container\V1\UpdateClusterRequest;
+use Google\Cloud\Container\V1\UpdateMasterRequest;
+use Google\Cloud\Container\V1\UpdateNodePoolRequest;
+use Google\Cloud\Container\V1\WorkloadMetadataConfig;
+use Google\Protobuf\GPBEmpty;
+
+/**
+ * Service Description: Google Kubernetes Engine Cluster Manager v1
+ *
+ * This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * ```
+ * $clusterManagerClient = new ClusterManagerClient();
+ * try {
+ *     $clusterManagerClient->cancelOperation();
+ * } finally {
+ *     $clusterManagerClient->close();
+ * }
+ * ```
+ */
+class ClusterManagerGapicClient
+{
+    use GapicClientTrait;
+
+    /**
+     * The name of the service.
+     */
+    const SERVICE_NAME = 'google.container.v1.ClusterManager';
+
+    /**
+     * The default address of the service.
+     */
+    const SERVICE_ADDRESS = 'container.googleapis.com';
+
+    /**
+     * The default port of the service.
+     */
+    const DEFAULT_SERVICE_PORT = 443;
+
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
+    const CODEGEN_NAME = 'gapic';
+
+    /**
+     * The default scopes required by the service.
+     */
+    public static $serviceScopes = [
+        'https://www.googleapis.com/auth/cloud-platform',
+    ];
+
+    private static function getClientDefaults()
+    {
+        return [
+            'serviceName' => self::SERVICE_NAME,
+            'serviceAddress' => self::SERVICE_ADDRESS . ':' . self::DEFAULT_SERVICE_PORT,
+            'clientConfig' => __DIR__ . '/../resources/cluster_manager_client_config.json',
+            'descriptorsConfigPath' => __DIR__ . '/../resources/cluster_manager_descriptor_config.php',
+            'gcpApiConfigPath' => __DIR__ . '/../resources/cluster_manager_grpc_config.json',
+            'credentialsConfig' => [
+                'defaultScopes' => self::$serviceScopes,
+            ],
+            'transportConfig' => [
+                'rest' => [
+                    'restClientConfigPath' => __DIR__ . '/../resources/cluster_manager_rest_client_config.php',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param array $options {
+     *     Optional. Options for configuring the service API wrapper.
+     *
+     *     @type string $serviceAddress
+     *           The address of the API remote host. May optionally include the port, formatted
+     *           as "<uri>:<port>". Default 'container.googleapis.com:443'.
+     *     @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials
+     *           The credentials to be used by the client to authorize API calls. This option
+     *           accepts either a path to a credentials file, or a decoded credentials file as a
+     *           PHP array.
+     *           *Advanced usage*: In addition, this option can also accept a pre-constructed
+     *           {@see \Google\Auth\FetchAuthTokenInterface} object or
+     *           {@see \Google\ApiCore\CredentialsWrapper} object. Note that when one of these
+     *           objects are provided, any settings in $credentialsConfig will be ignored.
+     *     @type array $credentialsConfig
+     *           Options used to configure credentials, including auth token caching, for the
+     *           client. For a full list of supporting configuration options, see
+     *           {@see \Google\ApiCore\CredentialsWrapper::build()} .
+     *     @type bool $disableRetries
+     *           Determines whether or not retries defined by the client configuration should be
+     *           disabled. Defaults to `false`.
+     *     @type string|array $clientConfig
+     *           Client method configuration, including retry settings. This option can be either
+     *           a path to a JSON file, or a PHP array containing the decoded JSON data. By
+     *           default this settings points to the default client config file, which is
+     *           provided in the resources folder.
+     *     @type string|TransportInterface $transport
+     *           The transport used for executing network requests. May be either the string
+     *           `rest` or `grpc`. Defaults to `grpc` if gRPC support is detected on the system.
+     *           *Advanced usage*: Additionally, it is possible to pass in an already
+     *           instantiated {@see \Google\ApiCore\Transport\TransportInterface} object. Note
+     *           that when this object is provided, any settings in $transportConfig, and any
+     *           $serviceAddress setting, will be ignored.
+     *     @type array $transportConfig
+     *           Configuration options that will be used to construct the transport. Options for
+     *           each supported transport type should be passed in a key for that transport. For
+     *           example:
+     *           $transportConfig = [
+     *               'grpc' => [...],
+     *               'rest' => [...],
+     *           ];
+     *           See the {@see \Google\ApiCore\Transport\GrpcTransport::build()} and
+     *           {@see \Google\ApiCore\Transport\RestTransport::build()} methods for the
+     *           supported options.
+     * }
+     *
+     * @throws ValidationException
+     */
+    public function __construct(array $options = [])
+    {
+        $clientOptions = $this->buildClientOptions($options);
+        $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * Cancels the specified operation.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $clusterManagerClient->cancelOperation();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           operation resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $operationId
+     *           Deprecated. The server-assigned `name` of the operation.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, operation id) of the operation to cancel.
+     *           Specified in the format `projects/&#42;/locations/&#42;/operations/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function cancelOperation(array $optionalArgs = [])
+    {
+        $request = new CancelOperationRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['operationId'])) {
+            $request->setOperationId($optionalArgs['operationId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('CancelOperation', GPBEmpty::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Completes master IP rotation.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->completeIPRotation();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster id) of the cluster to complete IP
+     *           rotation. Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function completeIPRotation(array $optionalArgs = [])
+    {
+        $request = new CompleteIPRotationRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('CompleteIPRotation', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Creates a cluster, consisting of the specified number and type of Google
+     * Compute Engine instances.
+     *
+     * By default, the cluster is created in the project's
+     * [default
+     * network](https://cloud.google.com/compute/docs/networks-and-firewalls#networks).
+     *
+     * One firewall is added for the cluster. After cluster creation,
+     * the Kubelet creates routes for each node to allow the containers
+     * on that node to communicate with all other instances in the
+     * cluster.
+     *
+     * Finally, an entry is added to the project's global metadata indicating
+     * which CIDR range the cluster is using.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $cluster = new Cluster();
+     *     $response = $clusterManagerClient->createCluster($cluster);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param Cluster $cluster      Required. A [cluster
+     *                              resource](https://cloud.google.com/container-engine/reference/rest/v1/projects.locations.clusters)
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the parent
+     *           field.
+     *     @type string $parent
+     *           The parent (project and location) where the cluster will be created.
+     *           Specified in the format `projects/&#42;/locations/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function createCluster($cluster, array $optionalArgs = [])
+    {
+        $request = new CreateClusterRequest();
+        $request->setCluster($cluster);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('CreateCluster', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Creates a node pool for a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $nodePool = new NodePool();
+     *     $response = $clusterManagerClient->createNodePool($nodePool);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param NodePool $nodePool     Required. The node pool to create.
+     * @param array    $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the parent
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $parent
+     *           The parent (project, location, cluster id) where the node pool will be
+     *           created. Specified in the format
+     *           `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function createNodePool($nodePool, array $optionalArgs = [])
+    {
+        $request = new CreateNodePoolRequest();
+        $request->setNodePool($nodePool);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('CreateNodePool', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Deletes the cluster, including the Kubernetes endpoint and all worker
+     * nodes.
+     *
+     * Firewalls and routes that were configured during cluster creation
+     * are also deleted.
+     *
+     * Other Google Compute Engine resources that might be in use by the cluster,
+     * such as load balancer resources, are not deleted if they weren't present
+     * when the cluster was initially created.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->deleteCluster();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to delete.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to delete.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function deleteCluster(array $optionalArgs = [])
+    {
+        $request = new DeleteClusterRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('DeleteCluster', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Deletes a node pool from a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->deleteNodePool();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool to delete.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool id) of the node pool to
+     *           delete. Specified in the format
+     *           `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function deleteNodePool(array $optionalArgs = [])
+    {
+        $request = new DeleteNodePoolRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('DeleteNodePool', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Gets the details of a specific cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->getCluster();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to retrieve.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to retrieve.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Cluster
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function getCluster(array $optionalArgs = [])
+    {
+        $request = new GetClusterRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetCluster', Cluster::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Gets the public component of the cluster signing keys in
+     * JSON Web Key format.
+     * This API is not yet intended for general use, and is not available for all
+     * clusters.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->getJSONWebKeys();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $parent
+     *           The cluster (project, location, cluster id) to get keys for. Specified in
+     *           the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\GetJSONWebKeysResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function getJSONWebKeys(array $optionalArgs = [])
+    {
+        $request = new GetJSONWebKeysRequest();
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetJSONWebKeys', GetJSONWebKeysResponse::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Retrieves the requested node pool.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->getNodePool();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool id) of the node pool to
+     *           get. Specified in the format
+     *           `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\NodePool
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function getNodePool(array $optionalArgs = [])
+    {
+        $request = new GetNodePoolRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetNodePool', NodePool::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Gets the specified operation.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->getOperation();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $operationId
+     *           Deprecated. The server-assigned `name` of the operation.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, operation id) of the operation to get.
+     *           Specified in the format `projects/&#42;/locations/&#42;/operations/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function getOperation(array $optionalArgs = [])
+    {
+        $request = new GetOperationRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['operationId'])) {
+            $request->setOperationId($optionalArgs['operationId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetOperation', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Returns configuration info about the Google Kubernetes Engine service.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->getServerConfig();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) to return
+     *           operations for. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $name
+     *           The name (project and location) of the server config to get,
+     *           specified in the format `projects/&#42;/locations/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\ServerConfig
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function getServerConfig(array $optionalArgs = [])
+    {
+        $request = new GetServerConfigRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetServerConfig', ServerConfig::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Lists all clusters owned by a project in either the specified zone or all
+     * zones.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->listClusters();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides, or "-" for all zones. This field has been deprecated and
+     *           replaced by the parent field.
+     *     @type string $parent
+     *           The parent (project and location) where the clusters will be listed.
+     *           Specified in the format `projects/&#42;/locations/*`.
+     *           Location "-" matches all zones and all regions.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\ListClustersResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function listClusters(array $optionalArgs = [])
+    {
+        $request = new ListClustersRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('ListClusters', ListClustersResponse::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Lists the node pools for a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->listNodePools();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the parent
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $parent
+     *           The parent (project, location, cluster id) where the node pools will be
+     *           listed. Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\ListNodePoolsResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function listNodePools(array $optionalArgs = [])
+    {
+        $request = new ListNodePoolsRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('ListNodePools', ListNodePoolsResponse::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Lists all operations in a project in a specific zone or all zones.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->listOperations();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the parent field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) to return
+     *           operations for, or `-` for all zones. This field has been deprecated and
+     *           replaced by the parent field.
+     *     @type string $parent
+     *           The parent (project and location) where the operations will be listed.
+     *           Specified in the format `projects/&#42;/locations/*`.
+     *           Location "-" matches all zones and all regions.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\ListOperationsResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function listOperations(array $optionalArgs = [])
+    {
+        $request = new ListOperationsRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('ListOperations', ListOperationsResponse::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Lists subnetworks that are usable for creating clusters in a project.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     // Iterate over pages of elements
+     *     $pagedResponse = $clusterManagerClient->listUsableSubnetworks();
+     *     foreach ($pagedResponse->iteratePages() as $page) {
+     *         foreach ($page as $element) {
+     *             // doSomethingWith($element);
+     *         }
+     *     }
+     *     // Alternatively:
+     *     // Iterate through all elements
+     *     $pagedResponse = $clusterManagerClient->listUsableSubnetworks();
+     *     foreach ($pagedResponse->iterateAllElements() as $element) {
+     *         // doSomethingWith($element);
+     *     }
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $parent
+     *           The parent project where subnetworks are usable.
+     *           Specified in the format `projects/*`.
+     *     @type string $filter
+     *           Filtering currently only supports equality on the networkProjectId and must
+     *           be in the form: "networkProjectId=[PROJECTID]", where `networkProjectId`
+     *           is the project which owns the listed subnetworks. This defaults to the
+     *           parent project ID.
+     *     @type int $pageSize
+     *           The maximum number of resources contained in the underlying API
+     *           response. The API may return fewer values in a page, even if
+     *           there are additional values to be retrieved.
+     *     @type string $pageToken
+     *           A page token is used to specify a page of values to be returned.
+     *           If no page token is specified (the default), the first page
+     *           of values will be returned. Any page token used here must have
+     *           been generated by a previous call to the API.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\ApiCore\PagedListResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function listUsableSubnetworks(array $optionalArgs = [])
+    {
+        $request = new ListUsableSubnetworksRequest();
+        if (isset($optionalArgs['parent'])) {
+            $request->setParent($optionalArgs['parent']);
+        }
+
+        if (isset($optionalArgs['filter'])) {
+            $request->setFilter($optionalArgs['filter']);
+        }
+
+        if (isset($optionalArgs['pageSize'])) {
+            $request->setPageSize($optionalArgs['pageSize']);
+        }
+
+        if (isset($optionalArgs['pageToken'])) {
+            $request->setPageToken($optionalArgs['pageToken']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'parent' => $request->getParent(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->getPagedListResponse('ListUsableSubnetworks', $optionalArgs, ListUsableSubnetworksResponse::class, $request);
+    }
+
+    /**
+     * Rolls back a previously Aborted or Failed NodePool upgrade.
+     * This makes no changes if the last upgrade successfully completed.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->rollbackNodePoolUpgrade();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to rollback.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool to rollback.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool id) of the node poll to
+     *           rollback upgrade.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function rollbackNodePoolUpgrade(array $optionalArgs = [])
+    {
+        $request = new RollbackNodePoolUpgradeRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('RollbackNodePoolUpgrade', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the addons for a specific cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $addonsConfig = new AddonsConfig();
+     *     $response = $clusterManagerClient->setAddonsConfig($addonsConfig);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param AddonsConfig $addonsConfig Required. The desired configurations for the various addons available to run in the
+     *                                   cluster.
+     * @param array        $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to set addons.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setAddonsConfig($addonsConfig, array $optionalArgs = [])
+    {
+        $request = new SetAddonsConfigRequest();
+        $request->setAddonsConfig($addonsConfig);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetAddonsConfig', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets labels on a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $resourceLabels = [];
+     *     $labelFingerprint = 'label_fingerprint';
+     *     $response = $clusterManagerClient->setLabels($resourceLabels, $labelFingerprint);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array  $resourceLabels   Required. The labels to set for that cluster.
+     * @param string $labelFingerprint Required. The fingerprint of the previous set of labels for this resource,
+     *                                 used to detect conflicts. The fingerprint is initially generated by
+     *                                 Kubernetes Engine and changes after every request to modify or update
+     *                                 labels. You must always provide an up-to-date fingerprint hash when
+     *                                 updating or changing labels. Make a `get()` request to the
+     *                                 resource to get the latest fingerprint.
+     * @param array  $optionalArgs     {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster id) of the cluster to set labels.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setLabels($resourceLabels, $labelFingerprint, array $optionalArgs = [])
+    {
+        $request = new SetLabelsRequest();
+        $request->setResourceLabels($resourceLabels);
+        $request->setLabelFingerprint($labelFingerprint);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetLabels', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Enables or disables the ABAC authorization mechanism on a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $enabled = false;
+     *     $response = $clusterManagerClient->setLegacyAbac($enabled);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param bool  $enabled      Required. Whether ABAC authorization will be enabled in the cluster.
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to update.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster id) of the cluster to set legacy abac.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setLegacyAbac($enabled, array $optionalArgs = [])
+    {
+        $request = new SetLegacyAbacRequest();
+        $request->setEnabled($enabled);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetLegacyAbac', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the locations for a specific cluster.
+     * Deprecated. Use
+     * [projects.locations.clusters.update](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters/update)
+     * instead.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $locations = [];
+     *     $response = $clusterManagerClient->setLocations($locations);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string[] $locations    Required. The desired list of Google Compute Engine
+     *                               [zones](https://cloud.google.com/compute/docs/zones#available) in which the
+     *                               cluster's nodes should be located. Changing the locations a cluster is in
+     *                               will result in nodes being either created or removed from the cluster,
+     *                               depending on whether locations are being added or removed.
+     *
+     *                               This list must always include the cluster's primary zone.
+     * @param array    $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to set locations.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setLocations($locations, array $optionalArgs = [])
+    {
+        $request = new SetLocationsRequest();
+        $request->setLocations($locations);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetLocations', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the logging service for a specific cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $loggingService = 'logging_service';
+     *     $response = $clusterManagerClient->setLoggingService($loggingService);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string $loggingService Required. The logging service the cluster should use to write logs.
+     *                               Currently available options:
+     *
+     *                               * `logging.googleapis.com/kubernetes` - The Cloud Logging
+     *                               service with a Kubernetes-native resource model
+     *                               * `logging.googleapis.com` - The legacy Cloud Logging service (no longer
+     *                               available as of GKE 1.15).
+     *                               * `none` - no logs will be exported from the cluster.
+     *
+     *                               If left as an empty string,`logging.googleapis.com/kubernetes` will be
+     *                               used for GKE 1.14+ or `logging.googleapis.com` for earlier versions.
+     * @param array  $optionalArgs   {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to set logging.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setLoggingService($loggingService, array $optionalArgs = [])
+    {
+        $request = new SetLoggingServiceRequest();
+        $request->setLoggingService($loggingService);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetLoggingService', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the maintenance policy for a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $projectId = 'project_id';
+     *     $zone = 'zone';
+     *     $clusterId = 'cluster_id';
+     *     $maintenancePolicy = new MaintenancePolicy();
+     *     $response = $clusterManagerClient->setMaintenancePolicy($projectId, $zone, $clusterId, $maintenancePolicy);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string            $projectId         Required. The Google Developers Console [project ID or project
+     *                                             number](https://support.google.com/cloud/answer/6158840).
+     * @param string            $zone              Required. The name of the Google Compute Engine
+     *                                             [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *                                             cluster resides.
+     * @param string            $clusterId         Required. The name of the cluster to update.
+     * @param MaintenancePolicy $maintenancePolicy Required. The maintenance policy to be set for the cluster. An empty field
+     *                                             clears the existing maintenance policy.
+     * @param array             $optionalArgs      {
+     *     Optional.
+     *
+     *     @type string $name
+     *           The name (project, location, cluster id) of the cluster to set maintenance
+     *           policy.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setMaintenancePolicy($projectId, $zone, $clusterId, $maintenancePolicy, array $optionalArgs = [])
+    {
+        $request = new SetMaintenancePolicyRequest();
+        $request->setProjectId($projectId);
+        $request->setZone($zone);
+        $request->setClusterId($clusterId);
+        $request->setMaintenancePolicy($maintenancePolicy);
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetMaintenancePolicy', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets master auth materials. Currently supports changing the admin password
+     * or a specific cluster, either via password generation or explicitly setting
+     * the password.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $action = Action::UNKNOWN;
+     *     $update = new MasterAuth();
+     *     $response = $clusterManagerClient->setMasterAuth($action, $update);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param int        $action       Required. The exact form of action to be taken on the master auth.
+     *                                 For allowed values, use constants defined on {@see \Google\Cloud\Container\V1\SetMasterAuthRequest\Action}
+     * @param MasterAuth $update       Required. A description of the update.
+     * @param array      $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to set auth.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setMasterAuth($action, $update, array $optionalArgs = [])
+    {
+        $request = new SetMasterAuthRequest();
+        $request->setAction($action);
+        $request->setUpdate($update);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetMasterAuth', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the monitoring service for a specific cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $monitoringService = 'monitoring_service';
+     *     $response = $clusterManagerClient->setMonitoringService($monitoringService);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string $monitoringService Required. The monitoring service the cluster should use to write metrics.
+     *                                  Currently available options:
+     *
+     *                                  * "monitoring.googleapis.com/kubernetes" - The Cloud Monitoring
+     *                                  service with a Kubernetes-native resource model
+     *                                  * `monitoring.googleapis.com` - The legacy Cloud Monitoring service (no
+     *                                  longer available as of GKE 1.15).
+     *                                  * `none` - No metrics will be exported from the cluster.
+     *
+     *                                  If left as an empty string,`monitoring.googleapis.com/kubernetes` will be
+     *                                  used for GKE 1.14+ or `monitoring.googleapis.com` for earlier versions.
+     * @param array  $optionalArgs      {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to set monitoring.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setMonitoringService($monitoringService, array $optionalArgs = [])
+    {
+        $request = new SetMonitoringServiceRequest();
+        $request->setMonitoringService($monitoringService);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetMonitoringService', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Enables or disables Network Policy for a cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $networkPolicy = new NetworkPolicy();
+     *     $response = $clusterManagerClient->setNetworkPolicy($networkPolicy);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param NetworkPolicy $networkPolicy Required. Configuration options for the NetworkPolicy feature.
+     * @param array         $optionalArgs  {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster id) of the cluster to set networking
+     *           policy. Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setNetworkPolicy($networkPolicy, array $optionalArgs = [])
+    {
+        $request = new SetNetworkPolicyRequest();
+        $request->setNetworkPolicy($networkPolicy);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetNetworkPolicy', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the autoscaling settings for the specified node pool.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $autoscaling = new NodePoolAutoscaling();
+     *     $response = $clusterManagerClient->setNodePoolAutoscaling($autoscaling);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param NodePoolAutoscaling $autoscaling  Required. Autoscaling configuration for the node pool.
+     * @param array               $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool) of the node pool to set
+     *           autoscaler settings. Specified in the format
+     *           `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setNodePoolAutoscaling($autoscaling, array $optionalArgs = [])
+    {
+        $request = new SetNodePoolAutoscalingRequest();
+        $request->setAutoscaling($autoscaling);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetNodePoolAutoscaling', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the NodeManagement options for a node pool.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $management = new NodeManagement();
+     *     $response = $clusterManagerClient->setNodePoolManagement($management);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param NodeManagement $management   Required. NodeManagement configuration for the node pool.
+     * @param array          $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to update.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool to update.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool id) of the node pool to set
+     *           management properties. Specified in the format
+     *           `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setNodePoolManagement($management, array $optionalArgs = [])
+    {
+        $request = new SetNodePoolManagementRequest();
+        $request->setManagement($management);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetNodePoolManagement', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the size for a specific node pool.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $nodeCount = 0;
+     *     $response = $clusterManagerClient->setNodePoolSize($nodeCount);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param int   $nodeCount    Required. The desired node count for the pool.
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to update.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool to update.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool id) of the node pool to set
+     *           size.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setNodePoolSize($nodeCount, array $optionalArgs = [])
+    {
+        $request = new SetNodePoolSizeRequest();
+        $request->setNodeCount($nodeCount);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetNodePoolSize', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Starts master IP rotation.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $response = $clusterManagerClient->startIPRotation();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://developers.google.com/console/help/new/#projectnumber).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster id) of the cluster to start IP
+     *           rotation. Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type bool $rotateCredentials
+     *           Whether to rotate credentials during IP rotation.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function startIPRotation(array $optionalArgs = [])
+    {
+        $request = new StartIPRotationRequest();
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        if (isset($optionalArgs['rotateCredentials'])) {
+            $request->setRotateCredentials($optionalArgs['rotateCredentials']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('StartIPRotation', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Updates the settings of a specific cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $update = new ClusterUpdate();
+     *     $response = $clusterManagerClient->updateCluster($update);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param ClusterUpdate $update       Required. A description of the update.
+     * @param array         $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to update.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function updateCluster($update, array $optionalArgs = [])
+    {
+        $request = new UpdateClusterRequest();
+        $request->setUpdate($update);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('UpdateCluster', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Updates the master for a specific cluster.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $masterVersion = 'master_version';
+     *     $response = $clusterManagerClient->updateMaster($masterVersion);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string $masterVersion Required. The Kubernetes version to change the master to.
+     *
+     *                              Users may specify either explicit versions offered by Kubernetes Engine or
+     *                              version aliases, which have the following behavior:
+     *
+     *                              - "latest": picks the highest valid Kubernetes version
+     *                              - "1.X": picks the highest valid patch+gke.N patch in the 1.X version
+     *                              - "1.X.Y": picks the highest valid gke.N patch in the 1.X.Y version
+     *                              - "1.X.Y-gke.N": picks an explicit Kubernetes version
+     *                              - "-": picks the default Kubernetes version
+     * @param array  $optionalArgs  {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster) of the cluster to update.
+     *           Specified in the format `projects/&#42;/locations/&#42;/clusters/*`.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function updateMaster($masterVersion, array $optionalArgs = [])
+    {
+        $request = new UpdateMasterRequest();
+        $request->setMasterVersion($masterVersion);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('UpdateMaster', Operation::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Updates the version and/or image type for the specified node pool.
+     *
+     * Sample code:
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * try {
+     *     $nodeVersion = 'node_version';
+     *     $imageType = 'image_type';
+     *     $response = $clusterManagerClient->updateNodePool($nodeVersion, $imageType);
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string $nodeVersion  Required. The Kubernetes version to change the nodes to (typically an
+     *                             upgrade).
+     *
+     *                             Users may specify either explicit versions offered by Kubernetes Engine or
+     *                             version aliases, which have the following behavior:
+     *
+     *                             - "latest": picks the highest valid Kubernetes version
+     *                             - "1.X": picks the highest valid patch+gke.N patch in the 1.X version
+     *                             - "1.X.Y": picks the highest valid gke.N patch in the 1.X.Y version
+     *                             - "1.X.Y-gke.N": picks an explicit Kubernetes version
+     *                             - "-": picks the Kubernetes master version
+     * @param string $imageType    Required. The desired image type for the node pool.
+     * @param array  $optionalArgs {
+     *     Optional.
+     *
+     *     @type string $projectId
+     *           Deprecated. The Google Developers Console [project ID or project
+     *           number](https://support.google.com/cloud/answer/6158840).
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $zone
+     *           Deprecated. The name of the Google Compute Engine
+     *           [zone](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           cluster resides. This field has been deprecated and replaced by the name
+     *           field.
+     *     @type string $clusterId
+     *           Deprecated. The name of the cluster to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $nodePoolId
+     *           Deprecated. The name of the node pool to upgrade.
+     *           This field has been deprecated and replaced by the name field.
+     *     @type string $name
+     *           The name (project, location, cluster, node pool) of the node pool to
+     *           update. Specified in the format
+     *           `projects/&#42;/locations/&#42;/clusters/&#42;/nodePools/*`.
+     *     @type string[] $locations
+     *           The desired list of Google Compute Engine
+     *           [zones](https://cloud.google.com/compute/docs/zones#available) in which the
+     *           node pool's nodes should be located. Changing the locations for a node pool
+     *           will result in nodes being either created or removed from the node pool,
+     *           depending on whether locations are being added or removed.
+     *     @type WorkloadMetadataConfig $workloadMetadataConfig
+     *           The desired workload metadata config for the node pool.
+     *     @type UpgradeSettings $upgradeSettings
+     *           Upgrade settings control disruption and speed of the upgrade.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Container\V1\Operation
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function updateNodePool($nodeVersion, $imageType, array $optionalArgs = [])
+    {
+        $request = new UpdateNodePoolRequest();
+        $request->setNodeVersion($nodeVersion);
+        $request->setImageType($imageType);
+        if (isset($optionalArgs['projectId'])) {
+            $request->setProjectId($optionalArgs['projectId']);
+        }
+
+        if (isset($optionalArgs['zone'])) {
+            $request->setZone($optionalArgs['zone']);
+        }
+
+        if (isset($optionalArgs['clusterId'])) {
+            $request->setClusterId($optionalArgs['clusterId']);
+        }
+
+        if (isset($optionalArgs['nodePoolId'])) {
+            $request->setNodePoolId($optionalArgs['nodePoolId']);
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+        }
+
+        if (isset($optionalArgs['locations'])) {
+            $request->setLocations($optionalArgs['locations']);
+        }
+
+        if (isset($optionalArgs['workloadMetadataConfig'])) {
+            $request->setWorkloadMetadataConfig($optionalArgs['workloadMetadataConfig']);
+        }
+
+        if (isset($optionalArgs['upgradeSettings'])) {
+            $request->setUpgradeSettings($optionalArgs['upgradeSettings']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor([
+            'name' => $request->getName(),
+        ]);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('UpdateNodePool', Operation::class, $optionalArgs, $request)->wait();
+    }
+}

--- a/tests/Integration/goldens/container/src/V1/gapic_metadata.json
+++ b/tests/Integration/goldens/container/src/V1/gapic_metadata.json
@@ -1,0 +1,178 @@
+{
+    "schema": "1.0",
+    "comment": "This file maps proto services\/RPCs to the corresponding library clients\/methods",
+    "language": "php",
+    "protoPackage": "google.container.v1",
+    "libraryPackage": "Google\\Cloud\\Container\\V1",
+    "services": {
+        "ClusterManager": {
+            "clients": {
+                "grpc": {
+                    "libraryClient": "ClusterManagerGapicClient",
+                    "rpcs": {
+                        "CancelOperation": {
+                            "methods": [
+                                "cancelOperation"
+                            ]
+                        },
+                        "CompleteIPRotation": {
+                            "methods": [
+                                "completeIPRotation"
+                            ]
+                        },
+                        "CreateCluster": {
+                            "methods": [
+                                "createCluster"
+                            ]
+                        },
+                        "CreateNodePool": {
+                            "methods": [
+                                "createNodePool"
+                            ]
+                        },
+                        "DeleteCluster": {
+                            "methods": [
+                                "deleteCluster"
+                            ]
+                        },
+                        "DeleteNodePool": {
+                            "methods": [
+                                "deleteNodePool"
+                            ]
+                        },
+                        "GetCluster": {
+                            "methods": [
+                                "getCluster"
+                            ]
+                        },
+                        "GetJSONWebKeys": {
+                            "methods": [
+                                "getJSONWebKeys"
+                            ]
+                        },
+                        "GetNodePool": {
+                            "methods": [
+                                "getNodePool"
+                            ]
+                        },
+                        "GetOperation": {
+                            "methods": [
+                                "getOperation"
+                            ]
+                        },
+                        "GetServerConfig": {
+                            "methods": [
+                                "getServerConfig"
+                            ]
+                        },
+                        "ListClusters": {
+                            "methods": [
+                                "listClusters"
+                            ]
+                        },
+                        "ListNodePools": {
+                            "methods": [
+                                "listNodePools"
+                            ]
+                        },
+                        "ListOperations": {
+                            "methods": [
+                                "listOperations"
+                            ]
+                        },
+                        "ListUsableSubnetworks": {
+                            "methods": [
+                                "listUsableSubnetworks"
+                            ]
+                        },
+                        "RollbackNodePoolUpgrade": {
+                            "methods": [
+                                "rollbackNodePoolUpgrade"
+                            ]
+                        },
+                        "SetAddonsConfig": {
+                            "methods": [
+                                "setAddonsConfig"
+                            ]
+                        },
+                        "SetLabels": {
+                            "methods": [
+                                "setLabels"
+                            ]
+                        },
+                        "SetLegacyAbac": {
+                            "methods": [
+                                "setLegacyAbac"
+                            ]
+                        },
+                        "SetLocations": {
+                            "methods": [
+                                "setLocations"
+                            ]
+                        },
+                        "SetLoggingService": {
+                            "methods": [
+                                "setLoggingService"
+                            ]
+                        },
+                        "SetMaintenancePolicy": {
+                            "methods": [
+                                "setMaintenancePolicy"
+                            ]
+                        },
+                        "SetMasterAuth": {
+                            "methods": [
+                                "setMasterAuth"
+                            ]
+                        },
+                        "SetMonitoringService": {
+                            "methods": [
+                                "setMonitoringService"
+                            ]
+                        },
+                        "SetNetworkPolicy": {
+                            "methods": [
+                                "setNetworkPolicy"
+                            ]
+                        },
+                        "SetNodePoolAutoscaling": {
+                            "methods": [
+                                "setNodePoolAutoscaling"
+                            ]
+                        },
+                        "SetNodePoolManagement": {
+                            "methods": [
+                                "setNodePoolManagement"
+                            ]
+                        },
+                        "SetNodePoolSize": {
+                            "methods": [
+                                "setNodePoolSize"
+                            ]
+                        },
+                        "StartIPRotation": {
+                            "methods": [
+                                "startIPRotation"
+                            ]
+                        },
+                        "UpdateCluster": {
+                            "methods": [
+                                "updateCluster"
+                            ]
+                        },
+                        "UpdateMaster": {
+                            "methods": [
+                                "updateMaster"
+                            ]
+                        },
+                        "UpdateNodePool": {
+                            "methods": [
+                                "updateNodePool"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Integration/goldens/container/src/V1/resources/cluster_manager_client_config.json
+++ b/tests/Integration/goldens/container/src/V1/resources/cluster_manager_client_config.json
@@ -1,0 +1,205 @@
+{
+    "interfaces": {
+        "google.container.v1.ClusterManager": {
+            "retry_codes": {
+                "no_retry_codes": [],
+                "retry_policy_1_codes": [
+                    "UNAVAILABLE",
+                    "DEADLINE_EXCEEDED"
+                ],
+                "no_retry_1_codes": []
+            },
+            "retry_params": {
+                "no_retry_params": {
+                    "initial_retry_delay_millis": 0,
+                    "retry_delay_multiplier": 0.0,
+                    "max_retry_delay_millis": 0,
+                    "initial_rpc_timeout_millis": 0,
+                    "rpc_timeout_multiplier": 1.0,
+                    "max_rpc_timeout_millis": 0,
+                    "total_timeout_millis": 0
+                },
+                "retry_policy_1_params": {
+                    "initial_retry_delay_millis": 100,
+                    "retry_delay_multiplier": 1.3,
+                    "max_retry_delay_millis": 60000,
+                    "initial_rpc_timeout_millis": 20000,
+                    "rpc_timeout_multiplier": 1.0,
+                    "max_rpc_timeout_millis": 20000,
+                    "total_timeout_millis": 20000
+                },
+                "no_retry_1_params": {
+                    "initial_retry_delay_millis": 0,
+                    "retry_delay_multiplier": 0.0,
+                    "max_retry_delay_millis": 0,
+                    "initial_rpc_timeout_millis": 45000,
+                    "rpc_timeout_multiplier": 1.0,
+                    "max_rpc_timeout_millis": 45000,
+                    "total_timeout_millis": 45000
+                }
+            },
+            "methods": {
+                "CancelOperation": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "CompleteIPRotation": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "CreateCluster": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "CreateNodePool": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "DeleteCluster": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "DeleteNodePool": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "GetCluster": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "GetJSONWebKeys": {
+                    "timeout_millis": 60000,
+                    "retry_codes_name": "no_retry_codes",
+                    "retry_params_name": "no_retry_params"
+                },
+                "GetNodePool": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "GetOperation": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "GetServerConfig": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "ListClusters": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "ListNodePools": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "ListOperations": {
+                    "timeout_millis": 20000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "ListUsableSubnetworks": {
+                    "timeout_millis": 60000,
+                    "retry_codes_name": "no_retry_codes",
+                    "retry_params_name": "no_retry_params"
+                },
+                "RollbackNodePoolUpgrade": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetAddonsConfig": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetLabels": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetLegacyAbac": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetLocations": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetLoggingService": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetMaintenancePolicy": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetMasterAuth": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetMonitoringService": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetNetworkPolicy": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetNodePoolAutoscaling": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetNodePoolManagement": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "SetNodePoolSize": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "StartIPRotation": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "UpdateCluster": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "UpdateMaster": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                },
+                "UpdateNodePool": {
+                    "timeout_millis": 45000,
+                    "retry_codes_name": "no_retry_1_codes",
+                    "retry_params_name": "no_retry_1_params"
+                }
+            }
+        }
+    }
+}

--- a/tests/Integration/goldens/container/src/V1/resources/cluster_manager_descriptor_config.php
+++ b/tests/Integration/goldens/container/src/V1/resources/cluster_manager_descriptor_config.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'interfaces' => [
+        'google.container.v1.ClusterManager' => [
+            'ListUsableSubnetworks' => [
+                'pageStreaming' => [
+                    'requestPageTokenGetMethod' => 'getPageToken',
+                    'requestPageTokenSetMethod' => 'setPageToken',
+                    'requestPageSizeGetMethod' => 'getPageSize',
+                    'requestPageSizeSetMethod' => 'setPageSize',
+                    'responsePageTokenGetMethod' => 'getNextPageToken',
+                    'resourcesGetMethod' => 'getSubnetworks',
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/Integration/goldens/container/src/V1/resources/cluster_manager_rest_client_config.php
+++ b/tests/Integration/goldens/container/src/V1/resources/cluster_manager_rest_client_config.php
@@ -1,0 +1,1047 @@
+<?php
+
+return [
+    'interfaces' => [
+        'google.container.v1.ClusterManager' => [
+            'CancelOperation' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/operations/*}:cancel',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/operations/{operation_id}:cancel',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'operation_id' => [
+                        'getters' => [
+                            'getOperationId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'CompleteIPRotation' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:completeIpRotation',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:completeIpRotation',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'CreateCluster' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*}/clusters',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'CreateNodePool' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*/clusters/*}/nodePools',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'DeleteCluster' => [
+                'method' => 'delete',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'delete',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'DeleteNodePool' => [
+                'method' => 'delete',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'delete',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'GetCluster' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'GetJSONWebKeys' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*/clusters/*}/jwks',
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                ],
+            ],
+            'GetNodePool' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'GetOperation' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/operations/*}',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/operations/{operation_id}',
+                    ],
+                ],
+                'placeholders' => [
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'operation_id' => [
+                        'getters' => [
+                            'getOperationId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'GetServerConfig' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*}/serverConfig',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/serverconfig',
+                    ],
+                ],
+                'placeholders' => [
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'ListClusters' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*}/clusters',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters',
+                    ],
+                ],
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'ListNodePools' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*/clusters/*}/nodePools',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'ListOperations' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{parent=projects/*/locations/*}/operations',
+                'additionalBindings' => [
+                    [
+                        'method' => 'get',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/operations',
+                    ],
+                ],
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'ListUsableSubnetworks' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/{parent=projects/*}/aggregated/usableSubnetworks',
+                'placeholders' => [
+                    'parent' => [
+                        'getters' => [
+                            'getParent',
+                        ],
+                    ],
+                ],
+            ],
+            'RollbackNodePoolUpgrade' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}:rollback',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}:rollback',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetAddonsConfig' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setAddons',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/addons',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetLabels' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setResourceLabels',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/resourceLabels',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetLegacyAbac' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setLegacyAbac',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/legacyAbac',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetLocations' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setLocations',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/locations',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetLoggingService' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setLogging',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/logging',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetMaintenancePolicy' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setMaintenancePolicy',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:setMaintenancePolicy',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetMasterAuth' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setMasterAuth',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:setMasterAuth',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetMonitoringService' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setMonitoring',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/monitoring',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetNetworkPolicy' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:setNetworkPolicy',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:setNetworkPolicy',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetNodePoolAutoscaling' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}:setAutoscaling',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/autoscaling',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetNodePoolManagement' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}:setManagement',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/setManagement',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'SetNodePoolSize' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}:setSize',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/setSize',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'StartIPRotation' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:startIpRotation',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}:startIpRotation',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'UpdateCluster' => [
+                'method' => 'put',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'put',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'UpdateMaster' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*}:updateMaster',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/master',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+            'UpdateNodePool' => [
+                'method' => 'put',
+                'uriTemplate' => '/v1/{name=projects/*/locations/*/clusters/*/nodePools/*}',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/projects/{project_id}/zones/{zone}/clusters/{cluster_id}/nodePools/{node_pool_id}/update',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'cluster_id' => [
+                        'getters' => [
+                            'getClusterId',
+                        ],
+                    ],
+                    'name' => [
+                        'getters' => [
+                            'getName',
+                        ],
+                    ],
+                    'node_pool_id' => [
+                        'getters' => [
+                            'getNodePoolId',
+                        ],
+                    ],
+                    'project_id' => [
+                        'getters' => [
+                            'getProjectId',
+                        ],
+                    ],
+                    'zone' => [
+                        'getters' => [
+                            'getZone',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
+++ b/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
@@ -1,0 +1,2494 @@
+<?php
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+namespace Google\Cloud\Container\Tests\Unit\V1;
+
+use Google\ApiCore\ApiException;
+
+use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\Testing\GeneratedTest;
+use Google\ApiCore\Testing\MockTransport;
+
+use Google\Cloud\Container\V1\AddonsConfig;
+use Google\Cloud\Container\V1\Cluster;
+use Google\Cloud\Container\V1\ClusterManagerClient;
+use Google\Cloud\Container\V1\ClusterUpdate;
+use Google\Cloud\Container\V1\GetJSONWebKeysResponse;
+use Google\Cloud\Container\V1\ListClustersResponse;
+use Google\Cloud\Container\V1\ListNodePoolsResponse;
+use Google\Cloud\Container\V1\ListOperationsResponse;
+use Google\Cloud\Container\V1\ListUsableSubnetworksResponse;
+use Google\Cloud\Container\V1\MaintenancePolicy;
+use Google\Cloud\Container\V1\MasterAuth;
+use Google\Cloud\Container\V1\NetworkPolicy;
+use Google\Cloud\Container\V1\NodeManagement;
+use Google\Cloud\Container\V1\NodePool;
+use Google\Cloud\Container\V1\NodePoolAutoscaling;
+use Google\Cloud\Container\V1\Operation;
+use Google\Cloud\Container\V1\ServerConfig;
+use Google\Cloud\Container\V1\SetMasterAuthRequest\Action;
+use Google\Cloud\Container\V1\UsableSubnetwork;
+use Google\Protobuf\GPBEmpty;
+use Google\Rpc\Code;
+use stdClass;
+
+/**
+ * @group container
+ *
+ * @group gapic
+ */
+class ClusterManagerClientTest extends GeneratedTest
+{
+    /**
+     * @return TransportInterface
+     */
+    private function createTransport($deserialize = null)
+    {
+        return new MockTransport($deserialize);
+    }
+
+    /**
+     * @return CredentialsWrapper
+     */
+    private function createCredentials()
+    {
+        return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
+    }
+
+    /**
+     * @return ClusterManagerClient
+     */
+    private function createClient(array $options = [])
+    {
+        $options += [
+            'credentials' => $this->createCredentials(),
+        ];
+        return new ClusterManagerClient($options);
+    }
+
+    /**
+     * @test
+     */
+    public function cancelOperationTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new GPBEmpty();
+        $transport->addResponse($expectedResponse);
+        $client->cancelOperation();
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/CancelOperation', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function cancelOperationExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->cancelOperation();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function completeIPRotationTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        $response = $client->completeIPRotation();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/CompleteIPRotation', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function completeIPRotationExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->completeIPRotation();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createClusterTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $cluster = new Cluster();
+        $response = $client->createCluster($cluster);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/CreateCluster', $actualFuncCall);
+        $actualValue = $actualRequestObject->getCluster();
+        $this->assertProtobufEquals($cluster, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createClusterExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $cluster = new Cluster();
+        try {
+            $client->createCluster($cluster);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createNodePoolTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $nodePool = new NodePool();
+        $response = $client->createNodePool($nodePool);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/CreateNodePool', $actualFuncCall);
+        $actualValue = $actualRequestObject->getNodePool();
+        $this->assertProtobufEquals($nodePool, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function createNodePoolExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $nodePool = new NodePool();
+        try {
+            $client->createNodePool($nodePool);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteClusterTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        $response = $client->deleteCluster();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/DeleteCluster', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteClusterExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->deleteCluster();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteNodePoolTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        $response = $client->deleteNodePool();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/DeleteNodePool', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function deleteNodePoolExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->deleteNodePool();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getClusterTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $description = 'description-1724546052';
+        $initialNodeCount = 1682564205;
+        $loggingService = 'loggingService-1700501035';
+        $monitoringService = 'monitoringService1469270462';
+        $network = 'network1843485230';
+        $clusterIpv4Cidr = 'clusterIpv4Cidr-141875831';
+        $subnetwork = 'subnetwork-1302785042';
+        $enableKubernetesAlpha = false;
+        $labelFingerprint = 'labelFingerprint714995737';
+        $selfLink = 'selfLink-1691268851';
+        $zone = 'zone3744684';
+        $endpoint = 'endpoint1741102485';
+        $initialClusterVersion = 'initialClusterVersion-276373352';
+        $currentMasterVersion = 'currentMasterVersion-920953983';
+        $currentNodeVersion = 'currentNodeVersion-407476063';
+        $createTime = 'createTime-493574096';
+        $statusMessage = 'statusMessage-239442758';
+        $nodeIpv4CidrSize = 1181176815;
+        $servicesIpv4Cidr = 'servicesIpv4Cidr1966438125';
+        $currentNodeCount = 178977560;
+        $expireTime = 'expireTime-96179731';
+        $location = 'location1901043637';
+        $enableTpu = false;
+        $tpuIpv4CidrBlock = 'tpuIpv4CidrBlock1137906646';
+        $expectedResponse = new Cluster();
+        $expectedResponse->setName($name);
+        $expectedResponse->setDescription($description);
+        $expectedResponse->setInitialNodeCount($initialNodeCount);
+        $expectedResponse->setLoggingService($loggingService);
+        $expectedResponse->setMonitoringService($monitoringService);
+        $expectedResponse->setNetwork($network);
+        $expectedResponse->setClusterIpv4Cidr($clusterIpv4Cidr);
+        $expectedResponse->setSubnetwork($subnetwork);
+        $expectedResponse->setEnableKubernetesAlpha($enableKubernetesAlpha);
+        $expectedResponse->setLabelFingerprint($labelFingerprint);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setEndpoint($endpoint);
+        $expectedResponse->setInitialClusterVersion($initialClusterVersion);
+        $expectedResponse->setCurrentMasterVersion($currentMasterVersion);
+        $expectedResponse->setCurrentNodeVersion($currentNodeVersion);
+        $expectedResponse->setCreateTime($createTime);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setNodeIpv4CidrSize($nodeIpv4CidrSize);
+        $expectedResponse->setServicesIpv4Cidr($servicesIpv4Cidr);
+        $expectedResponse->setCurrentNodeCount($currentNodeCount);
+        $expectedResponse->setExpireTime($expireTime);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setEnableTpu($enableTpu);
+        $expectedResponse->setTpuIpv4CidrBlock($tpuIpv4CidrBlock);
+        $transport->addResponse($expectedResponse);
+        $response = $client->getCluster();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/GetCluster', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getClusterExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->getCluster();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getJSONWebKeysTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new GetJSONWebKeysResponse();
+        $transport->addResponse($expectedResponse);
+        $response = $client->getJSONWebKeys();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/GetJSONWebKeys', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getJSONWebKeysExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->getJSONWebKeys();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNodePoolTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $initialNodeCount = 1682564205;
+        $selfLink = 'selfLink-1691268851';
+        $version = 'version351608024';
+        $statusMessage = 'statusMessage-239442758';
+        $podIpv4CidrSize = 1098768716;
+        $expectedResponse = new NodePool();
+        $expectedResponse->setName($name);
+        $expectedResponse->setInitialNodeCount($initialNodeCount);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setVersion($version);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setPodIpv4CidrSize($podIpv4CidrSize);
+        $transport->addResponse($expectedResponse);
+        $response = $client->getNodePool();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/GetNodePool', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getNodePoolExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->getNodePool();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getOperationTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        $response = $client->getOperation();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/GetOperation', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getOperationExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->getOperation();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getServerConfigTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $defaultClusterVersion = 'defaultClusterVersion111003029';
+        $defaultImageType = 'defaultImageType-918225828';
+        $expectedResponse = new ServerConfig();
+        $expectedResponse->setDefaultClusterVersion($defaultClusterVersion);
+        $expectedResponse->setDefaultImageType($defaultImageType);
+        $transport->addResponse($expectedResponse);
+        $response = $client->getServerConfig();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/GetServerConfig', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function getServerConfigExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->getServerConfig();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listClustersTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new ListClustersResponse();
+        $transport->addResponse($expectedResponse);
+        $response = $client->listClusters();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/ListClusters', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listClustersExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->listClusters();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listNodePoolsTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new ListNodePoolsResponse();
+        $transport->addResponse($expectedResponse);
+        $response = $client->listNodePools();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/ListNodePools', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listNodePoolsExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->listNodePools();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listOperationsTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new ListOperationsResponse();
+        $transport->addResponse($expectedResponse);
+        $response = $client->listOperations();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/ListOperations', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listOperationsExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->listOperations();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listUsableSubnetworksTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $nextPageToken = '';
+        $subnetworksElement = new UsableSubnetwork();
+        $subnetworks = [
+            $subnetworksElement,
+        ];
+        $expectedResponse = new ListUsableSubnetworksResponse();
+        $expectedResponse->setNextPageToken($nextPageToken);
+        $expectedResponse->setSubnetworks($subnetworks);
+        $transport->addResponse($expectedResponse);
+        $response = $client->listUsableSubnetworks();
+        $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
+        $resources = iterator_to_array($response->iterateAllElements());
+        $this->assertSame(1, count($resources));
+        $this->assertEquals($expectedResponse->getSubnetworks()[0], $resources[0]);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/ListUsableSubnetworks', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function listUsableSubnetworksExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->listUsableSubnetworks();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function rollbackNodePoolUpgradeTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        $response = $client->rollbackNodePoolUpgrade();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/RollbackNodePoolUpgrade', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function rollbackNodePoolUpgradeExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->rollbackNodePoolUpgrade();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setAddonsConfigTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $addonsConfig = new AddonsConfig();
+        $response = $client->setAddonsConfig($addonsConfig);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetAddonsConfig', $actualFuncCall);
+        $actualValue = $actualRequestObject->getAddonsConfig();
+        $this->assertProtobufEquals($addonsConfig, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setAddonsConfigExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $addonsConfig = new AddonsConfig();
+        try {
+            $client->setAddonsConfig($addonsConfig);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLabelsTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $resourceLabels = [];
+        $labelFingerprint = 'labelFingerprint714995737';
+        $response = $client->setLabels($resourceLabels, $labelFingerprint);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetLabels', $actualFuncCall);
+        $actualValue = $actualRequestObject->getResourceLabels();
+        $this->assertProtobufEquals($resourceLabels, $actualValue);
+        $actualValue = $actualRequestObject->getLabelFingerprint();
+        $this->assertProtobufEquals($labelFingerprint, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLabelsExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $resourceLabels = [];
+        $labelFingerprint = 'labelFingerprint714995737';
+        try {
+            $client->setLabels($resourceLabels, $labelFingerprint);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLegacyAbacTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $enabled = false;
+        $response = $client->setLegacyAbac($enabled);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetLegacyAbac', $actualFuncCall);
+        $actualValue = $actualRequestObject->getEnabled();
+        $this->assertProtobufEquals($enabled, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLegacyAbacExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $enabled = false;
+        try {
+            $client->setLegacyAbac($enabled);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLocationsTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $locations = [];
+        $response = $client->setLocations($locations);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetLocations', $actualFuncCall);
+        $actualValue = $actualRequestObject->getLocations();
+        $this->assertProtobufEquals($locations, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLocationsExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $locations = [];
+        try {
+            $client->setLocations($locations);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLoggingServiceTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $loggingService = 'loggingService-1700501035';
+        $response = $client->setLoggingService($loggingService);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetLoggingService', $actualFuncCall);
+        $actualValue = $actualRequestObject->getLoggingService();
+        $this->assertProtobufEquals($loggingService, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setLoggingServiceExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $loggingService = 'loggingService-1700501035';
+        try {
+            $client->setLoggingService($loggingService);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setMaintenancePolicyTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone2 = 'zone2-696322977';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone2);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $projectId = 'projectId-1969970175';
+        $zone = 'zone3744684';
+        $clusterId = 'clusterId240280960';
+        $maintenancePolicy = new MaintenancePolicy();
+        $response = $client->setMaintenancePolicy($projectId, $zone, $clusterId, $maintenancePolicy);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetMaintenancePolicy', $actualFuncCall);
+        $actualValue = $actualRequestObject->getProjectId();
+        $this->assertProtobufEquals($projectId, $actualValue);
+        $actualValue = $actualRequestObject->getZone();
+        $this->assertProtobufEquals($zone, $actualValue);
+        $actualValue = $actualRequestObject->getClusterId();
+        $this->assertProtobufEquals($clusterId, $actualValue);
+        $actualValue = $actualRequestObject->getMaintenancePolicy();
+        $this->assertProtobufEquals($maintenancePolicy, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setMaintenancePolicyExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $projectId = 'projectId-1969970175';
+        $zone = 'zone3744684';
+        $clusterId = 'clusterId240280960';
+        $maintenancePolicy = new MaintenancePolicy();
+        try {
+            $client->setMaintenancePolicy($projectId, $zone, $clusterId, $maintenancePolicy);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setMasterAuthTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $action = Action::UNKNOWN;
+        $update = new MasterAuth();
+        $response = $client->setMasterAuth($action, $update);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetMasterAuth', $actualFuncCall);
+        $actualValue = $actualRequestObject->getAction();
+        $this->assertProtobufEquals($action, $actualValue);
+        $actualValue = $actualRequestObject->getUpdate();
+        $this->assertProtobufEquals($update, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setMasterAuthExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $action = Action::UNKNOWN;
+        $update = new MasterAuth();
+        try {
+            $client->setMasterAuth($action, $update);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setMonitoringServiceTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $monitoringService = 'monitoringService1469270462';
+        $response = $client->setMonitoringService($monitoringService);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetMonitoringService', $actualFuncCall);
+        $actualValue = $actualRequestObject->getMonitoringService();
+        $this->assertProtobufEquals($monitoringService, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setMonitoringServiceExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $monitoringService = 'monitoringService1469270462';
+        try {
+            $client->setMonitoringService($monitoringService);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNetworkPolicyTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $networkPolicy = new NetworkPolicy();
+        $response = $client->setNetworkPolicy($networkPolicy);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetNetworkPolicy', $actualFuncCall);
+        $actualValue = $actualRequestObject->getNetworkPolicy();
+        $this->assertProtobufEquals($networkPolicy, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNetworkPolicyExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $networkPolicy = new NetworkPolicy();
+        try {
+            $client->setNetworkPolicy($networkPolicy);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNodePoolAutoscalingTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $autoscaling = new NodePoolAutoscaling();
+        $response = $client->setNodePoolAutoscaling($autoscaling);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetNodePoolAutoscaling', $actualFuncCall);
+        $actualValue = $actualRequestObject->getAutoscaling();
+        $this->assertProtobufEquals($autoscaling, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNodePoolAutoscalingExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $autoscaling = new NodePoolAutoscaling();
+        try {
+            $client->setNodePoolAutoscaling($autoscaling);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNodePoolManagementTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $management = new NodeManagement();
+        $response = $client->setNodePoolManagement($management);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetNodePoolManagement', $actualFuncCall);
+        $actualValue = $actualRequestObject->getManagement();
+        $this->assertProtobufEquals($management, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNodePoolManagementExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $management = new NodeManagement();
+        try {
+            $client->setNodePoolManagement($management);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNodePoolSizeTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $nodeCount = 1539922066;
+        $response = $client->setNodePoolSize($nodeCount);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/SetNodePoolSize', $actualFuncCall);
+        $actualValue = $actualRequestObject->getNodeCount();
+        $this->assertProtobufEquals($nodeCount, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function setNodePoolSizeExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $nodeCount = 1539922066;
+        try {
+            $client->setNodePoolSize($nodeCount);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function startIPRotationTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        $response = $client->startIPRotation();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/StartIPRotation', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function startIPRotationExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $client->startIPRotation();
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function updateClusterTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $update = new ClusterUpdate();
+        $response = $client->updateCluster($update);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/UpdateCluster', $actualFuncCall);
+        $actualValue = $actualRequestObject->getUpdate();
+        $this->assertProtobufEquals($update, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function updateClusterExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $update = new ClusterUpdate();
+        try {
+            $client->updateCluster($update);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function updateMasterTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $masterVersion = 'masterVersion-2139460613';
+        $response = $client->updateMaster($masterVersion);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/UpdateMaster', $actualFuncCall);
+        $actualValue = $actualRequestObject->getMasterVersion();
+        $this->assertProtobufEquals($masterVersion, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function updateMasterExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $masterVersion = 'masterVersion-2139460613';
+        try {
+            $client->updateMaster($masterVersion);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function updateNodePoolTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $name = 'name3373707';
+        $zone = 'zone3744684';
+        $detail = 'detail-1335224239';
+        $statusMessage = 'statusMessage-239442758';
+        $selfLink = 'selfLink-1691268851';
+        $targetLink = 'targetLink-2084812312';
+        $location = 'location1901043637';
+        $startTime = 'startTime-1573145462';
+        $endTime = 'endTime1725551537';
+        $expectedResponse = new Operation();
+        $expectedResponse->setName($name);
+        $expectedResponse->setZone($zone);
+        $expectedResponse->setDetail($detail);
+        $expectedResponse->setStatusMessage($statusMessage);
+        $expectedResponse->setSelfLink($selfLink);
+        $expectedResponse->setTargetLink($targetLink);
+        $expectedResponse->setLocation($location);
+        $expectedResponse->setStartTime($startTime);
+        $expectedResponse->setEndTime($endTime);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $nodeVersion = 'nodeVersion1790136219';
+        $imageType = 'imageType-1442758754';
+        $response = $client->updateNodePool($nodeVersion, $imageType);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.container.v1.ClusterManager/UpdateNodePool', $actualFuncCall);
+        $actualValue = $actualRequestObject->getNodeVersion();
+        $this->assertProtobufEquals($nodeVersion, $actualValue);
+        $actualValue = $actualRequestObject->getImageType();
+        $this->assertProtobufEquals($imageType, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function updateNodePoolExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $nodeVersion = 'nodeVersion1790136219';
+        $imageType = 'imageType-1442758754';
+        try {
+            $client->updateNodePool($nodeVersion, $imageType);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+}


### PR DESCRIPTION
Example: Container and the CancelOperation RPC.