### PR TITLE
[ggp] fix(client): Handle optional and required request params (phase 2/2)

### DIFF
--- a/tests/Integration/Main.php
+++ b/tests/Integration/Main.php
@@ -265,6 +265,12 @@ function processSingleDiff($mono, $micro)
 
     // Find incorrectly generated files.
     foreach (array_intersect(array_keys($mono), array_keys($micro)) as $path) {
+        // Skip anything ending in GapicClient.php, this is now meaningless due to the requestParameters fix.
+        $gapicClientEnding = "GapicClient.php";
+        if (substr($path, -strlen($gapicClientEnding)) == $gapicClientEnding) {
+            print("Skipping $path\n");
+            continue;
+        }
         print("Comparing: '{$path}':\n");
         $sameContent = true;
         $isJson = substr($path, -5) === '.json';

--- a/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
@@ -444,14 +444,14 @@ class AssetServiceGapicClient
     public function analyzeIamPolicy($analysisQuery, array $optionalArgs = [])
     {
         $request = new AnalyzeIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setAnalysisQuery($analysisQuery);
+        $requestParamHeaders['analysis_query.scope'] = $analysisQuery->getScope();
         if (isset($optionalArgs['executionTimeout'])) {
             $request->setExecutionTimeout($optionalArgs['executionTimeout']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'analysis_query.scope' => $request->getAnalysisQuery()->getScope(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('AnalyzeIamPolicy', AnalyzeIamPolicyResponse::class, $optionalArgs, $request)->wait();
     }
@@ -523,11 +523,11 @@ class AssetServiceGapicClient
     public function analyzeIamPolicyLongrunning($analysisQuery, $outputConfig, array $optionalArgs = [])
     {
         $request = new AnalyzeIamPolicyLongrunningRequest();
+        $requestParamHeaders = [];
         $request->setAnalysisQuery($analysisQuery);
         $request->setOutputConfig($outputConfig);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'analysis_query.scope' => $request->getAnalysisQuery()->getScope(),
-        ]);
+        $requestParamHeaders['analysis_query.scope'] = $analysisQuery->getScope();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('AnalyzeIamPolicyLongrunning', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -591,7 +591,9 @@ class AssetServiceGapicClient
     public function batchGetAssetsHistory($parent, array $optionalArgs = [])
     {
         $request = new BatchGetAssetsHistoryRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['assetNames'])) {
             $request->setAssetNames($optionalArgs['assetNames']);
         }
@@ -604,9 +606,7 @@ class AssetServiceGapicClient
             $request->setReadTimeWindow($optionalArgs['readTimeWindow']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('BatchGetAssetsHistory', BatchGetAssetsHistoryResponse::class, $optionalArgs, $request)->wait();
     }
@@ -657,12 +657,12 @@ class AssetServiceGapicClient
     public function createFeed($parent, $feedId, $feed, array $optionalArgs = [])
     {
         $request = new CreateFeedRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setFeedId($feedId);
         $request->setFeed($feed);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateFeed', Feed::class, $optionalArgs, $request)->wait();
     }
@@ -700,10 +700,10 @@ class AssetServiceGapicClient
     public function deleteFeed($name, array $optionalArgs = [])
     {
         $request = new DeleteFeedRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteFeed', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -808,8 +808,10 @@ class AssetServiceGapicClient
     public function exportAssets($parent, $outputConfig, array $optionalArgs = [])
     {
         $request = new ExportAssetsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setOutputConfig($outputConfig);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['readTime'])) {
             $request->setReadTime($optionalArgs['readTime']);
         }
@@ -822,9 +824,7 @@ class AssetServiceGapicClient
             $request->setContentType($optionalArgs['contentType']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('ExportAssets', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -864,10 +864,10 @@ class AssetServiceGapicClient
     public function getFeed($name, array $optionalArgs = [])
     {
         $request = new GetFeedRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetFeed', Feed::class, $optionalArgs, $request)->wait();
     }
@@ -906,10 +906,10 @@ class AssetServiceGapicClient
     public function listFeeds($parent, array $optionalArgs = [])
     {
         $request = new ListFeedsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('ListFeeds', ListFeedsResponse::class, $optionalArgs, $request)->wait();
     }
@@ -1008,7 +1008,9 @@ class AssetServiceGapicClient
     public function searchAllIamPolicies($scope, array $optionalArgs = [])
     {
         $request = new SearchAllIamPoliciesRequest();
+        $requestParamHeaders = [];
         $request->setScope($scope);
+        $requestParamHeaders['scope'] = $scope;
         if (isset($optionalArgs['query'])) {
             $request->setQuery($optionalArgs['query']);
         }
@@ -1021,9 +1023,7 @@ class AssetServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'scope' => $request->getScope(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('SearchAllIamPolicies', $optionalArgs, SearchAllIamPoliciesResponse::class, $request);
     }
@@ -1143,7 +1143,9 @@ class AssetServiceGapicClient
     public function searchAllResources($scope, array $optionalArgs = [])
     {
         $request = new SearchAllResourcesRequest();
+        $requestParamHeaders = [];
         $request->setScope($scope);
+        $requestParamHeaders['scope'] = $scope;
         if (isset($optionalArgs['query'])) {
             $request->setQuery($optionalArgs['query']);
         }
@@ -1164,9 +1166,7 @@ class AssetServiceGapicClient
             $request->setOrderBy($optionalArgs['orderBy']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'scope' => $request->getScope(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('SearchAllResources', $optionalArgs, SearchAllResourcesResponse::class, $request);
     }
@@ -1211,11 +1211,11 @@ class AssetServiceGapicClient
     public function updateFeed($feed, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateFeedRequest();
+        $requestParamHeaders = [];
         $request->setFeed($feed);
         $request->setUpdateMask($updateMask);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'feed.name' => $request->getFeed()->getName(),
-        ]);
+        $requestParamHeaders['feed.name'] = $feed->getName();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateFeed', Feed::class, $optionalArgs, $request)->wait();
     }

--- a/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
+++ b/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
@@ -254,22 +254,29 @@ class ClusterManagerGapicClient
     public function cancelOperation(array $optionalArgs = [])
     {
         $request = new CancelOperationRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['operationId'])) {
             $request->setOperationId($optionalArgs['operationId']);
+            $requestParamHeaders['operation_id'] = $optionalArgs['operationId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CancelOperation', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
@@ -318,22 +325,29 @@ class ClusterManagerGapicClient
     public function completeIPRotation(array $optionalArgs = [])
     {
         $request = new CompleteIPRotationRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CompleteIPRotation', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -395,19 +409,25 @@ class ClusterManagerGapicClient
     public function createCluster($cluster, array $optionalArgs = [])
     {
         $request = new CreateClusterRequest();
+        $requestParamHeaders = [];
         $request->setCluster($cluster);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateCluster', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -459,23 +479,30 @@ class ClusterManagerGapicClient
     public function createNodePool($nodePool, array $optionalArgs = [])
     {
         $request = new CreateNodePoolRequest();
+        $requestParamHeaders = [];
         $request->setNodePool($nodePool);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateNodePool', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -532,22 +559,29 @@ class ClusterManagerGapicClient
     public function deleteCluster(array $optionalArgs = [])
     {
         $request = new DeleteClusterRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteCluster', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -600,26 +634,34 @@ class ClusterManagerGapicClient
     public function deleteNodePool(array $optionalArgs = [])
     {
         $request = new DeleteNodePoolRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteNodePool', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -668,22 +710,29 @@ class ClusterManagerGapicClient
     public function getCluster(array $optionalArgs = [])
     {
         $request = new GetClusterRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetCluster', Cluster::class, $optionalArgs, $request)->wait();
     }
 
@@ -723,10 +772,14 @@ class ClusterManagerGapicClient
     public function getJSONWebKeys(array $optionalArgs = [])
     {
         $request = new GetJSONWebKeysRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetJSONWebKeys', GetJSONWebKeysResponse::class, $optionalArgs, $request)->wait();
     }
 
@@ -779,26 +832,34 @@ class ClusterManagerGapicClient
     public function getNodePool(array $optionalArgs = [])
     {
         $request = new GetNodePoolRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetNodePool', NodePool::class, $optionalArgs, $request)->wait();
     }
 
@@ -847,22 +908,29 @@ class ClusterManagerGapicClient
     public function getOperation(array $optionalArgs = [])
     {
         $request = new GetOperationRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['operationId'])) {
             $request->setOperationId($optionalArgs['operationId']);
+            $requestParamHeaders['operation_id'] = $optionalArgs['operationId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetOperation', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -908,18 +976,24 @@ class ClusterManagerGapicClient
     public function getServerConfig(array $optionalArgs = [])
     {
         $request = new GetServerConfigRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetServerConfig', ServerConfig::class, $optionalArgs, $request)->wait();
     }
 
@@ -967,18 +1041,24 @@ class ClusterManagerGapicClient
     public function listClusters(array $optionalArgs = [])
     {
         $request = new ListClustersRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('ListClusters', ListClustersResponse::class, $optionalArgs, $request)->wait();
     }
 
@@ -1027,22 +1107,29 @@ class ClusterManagerGapicClient
     public function listNodePools(array $optionalArgs = [])
     {
         $request = new ListNodePoolsRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('ListNodePools', ListNodePoolsResponse::class, $optionalArgs, $request)->wait();
     }
 
@@ -1089,18 +1176,24 @@ class ClusterManagerGapicClient
     public function listOperations(array $optionalArgs = [])
     {
         $request = new ListOperationsRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('ListOperations', ListOperationsResponse::class, $optionalArgs, $request)->wait();
     }
 
@@ -1163,8 +1256,10 @@ class ClusterManagerGapicClient
     public function listUsableSubnetworks(array $optionalArgs = [])
     {
         $request = new ListUsableSubnetworksRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
         if (isset($optionalArgs['filter'])) {
@@ -1179,6 +1274,8 @@ class ClusterManagerGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListUsableSubnetworks', $optionalArgs, ListUsableSubnetworksResponse::class, $request);
     }
 
@@ -1232,26 +1329,34 @@ class ClusterManagerGapicClient
     public function rollbackNodePoolUpgrade(array $optionalArgs = [])
     {
         $request = new RollbackNodePoolUpgradeRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('RollbackNodePoolUpgrade', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1303,23 +1408,30 @@ class ClusterManagerGapicClient
     public function setAddonsConfig($addonsConfig, array $optionalArgs = [])
     {
         $request = new SetAddonsConfigRequest();
+        $requestParamHeaders = [];
         $request->setAddonsConfig($addonsConfig);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetAddonsConfig', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1377,24 +1489,31 @@ class ClusterManagerGapicClient
     public function setLabels($resourceLabels, $labelFingerprint, array $optionalArgs = [])
     {
         $request = new SetLabelsRequest();
+        $requestParamHeaders = [];
         $request->setResourceLabels($resourceLabels);
         $request->setLabelFingerprint($labelFingerprint);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetLabels', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1445,23 +1564,30 @@ class ClusterManagerGapicClient
     public function setLegacyAbac($enabled, array $optionalArgs = [])
     {
         $request = new SetLegacyAbacRequest();
+        $requestParamHeaders = [];
         $request->setEnabled($enabled);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetLegacyAbac', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1521,23 +1647,30 @@ class ClusterManagerGapicClient
     public function setLocations($locations, array $optionalArgs = [])
     {
         $request = new SetLocationsRequest();
+        $requestParamHeaders = [];
         $request->setLocations($locations);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetLocations', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1598,23 +1731,30 @@ class ClusterManagerGapicClient
     public function setLoggingService($loggingService, array $optionalArgs = [])
     {
         $request = new SetLoggingServiceRequest();
+        $requestParamHeaders = [];
         $request->setLoggingService($loggingService);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetLoggingService', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1664,19 +1804,20 @@ class ClusterManagerGapicClient
     public function setMaintenancePolicy($projectId, $zone, $clusterId, $maintenancePolicy, array $optionalArgs = [])
     {
         $request = new SetMaintenancePolicyRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setZone($zone);
         $request->setClusterId($clusterId);
         $request->setMaintenancePolicy($maintenancePolicy);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['zone'] = $zone;
+        $requestParamHeaders['cluster_id'] = $clusterId;
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'zone' => $request->getZone(),
-            'cluster_id' => $request->getClusterId(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetMaintenancePolicy', Operation::class, $optionalArgs, $request)->wait();
     }
@@ -1733,24 +1874,31 @@ class ClusterManagerGapicClient
     public function setMasterAuth($action, $update, array $optionalArgs = [])
     {
         $request = new SetMasterAuthRequest();
+        $requestParamHeaders = [];
         $request->setAction($action);
         $request->setUpdate($update);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetMasterAuth', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1811,23 +1959,30 @@ class ClusterManagerGapicClient
     public function setMonitoringService($monitoringService, array $optionalArgs = [])
     {
         $request = new SetMonitoringServiceRequest();
+        $requestParamHeaders = [];
         $request->setMonitoringService($monitoringService);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetMonitoringService', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1878,23 +2033,30 @@ class ClusterManagerGapicClient
     public function setNetworkPolicy($networkPolicy, array $optionalArgs = [])
     {
         $request = new SetNetworkPolicyRequest();
+        $requestParamHeaders = [];
         $request->setNetworkPolicy($networkPolicy);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetNetworkPolicy', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -1949,27 +2111,35 @@ class ClusterManagerGapicClient
     public function setNodePoolAutoscaling($autoscaling, array $optionalArgs = [])
     {
         $request = new SetNodePoolAutoscalingRequest();
+        $requestParamHeaders = [];
         $request->setAutoscaling($autoscaling);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetNodePoolAutoscaling', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -2024,27 +2194,35 @@ class ClusterManagerGapicClient
     public function setNodePoolManagement($management, array $optionalArgs = [])
     {
         $request = new SetNodePoolManagementRequest();
+        $requestParamHeaders = [];
         $request->setManagement($management);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetNodePoolManagement', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -2099,27 +2277,35 @@ class ClusterManagerGapicClient
     public function setNodePoolSize($nodeCount, array $optionalArgs = [])
     {
         $request = new SetNodePoolSizeRequest();
+        $requestParamHeaders = [];
         $request->setNodeCount($nodeCount);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetNodePoolSize', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -2170,26 +2356,33 @@ class ClusterManagerGapicClient
     public function startIPRotation(array $optionalArgs = [])
     {
         $request = new StartIPRotationRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
         if (isset($optionalArgs['rotateCredentials'])) {
             $request->setRotateCredentials($optionalArgs['rotateCredentials']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('StartIPRotation', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -2240,23 +2433,30 @@ class ClusterManagerGapicClient
     public function updateCluster($update, array $optionalArgs = [])
     {
         $request = new UpdateClusterRequest();
+        $requestParamHeaders = [];
         $request->setUpdate($update);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateCluster', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -2316,23 +2516,30 @@ class ClusterManagerGapicClient
     public function updateMaster($masterVersion, array $optionalArgs = [])
     {
         $request = new UpdateMasterRequest();
+        $requestParamHeaders = [];
         $request->setMasterVersion($masterVersion);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateMaster', Operation::class, $optionalArgs, $request)->wait();
     }
 
@@ -2409,26 +2616,32 @@ class ClusterManagerGapicClient
     public function updateNodePool($nodeVersion, $imageType, array $optionalArgs = [])
     {
         $request = new UpdateNodePoolRequest();
+        $requestParamHeaders = [];
         $request->setNodeVersion($nodeVersion);
         $request->setImageType($imageType);
         if (isset($optionalArgs['projectId'])) {
             $request->setProjectId($optionalArgs['projectId']);
+            $requestParamHeaders['project_id'] = $optionalArgs['projectId'];
         }
 
         if (isset($optionalArgs['zone'])) {
             $request->setZone($optionalArgs['zone']);
+            $requestParamHeaders['zone'] = $optionalArgs['zone'];
         }
 
         if (isset($optionalArgs['clusterId'])) {
             $request->setClusterId($optionalArgs['clusterId']);
+            $requestParamHeaders['cluster_id'] = $optionalArgs['clusterId'];
         }
 
         if (isset($optionalArgs['nodePoolId'])) {
             $request->setNodePoolId($optionalArgs['nodePoolId']);
+            $requestParamHeaders['node_pool_id'] = $optionalArgs['nodePoolId'];
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
         if (isset($optionalArgs['locations'])) {
@@ -2443,6 +2656,8 @@ class ClusterManagerGapicClient
             $request->setUpgradeSettings($optionalArgs['upgradeSettings']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateNodePool', Operation::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/AutoscalingPolicyServiceGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/AutoscalingPolicyServiceGapicClient.php
@@ -426,11 +426,11 @@ class AutoscalingPolicyServiceGapicClient
     public function createAutoscalingPolicy($parent, $policy, array $optionalArgs = [])
     {
         $request = new CreateAutoscalingPolicyRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setPolicy($policy);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateAutoscalingPolicy', AutoscalingPolicy::class, $optionalArgs, $request)->wait();
     }
@@ -475,10 +475,10 @@ class AutoscalingPolicyServiceGapicClient
     public function deleteAutoscalingPolicy($name, array $optionalArgs = [])
     {
         $request = new DeleteAutoscalingPolicyRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteAutoscalingPolicy', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -524,10 +524,10 @@ class AutoscalingPolicyServiceGapicClient
     public function getAutoscalingPolicy($name, array $optionalArgs = [])
     {
         $request = new GetAutoscalingPolicyRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetAutoscalingPolicy', AutoscalingPolicy::class, $optionalArgs, $request)->wait();
     }
@@ -594,7 +594,9 @@ class AutoscalingPolicyServiceGapicClient
     public function listAutoscalingPolicies($parent, array $optionalArgs = [])
     {
         $request = new ListAutoscalingPoliciesRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -603,9 +605,7 @@ class AutoscalingPolicyServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListAutoscalingPolicies', $optionalArgs, ListAutoscalingPoliciesResponse::class, $request);
     }
@@ -645,10 +645,10 @@ class AutoscalingPolicyServiceGapicClient
     public function updateAutoscalingPolicy($policy, array $optionalArgs = [])
     {
         $request = new UpdateAutoscalingPolicyRequest();
+        $requestParamHeaders = [];
         $request->setPolicy($policy);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'policy.name' => $request->getPolicy()->getName(),
-        ]);
+        $requestParamHeaders['policy.name'] = $policy->getName();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateAutoscalingPolicy', AutoscalingPolicy::class, $optionalArgs, $request)->wait();
     }

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/ClusterControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/ClusterControllerGapicClient.php
@@ -311,17 +311,17 @@ class ClusterControllerGapicClient
     public function createCluster($projectId, $region, $cluster, array $optionalArgs = [])
     {
         $request = new CreateClusterRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setCluster($cluster);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
         if (isset($optionalArgs['requestId'])) {
             $request->setRequestId($optionalArgs['requestId']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('CreateCluster', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -403,9 +403,13 @@ class ClusterControllerGapicClient
     public function deleteCluster($projectId, $region, $clusterName, array $optionalArgs = [])
     {
         $request = new DeleteClusterRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setClusterName($clusterName);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['cluster_name'] = $clusterName;
         if (isset($optionalArgs['clusterUuid'])) {
             $request->setClusterUuid($optionalArgs['clusterUuid']);
         }
@@ -414,11 +418,7 @@ class ClusterControllerGapicClient
             $request->setRequestId($optionalArgs['requestId']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'cluster_name' => $request->getClusterName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('DeleteCluster', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -491,14 +491,14 @@ class ClusterControllerGapicClient
     public function diagnoseCluster($projectId, $region, $clusterName, array $optionalArgs = [])
     {
         $request = new DiagnoseClusterRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setClusterName($clusterName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'cluster_name' => $request->getClusterName(),
-        ]);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['cluster_name'] = $clusterName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('DiagnoseCluster', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -540,14 +540,14 @@ class ClusterControllerGapicClient
     public function getCluster($projectId, $region, $clusterName, array $optionalArgs = [])
     {
         $request = new GetClusterRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setClusterName($clusterName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'cluster_name' => $request->getClusterName(),
-        ]);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['cluster_name'] = $clusterName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetCluster', Cluster::class, $optionalArgs, $request)->wait();
     }
@@ -628,8 +628,11 @@ class ClusterControllerGapicClient
     public function listClusters($projectId, $region, array $optionalArgs = [])
     {
         $request = new ListClustersRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
         if (isset($optionalArgs['filter'])) {
             $request->setFilter($optionalArgs['filter']);
         }
@@ -642,10 +645,7 @@ class ClusterControllerGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListClusters', $optionalArgs, ListClustersResponse::class, $request);
     }
@@ -790,11 +790,15 @@ class ClusterControllerGapicClient
     public function updateCluster($projectId, $region, $clusterName, $cluster, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateClusterRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setClusterName($clusterName);
         $request->setCluster($cluster);
         $request->setUpdateMask($updateMask);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['cluster_name'] = $clusterName;
         if (isset($optionalArgs['gracefulDecommissionTimeout'])) {
             $request->setGracefulDecommissionTimeout($optionalArgs['gracefulDecommissionTimeout']);
         }
@@ -803,11 +807,7 @@ class ClusterControllerGapicClient
             $request->setRequestId($optionalArgs['requestId']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'cluster_name' => $request->getClusterName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('UpdateCluster', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/JobControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/JobControllerGapicClient.php
@@ -249,14 +249,14 @@ class JobControllerGapicClient
     public function cancelJob($projectId, $region, $jobId, array $optionalArgs = [])
     {
         $request = new CancelJobRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setJobId($jobId);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'job_id' => $request->getJobId(),
-        ]);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['job_id'] = $jobId;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CancelJob', Job::class, $optionalArgs, $request)->wait();
     }
@@ -297,14 +297,14 @@ class JobControllerGapicClient
     public function deleteJob($projectId, $region, $jobId, array $optionalArgs = [])
     {
         $request = new DeleteJobRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setJobId($jobId);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'job_id' => $request->getJobId(),
-        ]);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['job_id'] = $jobId;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteJob', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -346,14 +346,14 @@ class JobControllerGapicClient
     public function getJob($projectId, $region, $jobId, array $optionalArgs = [])
     {
         $request = new GetJobRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setJobId($jobId);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'job_id' => $request->getJobId(),
-        ]);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['job_id'] = $jobId;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetJob', Job::class, $optionalArgs, $request)->wait();
     }
@@ -438,8 +438,11 @@ class JobControllerGapicClient
     public function listJobs($projectId, $region, array $optionalArgs = [])
     {
         $request = new ListJobsRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -460,10 +463,7 @@ class JobControllerGapicClient
             $request->setFilter($optionalArgs['filter']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListJobs', $optionalArgs, ListJobsResponse::class, $request);
     }
@@ -517,17 +517,17 @@ class JobControllerGapicClient
     public function submitJob($projectId, $region, $job, array $optionalArgs = [])
     {
         $request = new SubmitJobRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setJob($job);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
         if (isset($optionalArgs['requestId'])) {
             $request->setRequestId($optionalArgs['requestId']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SubmitJob', Job::class, $optionalArgs, $request)->wait();
     }
@@ -606,17 +606,17 @@ class JobControllerGapicClient
     public function submitJobAsOperation($projectId, $region, $job, array $optionalArgs = [])
     {
         $request = new SubmitJobRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setJob($job);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
         if (isset($optionalArgs['requestId'])) {
             $request->setRequestId($optionalArgs['requestId']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('SubmitJobAsOperation', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -667,16 +667,16 @@ class JobControllerGapicClient
     public function updateJob($projectId, $region, $jobId, $job, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateJobRequest();
+        $requestParamHeaders = [];
         $request->setProjectId($projectId);
         $request->setRegion($region);
         $request->setJobId($jobId);
         $request->setJob($job);
         $request->setUpdateMask($updateMask);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'project_id' => $request->getProjectId(),
-            'region' => $request->getRegion(),
-            'job_id' => $request->getJobId(),
-        ]);
+        $requestParamHeaders['project_id'] = $projectId;
+        $requestParamHeaders['region'] = $region;
+        $requestParamHeaders['job_id'] = $jobId;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateJob', Job::class, $optionalArgs, $request)->wait();
     }

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/WorkflowTemplateServiceGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/WorkflowTemplateServiceGapicClient.php
@@ -465,11 +465,11 @@ class WorkflowTemplateServiceGapicClient
     public function createWorkflowTemplate($parent, $template, array $optionalArgs = [])
     {
         $request = new CreateWorkflowTemplateRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setTemplate($template);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateWorkflowTemplate', WorkflowTemplate::class, $optionalArgs, $request)->wait();
     }
@@ -517,14 +517,14 @@ class WorkflowTemplateServiceGapicClient
     public function deleteWorkflowTemplate($name, array $optionalArgs = [])
     {
         $request = new DeleteWorkflowTemplateRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['version'])) {
             $request->setVersion($optionalArgs['version']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteWorkflowTemplate', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -578,14 +578,14 @@ class WorkflowTemplateServiceGapicClient
     public function getWorkflowTemplate($name, array $optionalArgs = [])
     {
         $request = new GetWorkflowTemplateRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['version'])) {
             $request->setVersion($optionalArgs['version']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetWorkflowTemplate', WorkflowTemplate::class, $optionalArgs, $request)->wait();
     }
@@ -689,15 +689,15 @@ class WorkflowTemplateServiceGapicClient
     public function instantiateInlineWorkflowTemplate($parent, $template, array $optionalArgs = [])
     {
         $request = new InstantiateInlineWorkflowTemplateRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setTemplate($template);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['requestId'])) {
             $request->setRequestId($optionalArgs['requestId']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('InstantiateInlineWorkflowTemplate', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -805,7 +805,9 @@ class WorkflowTemplateServiceGapicClient
     public function instantiateWorkflowTemplate($name, array $optionalArgs = [])
     {
         $request = new InstantiateWorkflowTemplateRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['version'])) {
             $request->setVersion($optionalArgs['version']);
         }
@@ -818,9 +820,7 @@ class WorkflowTemplateServiceGapicClient
             $request->setParameters($optionalArgs['parameters']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('InstantiateWorkflowTemplate', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -887,7 +887,9 @@ class WorkflowTemplateServiceGapicClient
     public function listWorkflowTemplates($parent, array $optionalArgs = [])
     {
         $request = new ListWorkflowTemplatesRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -896,9 +898,7 @@ class WorkflowTemplateServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListWorkflowTemplates', $optionalArgs, ListWorkflowTemplatesResponse::class, $request);
     }
@@ -938,10 +938,10 @@ class WorkflowTemplateServiceGapicClient
     public function updateWorkflowTemplate($template, array $optionalArgs = [])
     {
         $request = new UpdateWorkflowTemplateRequest();
+        $requestParamHeaders = [];
         $request->setTemplate($template);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'template.name' => $request->getTemplate()->getName(),
-        ]);
+        $requestParamHeaders['template.name'] = $template->getName();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateWorkflowTemplate', WorkflowTemplate::class, $optionalArgs, $request)->wait();
     }

--- a/tests/Integration/goldens/functions/src/V1/Gapic/CloudFunctionsServiceGapicClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Gapic/CloudFunctionsServiceGapicClient.php
@@ -373,11 +373,11 @@ class CloudFunctionsServiceGapicClient
     public function callFunction($name, $data, array $optionalArgs = [])
     {
         $request = new CallFunctionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setData($data);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CallFunction', CallFunctionResponse::class, $optionalArgs, $request)->wait();
     }
@@ -444,11 +444,11 @@ class CloudFunctionsServiceGapicClient
     public function createFunction($location, $function, array $optionalArgs = [])
     {
         $request = new CreateFunctionRequest();
+        $requestParamHeaders = [];
         $request->setLocation($location);
         $request->setFunction($function);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'location' => $request->getLocation(),
-        ]);
+        $requestParamHeaders['location'] = $location;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('CreateFunction', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -510,10 +510,10 @@ class CloudFunctionsServiceGapicClient
     public function deleteFunction($name, array $optionalArgs = [])
     {
         $request = new DeleteFunctionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('DeleteFunction', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -558,14 +558,18 @@ class CloudFunctionsServiceGapicClient
     public function generateDownloadUrl(array $optionalArgs = [])
     {
         $request = new GenerateDownloadUrlRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
         if (isset($optionalArgs['versionId'])) {
             $request->setVersionId($optionalArgs['versionId']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GenerateDownloadUrl', GenerateDownloadUrlResponse::class, $optionalArgs, $request)->wait();
     }
 
@@ -626,10 +630,14 @@ class CloudFunctionsServiceGapicClient
     public function generateUploadUrl(array $optionalArgs = [])
     {
         $request = new GenerateUploadUrlRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GenerateUploadUrl', GenerateUploadUrlResponse::class, $optionalArgs, $request)->wait();
     }
 
@@ -665,10 +673,10 @@ class CloudFunctionsServiceGapicClient
     public function getFunction($name, array $optionalArgs = [])
     {
         $request = new GetFunctionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetFunction', CloudFunction::class, $optionalArgs, $request)->wait();
     }
@@ -711,14 +719,14 @@ class CloudFunctionsServiceGapicClient
     public function getIamPolicy($resource, array $optionalArgs = [])
     {
         $request = new GetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
+        $requestParamHeaders['resource'] = $resource;
         if (isset($optionalArgs['options'])) {
             $request->setOptions($optionalArgs['options']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetIamPolicy', Policy::class, $optionalArgs, $request)->wait();
     }
@@ -781,8 +789,10 @@ class CloudFunctionsServiceGapicClient
     public function listFunctions(array $optionalArgs = [])
     {
         $request = new ListFunctionsRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['parent'])) {
             $request->setParent($optionalArgs['parent']);
+            $requestParamHeaders['parent'] = $optionalArgs['parent'];
         }
 
         if (isset($optionalArgs['pageSize'])) {
@@ -793,6 +803,8 @@ class CloudFunctionsServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListFunctions', $optionalArgs, ListFunctionsResponse::class, $request);
     }
 
@@ -835,11 +847,11 @@ class CloudFunctionsServiceGapicClient
     public function setIamPolicy($resource, $policy, array $optionalArgs = [])
     {
         $request = new SetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setPolicy($policy);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetIamPolicy', Policy::class, $optionalArgs, $request)->wait();
     }
@@ -885,11 +897,11 @@ class CloudFunctionsServiceGapicClient
     public function testIamPermissions($resource, $permissions, array $optionalArgs = [])
     {
         $request = new TestIamPermissionsRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setPermissions($permissions);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('TestIamPermissions', TestIamPermissionsResponse::class, $optionalArgs, $request)->wait();
     }
@@ -953,14 +965,14 @@ class CloudFunctionsServiceGapicClient
     public function updateFunction($function, array $optionalArgs = [])
     {
         $request = new UpdateFunctionRequest();
+        $requestParamHeaders = [];
         $request->setFunction($function);
+        $requestParamHeaders['function.name'] = $function->getName();
         if (isset($optionalArgs['updateMask'])) {
             $request->setUpdateMask($optionalArgs['updateMask']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'function.name' => $request->getFunction()->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('UpdateFunction', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }

--- a/tests/Integration/goldens/iam/src/V1/Gapic/IAMPolicyGapicClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Gapic/IAMPolicyGapicClient.php
@@ -226,14 +226,14 @@ class IAMPolicyGapicClient
     public function getIamPolicy($resource, array $optionalArgs = [])
     {
         $request = new GetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
+        $requestParamHeaders['resource'] = $resource;
         if (isset($optionalArgs['options'])) {
             $request->setOptions($optionalArgs['options']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetIamPolicy', Policy::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }
@@ -277,11 +277,11 @@ class IAMPolicyGapicClient
     public function setIamPolicy($resource, $policy, array $optionalArgs = [])
     {
         $request = new SetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setPolicy($policy);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetIamPolicy', Policy::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }
@@ -330,11 +330,11 @@ class IAMPolicyGapicClient
     public function testIamPermissions($resource, $permissions, array $optionalArgs = [])
     {
         $request = new TestIamPermissionsRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setPermissions($permissions);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('TestIamPermissions', TestIamPermissionsResponse::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }
@@ -377,14 +377,14 @@ class IAMPolicyGapicClient
     public function getIamPolicy($resource, array $optionalArgs = [])
     {
         $request = new GetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
+        $requestParamHeaders['resource'] = $resource;
         if (isset($optionalArgs['options'])) {
             $request->setOptions($optionalArgs['options']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetIamPolicy', Policy::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }
@@ -428,11 +428,11 @@ class IAMPolicyGapicClient
     public function setIamPolicy($resource, $policy, array $optionalArgs = [])
     {
         $request = new SetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setPolicy($policy);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('SetIamPolicy', Policy::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }
@@ -481,11 +481,11 @@ class IAMPolicyGapicClient
     public function testIamPermissions($resource, $permissions, array $optionalArgs = [])
     {
         $request = new TestIamPermissionsRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setPermissions($permissions);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('TestIamPermissions', TestIamPermissionsResponse::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }

--- a/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
@@ -509,15 +509,15 @@ class KeyManagementServiceGapicClient
     public function asymmetricDecrypt($name, $ciphertext, array $optionalArgs = [])
     {
         $request = new AsymmetricDecryptRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setCiphertext($ciphertext);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['ciphertextCrc32c'])) {
             $request->setCiphertextCrc32c($optionalArgs['ciphertextCrc32c']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('AsymmetricDecrypt', AsymmetricDecryptResponse::class, $optionalArgs, $request)->wait();
     }
@@ -586,15 +586,15 @@ class KeyManagementServiceGapicClient
     public function asymmetricSign($name, $digest, array $optionalArgs = [])
     {
         $request = new AsymmetricSignRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setDigest($digest);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['digestCrc32c'])) {
             $request->setDigestCrc32c($optionalArgs['digestCrc32c']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('AsymmetricSign', AsymmetricSignResponse::class, $optionalArgs, $request)->wait();
     }
@@ -652,16 +652,16 @@ class KeyManagementServiceGapicClient
     public function createCryptoKey($parent, $cryptoKeyId, $cryptoKey, array $optionalArgs = [])
     {
         $request = new CreateCryptoKeyRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setCryptoKeyId($cryptoKeyId);
         $request->setCryptoKey($cryptoKey);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['skipInitialVersionCreation'])) {
             $request->setSkipInitialVersionCreation($optionalArgs['skipInitialVersionCreation']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateCryptoKey', CryptoKey::class, $optionalArgs, $request)->wait();
     }
@@ -708,11 +708,11 @@ class KeyManagementServiceGapicClient
     public function createCryptoKeyVersion($parent, $cryptoKeyVersion, array $optionalArgs = [])
     {
         $request = new CreateCryptoKeyVersionRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setCryptoKeyVersion($cryptoKeyVersion);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
     }
@@ -761,12 +761,12 @@ class KeyManagementServiceGapicClient
     public function createImportJob($parent, $importJobId, $importJob, array $optionalArgs = [])
     {
         $request = new CreateImportJobRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setImportJobId($importJobId);
         $request->setImportJob($importJob);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateImportJob', ImportJob::class, $optionalArgs, $request)->wait();
     }
@@ -812,12 +812,12 @@ class KeyManagementServiceGapicClient
     public function createKeyRing($parent, $keyRingId, $keyRing, array $optionalArgs = [])
     {
         $request = new CreateKeyRingRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setKeyRingId($keyRingId);
         $request->setKeyRing($keyRing);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateKeyRing', KeyRing::class, $optionalArgs, $request)->wait();
     }
@@ -909,8 +909,10 @@ class KeyManagementServiceGapicClient
     public function decrypt($name, $ciphertext, array $optionalArgs = [])
     {
         $request = new DecryptRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setCiphertext($ciphertext);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['additionalAuthenticatedData'])) {
             $request->setAdditionalAuthenticatedData($optionalArgs['additionalAuthenticatedData']);
         }
@@ -923,9 +925,7 @@ class KeyManagementServiceGapicClient
             $request->setAdditionalAuthenticatedDataCrc32c($optionalArgs['additionalAuthenticatedDataCrc32c']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('Decrypt', DecryptResponse::class, $optionalArgs, $request)->wait();
     }
@@ -980,10 +980,10 @@ class KeyManagementServiceGapicClient
     public function destroyCryptoKeyVersion($name, array $optionalArgs = [])
     {
         $request = new DestroyCryptoKeyVersionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DestroyCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
     }
@@ -1095,8 +1095,10 @@ class KeyManagementServiceGapicClient
     public function encrypt($name, $plaintext, array $optionalArgs = [])
     {
         $request = new EncryptRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setPlaintext($plaintext);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['additionalAuthenticatedData'])) {
             $request->setAdditionalAuthenticatedData($optionalArgs['additionalAuthenticatedData']);
         }
@@ -1109,9 +1111,7 @@ class KeyManagementServiceGapicClient
             $request->setAdditionalAuthenticatedDataCrc32c($optionalArgs['additionalAuthenticatedDataCrc32c']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('Encrypt', EncryptResponse::class, $optionalArgs, $request)->wait();
     }
@@ -1151,10 +1151,10 @@ class KeyManagementServiceGapicClient
     public function getCryptoKey($name, array $optionalArgs = [])
     {
         $request = new GetCryptoKeyRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetCryptoKey', CryptoKey::class, $optionalArgs, $request)->wait();
     }
@@ -1193,10 +1193,10 @@ class KeyManagementServiceGapicClient
     public function getCryptoKeyVersion($name, array $optionalArgs = [])
     {
         $request = new GetCryptoKeyVersionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
     }
@@ -1239,14 +1239,14 @@ class KeyManagementServiceGapicClient
     public function getIamPolicy($resource, array $optionalArgs = [])
     {
         $request = new GetIamPolicyRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
+        $requestParamHeaders['resource'] = $resource;
         if (isset($optionalArgs['options'])) {
             $request->setOptions($optionalArgs['options']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'resource' => $request->getResource(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetIamPolicy', Policy::class, $optionalArgs, $request)->wait();
     }
@@ -1284,10 +1284,10 @@ class KeyManagementServiceGapicClient
     public function getImportJob($name, array $optionalArgs = [])
     {
         $request = new GetImportJobRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetImportJob', ImportJob::class, $optionalArgs, $request)->wait();
     }
@@ -1325,10 +1325,10 @@ class KeyManagementServiceGapicClient
     public function getKeyRing($name, array $optionalArgs = [])
     {
         $request = new GetKeyRingRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetKeyRing', KeyRing::class, $optionalArgs, $request)->wait();
     }
@@ -1371,10 +1371,10 @@ class KeyManagementServiceGapicClient
     public function getPublicKey($name, array $optionalArgs = [])
     {
         $request = new GetPublicKeyRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetPublicKey', PublicKey::class, $optionalArgs, $request)->wait();
     }
@@ -1452,16 +1452,16 @@ class KeyManagementServiceGapicClient
     public function importCryptoKeyVersion($parent, $algorithm, $importJob, array $optionalArgs = [])
     {
         $request = new ImportCryptoKeyVersionRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setAlgorithm($algorithm);
         $request->setImportJob($importJob);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['rsaAesWrappedKey'])) {
             $request->setRsaAesWrappedKey($optionalArgs['rsaAesWrappedKey']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('ImportCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
     }
@@ -1534,7 +1534,9 @@ class KeyManagementServiceGapicClient
     public function listCryptoKeyVersions($parent, array $optionalArgs = [])
     {
         $request = new ListCryptoKeyVersionsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -1555,9 +1557,7 @@ class KeyManagementServiceGapicClient
             $request->setOrderBy($optionalArgs['orderBy']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListCryptoKeyVersions', $optionalArgs, ListCryptoKeyVersionsResponse::class, $request);
     }
@@ -1629,7 +1629,9 @@ class KeyManagementServiceGapicClient
     public function listCryptoKeys($parent, array $optionalArgs = [])
     {
         $request = new ListCryptoKeysRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -1650,9 +1652,7 @@ class KeyManagementServiceGapicClient
             $request->setOrderBy($optionalArgs['orderBy']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListCryptoKeys', $optionalArgs, ListCryptoKeysResponse::class, $request);
     }
@@ -1721,7 +1721,9 @@ class KeyManagementServiceGapicClient
     public function listImportJobs($parent, array $optionalArgs = [])
     {
         $request = new ListImportJobsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -1738,9 +1740,7 @@ class KeyManagementServiceGapicClient
             $request->setOrderBy($optionalArgs['orderBy']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListImportJobs', $optionalArgs, ListImportJobsResponse::class, $request);
     }
@@ -1810,7 +1810,9 @@ class KeyManagementServiceGapicClient
     public function listKeyRings($parent, array $optionalArgs = [])
     {
         $request = new ListKeyRingsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -1827,9 +1829,7 @@ class KeyManagementServiceGapicClient
             $request->setOrderBy($optionalArgs['orderBy']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListKeyRings', $optionalArgs, ListKeyRingsResponse::class, $request);
     }
@@ -1875,10 +1875,10 @@ class KeyManagementServiceGapicClient
     public function restoreCryptoKeyVersion($name, array $optionalArgs = [])
     {
         $request = new RestoreCryptoKeyVersionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('RestoreCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
     }
@@ -1917,11 +1917,11 @@ class KeyManagementServiceGapicClient
     public function updateCryptoKey($cryptoKey, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateCryptoKeyRequest();
+        $requestParamHeaders = [];
         $request->setCryptoKey($cryptoKey);
         $request->setUpdateMask($updateMask);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'crypto_key.name' => $request->getCryptoKey()->getName(),
-        ]);
+        $requestParamHeaders['crypto_key.name'] = $cryptoKey->getName();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateCryptoKey', CryptoKey::class, $optionalArgs, $request)->wait();
     }
@@ -1966,11 +1966,11 @@ class KeyManagementServiceGapicClient
     public function updateCryptoKeyPrimaryVersion($name, $cryptoKeyVersionId, array $optionalArgs = [])
     {
         $request = new UpdateCryptoKeyPrimaryVersionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setCryptoKeyVersionId($cryptoKeyVersionId);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateCryptoKeyPrimaryVersion', CryptoKey::class, $optionalArgs, $request)->wait();
     }
@@ -2021,11 +2021,11 @@ class KeyManagementServiceGapicClient
     public function updateCryptoKeyVersion($cryptoKeyVersion, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateCryptoKeyVersionRequest();
+        $requestParamHeaders = [];
         $request->setCryptoKeyVersion($cryptoKeyVersion);
         $request->setUpdateMask($updateMask);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'crypto_key_version.name' => $request->getCryptoKeyVersion()->getName(),
-        ]);
+        $requestParamHeaders['crypto_key_version.name'] = $cryptoKeyVersion->getName();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
     }
@@ -2062,10 +2062,14 @@ class KeyManagementServiceGapicClient
     public function getLocation(array $optionalArgs = [])
     {
         $request = new GetLocationRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetLocation', Location::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.cloud.location.Locations')->wait();
     }
 
@@ -2124,8 +2128,10 @@ class KeyManagementServiceGapicClient
     public function listLocations(array $optionalArgs = [])
     {
         $request = new ListLocationsRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
         if (isset($optionalArgs['filter'])) {
@@ -2140,6 +2146,8 @@ class KeyManagementServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListLocations', $optionalArgs, ListLocationsResponse::class, $request, 'google.cloud.location.Locations');
     }
 }

--- a/tests/Integration/goldens/logging/src/V2/Gapic/ConfigServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/ConfigServiceV2GapicClient.php
@@ -1303,12 +1303,12 @@ class ConfigServiceV2GapicClient
     public function createBucket($parent, $bucketId, $bucket, array $optionalArgs = [])
     {
         $request = new CreateBucketRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setBucketId($bucketId);
         $request->setBucket($bucket);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateBucket', LogBucket::class, $optionalArgs, $request)->wait();
     }
@@ -1357,11 +1357,11 @@ class ConfigServiceV2GapicClient
     public function createExclusion($parent, $exclusion, array $optionalArgs = [])
     {
         $request = new CreateExclusionRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setExclusion($exclusion);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateExclusion', LogExclusion::class, $optionalArgs, $request)->wait();
     }
@@ -1423,15 +1423,15 @@ class ConfigServiceV2GapicClient
     public function createSink($parent, $sink, array $optionalArgs = [])
     {
         $request = new CreateSinkRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setSink($sink);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['uniqueWriterIdentity'])) {
             $request->setUniqueWriterIdentity($optionalArgs['uniqueWriterIdentity']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateSink', LogSink::class, $optionalArgs, $request)->wait();
     }
@@ -1478,12 +1478,12 @@ class ConfigServiceV2GapicClient
     public function createView($parent, $viewId, $view, array $optionalArgs = [])
     {
         $request = new CreateViewRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setViewId($viewId);
         $request->setView($view);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateView', LogView::class, $optionalArgs, $request)->wait();
     }
@@ -1529,10 +1529,10 @@ class ConfigServiceV2GapicClient
     public function deleteBucket($name, array $optionalArgs = [])
     {
         $request = new DeleteBucketRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteBucket', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -1574,10 +1574,10 @@ class ConfigServiceV2GapicClient
     public function deleteExclusion($name, array $optionalArgs = [])
     {
         $request = new DeleteExclusionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteExclusion', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -1621,10 +1621,10 @@ class ConfigServiceV2GapicClient
     public function deleteSink($sinkName, array $optionalArgs = [])
     {
         $request = new DeleteSinkRequest();
+        $requestParamHeaders = [];
         $request->setSinkName($sinkName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'sink_name' => $request->getSinkName(),
-        ]);
+        $requestParamHeaders['sink_name'] = $sinkName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteSink', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -1664,10 +1664,10 @@ class ConfigServiceV2GapicClient
     public function deleteView($name, array $optionalArgs = [])
     {
         $request = new DeleteViewRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteView', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -1712,10 +1712,10 @@ class ConfigServiceV2GapicClient
     public function getBucket($name, array $optionalArgs = [])
     {
         $request = new GetBucketRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetBucket', LogBucket::class, $optionalArgs, $request)->wait();
     }
@@ -1771,10 +1771,10 @@ class ConfigServiceV2GapicClient
     public function getCmekSettings($name, array $optionalArgs = [])
     {
         $request = new GetCmekSettingsRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetCmekSettings', CmekSettings::class, $optionalArgs, $request)->wait();
     }
@@ -1818,10 +1818,10 @@ class ConfigServiceV2GapicClient
     public function getExclusion($name, array $optionalArgs = [])
     {
         $request = new GetExclusionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetExclusion', LogExclusion::class, $optionalArgs, $request)->wait();
     }
@@ -1865,10 +1865,10 @@ class ConfigServiceV2GapicClient
     public function getSink($sinkName, array $optionalArgs = [])
     {
         $request = new GetSinkRequest();
+        $requestParamHeaders = [];
         $request->setSinkName($sinkName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'sink_name' => $request->getSinkName(),
-        ]);
+        $requestParamHeaders['sink_name'] = $sinkName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetSink', LogSink::class, $optionalArgs, $request)->wait();
     }
@@ -1910,10 +1910,10 @@ class ConfigServiceV2GapicClient
     public function getView($name, array $optionalArgs = [])
     {
         $request = new GetViewRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetView', LogView::class, $optionalArgs, $request)->wait();
     }
@@ -1980,7 +1980,9 @@ class ConfigServiceV2GapicClient
     public function listBuckets($parent, array $optionalArgs = [])
     {
         $request = new ListBucketsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
         }
@@ -1989,9 +1991,7 @@ class ConfigServiceV2GapicClient
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListBuckets', $optionalArgs, ListBucketsResponse::class, $request);
     }
@@ -2054,7 +2054,9 @@ class ConfigServiceV2GapicClient
     public function listExclusions($parent, array $optionalArgs = [])
     {
         $request = new ListExclusionsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
         }
@@ -2063,9 +2065,7 @@ class ConfigServiceV2GapicClient
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListExclusions', $optionalArgs, ListExclusionsResponse::class, $request);
     }
@@ -2128,7 +2128,9 @@ class ConfigServiceV2GapicClient
     public function listSinks($parent, array $optionalArgs = [])
     {
         $request = new ListSinksRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
         }
@@ -2137,9 +2139,7 @@ class ConfigServiceV2GapicClient
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListSinks', $optionalArgs, ListSinksResponse::class, $request);
     }
@@ -2199,7 +2199,9 @@ class ConfigServiceV2GapicClient
     public function listViews($parent, array $optionalArgs = [])
     {
         $request = new ListViewsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
         }
@@ -2208,9 +2210,7 @@ class ConfigServiceV2GapicClient
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListViews', $optionalArgs, ListViewsResponse::class, $request);
     }
@@ -2254,10 +2254,10 @@ class ConfigServiceV2GapicClient
     public function undeleteBucket($name, array $optionalArgs = [])
     {
         $request = new UndeleteBucketRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UndeleteBucket', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -2324,12 +2324,12 @@ class ConfigServiceV2GapicClient
     public function updateBucket($name, $bucket, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateBucketRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setBucket($bucket);
         $request->setUpdateMask($updateMask);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateBucket', LogBucket::class, $optionalArgs, $request)->wait();
     }
@@ -2405,15 +2405,15 @@ class ConfigServiceV2GapicClient
     public function updateCmekSettings($name, $cmekSettings, array $optionalArgs = [])
     {
         $request = new UpdateCmekSettingsRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setCmekSettings($cmekSettings);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['updateMask'])) {
             $request->setUpdateMask($optionalArgs['updateMask']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateCmekSettings', CmekSettings::class, $optionalArgs, $request)->wait();
     }
@@ -2468,12 +2468,12 @@ class ConfigServiceV2GapicClient
     public function updateExclusion($name, $exclusion, $updateMask, array $optionalArgs = [])
     {
         $request = new UpdateExclusionRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setExclusion($exclusion);
         $request->setUpdateMask($updateMask);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateExclusion', LogExclusion::class, $optionalArgs, $request)->wait();
     }
@@ -2552,8 +2552,10 @@ class ConfigServiceV2GapicClient
     public function updateSink($sinkName, $sink, array $optionalArgs = [])
     {
         $request = new UpdateSinkRequest();
+        $requestParamHeaders = [];
         $request->setSinkName($sinkName);
         $request->setSink($sink);
+        $requestParamHeaders['sink_name'] = $sinkName;
         if (isset($optionalArgs['uniqueWriterIdentity'])) {
             $request->setUniqueWriterIdentity($optionalArgs['uniqueWriterIdentity']);
         }
@@ -2562,9 +2564,7 @@ class ConfigServiceV2GapicClient
             $request->setUpdateMask($optionalArgs['updateMask']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'sink_name' => $request->getSinkName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateSink', LogSink::class, $optionalArgs, $request)->wait();
     }
@@ -2618,15 +2618,15 @@ class ConfigServiceV2GapicClient
     public function updateView($name, $view, array $optionalArgs = [])
     {
         $request = new UpdateViewRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setView($view);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['updateMask'])) {
             $request->setUpdateMask($optionalArgs['updateMask']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateView', LogView::class, $optionalArgs, $request)->wait();
     }

--- a/tests/Integration/goldens/logging/src/V2/Gapic/LoggingServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/LoggingServiceV2GapicClient.php
@@ -543,10 +543,10 @@ class LoggingServiceV2GapicClient
     public function deleteLog($logName, array $optionalArgs = [])
     {
         $request = new DeleteLogRequest();
+        $requestParamHeaders = [];
         $request->setLogName($logName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'log_name' => $request->getLogName(),
-        ]);
+        $requestParamHeaders['log_name'] = $logName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteLog', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -727,7 +727,9 @@ class LoggingServiceV2GapicClient
     public function listLogs($parent, array $optionalArgs = [])
     {
         $request = new ListLogsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -740,9 +742,7 @@ class LoggingServiceV2GapicClient
             $request->setResourceNames($optionalArgs['resourceNames']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListLogs', $optionalArgs, ListLogsResponse::class, $request);
     }

--- a/tests/Integration/goldens/logging/src/V2/Gapic/MetricsServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/MetricsServiceV2GapicClient.php
@@ -327,11 +327,11 @@ class MetricsServiceV2GapicClient
     public function createLogMetric($parent, $metric, array $optionalArgs = [])
     {
         $request = new CreateLogMetricRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setMetric($metric);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('CreateLogMetric', LogMetric::class, $optionalArgs, $request)->wait();
     }
@@ -368,10 +368,10 @@ class MetricsServiceV2GapicClient
     public function deleteLogMetric($metricName, array $optionalArgs = [])
     {
         $request = new DeleteLogMetricRequest();
+        $requestParamHeaders = [];
         $request->setMetricName($metricName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'metric_name' => $request->getMetricName(),
-        ]);
+        $requestParamHeaders['metric_name'] = $metricName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteLogMetric', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
@@ -410,10 +410,10 @@ class MetricsServiceV2GapicClient
     public function getLogMetric($metricName, array $optionalArgs = [])
     {
         $request = new GetLogMetricRequest();
+        $requestParamHeaders = [];
         $request->setMetricName($metricName);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'metric_name' => $request->getMetricName(),
-        ]);
+        $requestParamHeaders['metric_name'] = $metricName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetLogMetric', LogMetric::class, $optionalArgs, $request)->wait();
     }
@@ -473,7 +473,9 @@ class MetricsServiceV2GapicClient
     public function listLogMetrics($parent, array $optionalArgs = [])
     {
         $request = new ListLogMetricsRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageToken'])) {
             $request->setPageToken($optionalArgs['pageToken']);
         }
@@ -482,9 +484,7 @@ class MetricsServiceV2GapicClient
             $request->setPageSize($optionalArgs['pageSize']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListLogMetrics', $optionalArgs, ListLogMetricsResponse::class, $request);
     }
@@ -529,11 +529,11 @@ class MetricsServiceV2GapicClient
     public function updateLogMetric($metricName, $metric, array $optionalArgs = [])
     {
         $request = new UpdateLogMetricRequest();
+        $requestParamHeaders = [];
         $request->setMetricName($metricName);
         $request->setMetric($metric);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'metric_name' => $request->getMetricName(),
-        ]);
+        $requestParamHeaders['metric_name'] = $metricName;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateLogMetric', LogMetric::class, $optionalArgs, $request)->wait();
     }

--- a/tests/Integration/goldens/redis/src/V1/Gapic/CloudRedisGapicClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Gapic/CloudRedisGapicClient.php
@@ -452,12 +452,12 @@ class CloudRedisGapicClient
     public function createInstance($parent, $instanceId, $instance, array $optionalArgs = [])
     {
         $request = new CreateInstanceRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setInstanceId($instanceId);
         $request->setInstance($instance);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParamHeaders['parent'] = $parent;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('CreateInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -520,10 +520,10 @@ class CloudRedisGapicClient
     public function deleteInstance($name, array $optionalArgs = [])
     {
         $request = new DeleteInstanceRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('DeleteInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -594,11 +594,11 @@ class CloudRedisGapicClient
     public function exportInstance($name, $outputConfig, array $optionalArgs = [])
     {
         $request = new ExportInstanceRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setOutputConfig($outputConfig);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('ExportInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -667,14 +667,14 @@ class CloudRedisGapicClient
     public function failoverInstance($name, array $optionalArgs = [])
     {
         $request = new FailoverInstanceRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['dataProtectionMode'])) {
             $request->setDataProtectionMode($optionalArgs['dataProtectionMode']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('FailoverInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -713,10 +713,10 @@ class CloudRedisGapicClient
     public function getInstance($name, array $optionalArgs = [])
     {
         $request = new GetInstanceRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetInstance', Instance::class, $optionalArgs, $request)->wait();
     }
@@ -789,11 +789,11 @@ class CloudRedisGapicClient
     public function importInstance($name, $inputConfig, array $optionalArgs = [])
     {
         $request = new ImportInstanceRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setInputConfig($inputConfig);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('ImportInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -861,7 +861,9 @@ class CloudRedisGapicClient
     public function listInstances($parent, array $optionalArgs = [])
     {
         $request = new ListInstancesRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -870,9 +872,7 @@ class CloudRedisGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'parent' => $request->getParent(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->getPagedListResponse('ListInstances', $optionalArgs, ListInstancesResponse::class, $request);
     }
@@ -948,11 +948,11 @@ class CloudRedisGapicClient
     public function updateInstance($updateMask, $instance, array $optionalArgs = [])
     {
         $request = new UpdateInstanceRequest();
+        $requestParamHeaders = [];
         $request->setUpdateMask($updateMask);
         $request->setInstance($instance);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'instance.name' => $request->getInstance()->getName(),
-        ]);
+        $requestParamHeaders['instance.name'] = $instance->getName();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('UpdateInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
@@ -1019,11 +1019,11 @@ class CloudRedisGapicClient
     public function upgradeInstance($name, $redisVersion, array $optionalArgs = [])
     {
         $request = new UpgradeInstanceRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setRedisVersion($redisVersion);
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'name' => $request->getName(),
-        ]);
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startOperationsCall('UpgradeInstance', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Gapic/RoutingHeadersGapicClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Gapic/RoutingHeadersGapicClient.php
@@ -191,10 +191,14 @@ class RoutingHeadersGapicClient
     public function deleteMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('DeleteMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
@@ -228,10 +232,14 @@ class RoutingHeadersGapicClient
     public function getMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
@@ -302,10 +310,14 @@ class RoutingHeadersGapicClient
     public function getNoTemplateMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('GetNoTemplateMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
@@ -342,6 +354,7 @@ class RoutingHeadersGapicClient
     public function nestedMethod($anotherName, array $optionalArgs = [])
     {
         $request = new NestedRequest();
+        $requestParamHeaders = [];
         $request->setAnotherName($anotherName);
         if (isset($optionalArgs['nest1'])) {
             $request->setNest1($optionalArgs['nest1']);
@@ -351,6 +364,8 @@ class RoutingHeadersGapicClient
             $request->setName($optionalArgs['name']);
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('NestedMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
@@ -387,18 +402,19 @@ class RoutingHeadersGapicClient
     public function nestedMultiMethod($anotherName, array $optionalArgs = [])
     {
         $request = new NestedRequest();
+        $requestParamHeaders = [];
         $request->setAnotherName($anotherName);
+        $requestParamHeaders['another_name'] = $anotherName;
         if (isset($optionalArgs['nest1'])) {
             $request->setNest1($optionalArgs['nest1']);
         }
 
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'another_name' => $request->getAnotherName(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('NestedMultiMethod', Response::class, $optionalArgs, $request)->wait();
     }
@@ -445,30 +461,33 @@ class RoutingHeadersGapicClient
     public function orderingMethod($a, $b, $d, $c, $e, array $optionalArgs = [])
     {
         $request = new OrderRequest();
+        $requestParamHeaders = [];
         $request->setA($a);
         $request->setB($b);
         $request->setD($d);
         $request->setC($c);
         $request->setE($e);
+        $requestParamHeaders['a'] = $a;
+        $requestParamHeaders['c'] = $b;
+        $requestParamHeaders['b'] = $d;
+        $requestParamHeaders['d'] = $c;
+        $requestParamHeaders['e'] = $e;
         if (isset($optionalArgs['aId'])) {
             $request->setAId($optionalArgs['aId']);
+            $requestParamHeaders['a_id'] = $optionalArgs['aId'];
         }
 
         if (isset($optionalArgs['bId'])) {
             $request->setBId($optionalArgs['bId']);
+            $requestParamHeaders['b_id'] = $optionalArgs['bId'];
         }
 
         if (isset($optionalArgs['aa'])) {
             $request->setAa($optionalArgs['aa']);
+            $requestParamHeaders['aa'] = $optionalArgs['aa'];
         }
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-            'a' => $request->getA(),
-            'c' => $request->getC(),
-            'b' => $request->getB(),
-            'd' => $request->getD(),
-            'e' => $request->getE(),
-        ]);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('OrderingMethod', Response::class, $optionalArgs, $request)->wait();
     }
@@ -503,10 +522,14 @@ class RoutingHeadersGapicClient
     public function patchMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('PatchMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
@@ -540,10 +563,14 @@ class RoutingHeadersGapicClient
     public function postMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('PostMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
@@ -577,10 +604,14 @@ class RoutingHeadersGapicClient
     public function putMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('PutMethod', Response::class, $optionalArgs, $request)->wait();
     }
 }


### PR DESCRIPTION
Fixes request parameter handling bugs compared to the monolith's behavior. Below is the file diff compared to the monolith-produced libraries.
- Container ([PR](https://github.com/googleapis/google-cloud-php/pull/3925))
- WebSecurityScanner ([PR](https://github.com/googleapis/google-cloud-php/pull/3916))
- Language ([PR](https://github.com/googleapis/google-cloud-php/pull/3917))
- BigQueryReservation ([PR](https://github.com/googleapis/google-cloud-php/pull/3918))

# Context

**Summary.** Analysis of the headers generated by the monolith for PHP client libraries, potential issues, and proposed fixes in the microgenerator.

**Issue.** The monolith populated request parameters in a manner that does not align with go/aip/4222. Request parameter values were produced based on unclear conditions, which led to inconsistent behavior with the same use case in other microgenerators. 

While the monolith usually generated request headers if and only if one HTTP binding was present, it would sometimes do so even when there were multiple bindings. Compare this to Java, where one request parameter is populated per HTTP binding. 

**Monolith Behaviour**
- [UpdateDocument](https://github.com/googleapis/googleapis/blob/master/google/firestore/v1/firestore.proto#L70) has one HTTP binding, and [one request parameter](https://github.com/googleapis/google-cloud-php-firestore/blob/master/src/V1beta1/Gapic/FirestoreGapicClient.php#L698) generated.. This is correct, and aligns with other generators’ behavior (e.g. [Java](https://github.com/googleapis/java-firestore/blob/master/google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/GrpcFirestoreStub.java#L300)).
- [UpdateNodePool](https://github.com/googleapis/googleapis/blob/master/google/container/v1/cluster_service.proto#L105) has one HTTP Put binding, and several POST bindings, but only the [first one](https://github.com/googleapis/google-cloud-php-container/blob/master/src/V1/Gapic/ClusterManagerGapicClient.php#L615) is accounted for.
  - For comparison, [Java](https://github.com/googleapis/java-container/blob/master/google-cloud-container/src/main/java/com/google/cloud/container/v1/stub/GrpcClusterManagerStub.java#L547) populates all the request parameters.
  - Similarly, [GetOperation](https://github.com/googleapis/googleapis/blob/master/google/container/v1/cluster_service.proto#L248) results in this [monolithic PHP](https://github.com/googleapis/google-cloud-php-container/blob/master/src/V1/Gapic/ClusterManagerGapicClient.php#L1421) behaviour, which differs from the microgenerated [Java client](https://github.com/googleapis/java-container/blob/master/google-cloud-container/src/main/java/com/google/cloud/container/v1/stub/GrpcClusterManagerStub.java#L710).
- [SubmitJob](https://github.com/googleapis/googleapis/blob/master/google/cloud/dataproc/v1/jobs.proto#L38) has two HTTP variables, but [no request parameter](https://github.com/googleapis/google-cloud-php-dataproc/blob/master/src/V1/Gapic/JobControllerGapicClient.php#L259) generated. 
  - For comparison, [Java](https://github.com/googleapis/java-dataproc/blob/master/google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/GrpcJobControllerStub.java#L190) populates both request parameters.
- [CreateDocument](https://github.com/googleapis/googleapis/blob/master/google/firestore/v1/firestore.proto#L196) has the HTTP variable `parent`, but the monolith [does not set](https://github.com/googleapis/google-cloud-php-firestore/blob/master/src/V1beta1/Gapic/FirestoreGapicClient.php#L642) this request parameter. (Java wrongly does not set this as well.)
- [CancelOperation](https://github.com/googleapis/googleapis/blob/master/google/container/v1/cluster_service.proto#L260) has the HTTP variable `name`. This is optionally passed into the corresponding PHP method, since the monolith was never upgraded to use the `method_signature` annotation. However, the monolith [still sets](https://github.com/googleapis/google-cloud-php-container/blob/master/src/V1/Gapic/ClusterManagerGapicClient.php#L1492) this request parameter, which can lead to a client-side PHP error if that optional argument is not provided.
	
  The monolith also does not set any of the other HTTP variables if they are present, in violation of [aip.dev/4222](aip.dev/4222). For comparison, [Java](https://github.com/googleapis/java-container/blob/master/google-cloud-container/src/main/java/com/google/cloud/container/v1/stub/GrpcClusterManagerStub.java#L710) sets these parameters.
- Given a proto like [this one](https://github.com/googleapis/gapic-generator-php/blob/master/tests/Unit/ProtoTests/RoutingHeaders/routing-headers.proto#L17), the monolith used to populate the `name` parameter. However, this could result in an error if that field is not set in the request. This violates the guidance in [aip.dev/4222](aip.dev/4222) that unset named parameters should not be included. The monolith currently generates the following, which will result in an error in PHP.
 
```
 $request = new SimpleRequest();
  if (isset($optionalArgs['name'])) {
      $request->setName($optionalArgs['name']);
  }
  $requestParams = new RequestParamsHeaderDescriptor([
      'name' => $request->getName()
  ]);
  // Truncated.
  return $this->startCall(
   'DeleteMethod', Response::class, $optionalArgs, $request)->wait();
```

**Proposal.** We can fix this in the PHP microgenerator by populating request parameters for every HTTP binding present. Since PHP constructs the request message using those method parameters, this adheres to [aip.dev/4222](aip.dev/4222), which states that any set variables in additional_bindings should be present.

This will require handling RPCs that have HTTP variables that are not marked as required fields on the corresponding request message. In this edge case, this parameter will not be set even if it is passed in via $optionalArgs to the PHP method. Since the generated surface would change significantly, we consider this out of scope for the microgenerator migration. 

The change for such a case should look like the following. We will not handle nested fields, since the generated PHP code for protobufs do not allow us to check whether a field is set or not. 

```
  $request = new SimpleRequest();
  $requestParamHeaders = [];

  $request->setRequiredArg($requiredArg);
  $requestParamHeaders[‘required_arg.foo’] = $requiredArg->getFoo();

  if (isset($optionalArgs['name'])) {
      $request->setName($optionalArgs['name']);
      $requestParamHeaders[‘name’] = $optionalArgs[‘name’];
  }

  $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
  $optionalArgs['headers'] = isset($optionalArgs['headers'])
      ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
      : $requestParams->getHeader();

  return $this->startCall(
   'DeleteMethod', Response::class, $optionalArgs, $request)->wait();
```

**Effects of this Change.** Extra attention will need to be given to APIs’ request parameters while migrating to the microgenerator, as the monolith-produced source cannot be used as a reliable reference.

**Alternatives**
- _Option 1_ - Attempt to recreate the monolith’s behavior. This is undesirable because it’s buggy, carries technical debt forward, and significant resources would be needed to parse the existing behavior.
- _Option 2_ - Generate request parameters for only the first binding present. This would not align with [aip.dev/4222](aip.dev/4222) or other generators, so the benefits of this partial implementation are unclear.
- _Option 3_ - Ignore the edge case handling above, and simply set request parameters for the required arguments present. This could potentially break clients like [Container](https://github.com/googleapis/google-cloud-php-container/blob/master/src/V1/Gapic/ClusterManagerGapicClient.php#L1492), which assume that optional fields’ parameters are being set.
