### PR TITLE
[ggp] feat: Initialize required fields in tests, fix potential missing field errors

### DIFF
--- a/src/Generation/GapicClientExamplesGenerator.php
+++ b/src/Generation/GapicClientExamplesGenerator.php
@@ -96,7 +96,9 @@ class GapicClientExamplesGenerator
                         $initCode = AST::assign($var, $f->exampleValue($this->ctx));
                     } else {
                         $serviceClient = AST::var($this->serviceDetails->clientVarName);
-                        $initCode = $this->prod->fieldInit($method, $f, fn () => [$var, $varName], $serviceClient);
+                        $astAcc = Vector::new([]);
+                        $this->prod->fieldInit($method, $f, $var, $varName, $serviceClient, $astAcc);
+                        $initCode = $astAcc === null ? $astAcc : $astAcc->flatten();
                     }
                     return [$initCode, $var, $f->isRequired];
                 }

--- a/src/Generation/TestNameValueProducer.php
+++ b/src/Generation/TestNameValueProducer.php
@@ -94,9 +94,7 @@ class TestNameValueProducer
 
     public function perFieldRequest(MethodDetails $method): array
     {
-        // Handle test request value generation, including using values
-        // specified in the gapic-config if present.
-
+        // Handle test request value generation.
         $perField = static::filterFirstOneOf($method->allFields)
             ->map(fn ($f) => new class($this, $method, $f) {
                 public function __construct($prod, $method, $f)
@@ -106,12 +104,11 @@ class TestNameValueProducer
                     // Name generation is stateful.
                     // TODO: Consider refactoring this.
                     $this->field = $f;
-                    $fnVarName = function () use ($prod, $f) {
-                        $this->name = ($f->useResourceTestValue ? 'formatted_' : '') . $prod->name($f->name);
-                        $this->var = AST::var(Helpers::toCamelCase($this->name));
-                        return [$this->var, $this->name];
-                    };
-                    $this->initCode = $prod->fieldInit($method, $f, $fnVarName);
+                    $this->name = ($f->useResourceTestValue ? 'formatted_' : '') . $prod->name($f->name);
+                    $this->var = AST::var(Helpers::toCamelCase($this->name));
+                    $astAcc = Vector::new([]);
+                    $prod->fieldInit($method, $f, $this->var, $this->name, null, $astAcc);
+                    $this->initCode = $astAcc;
                 }
 
                 public FieldDetails $field;
@@ -119,10 +116,10 @@ class TestNameValueProducer
                 public Variable $var;
                 public $initCode;
             })
-            ->filter(fn ($x) => !is_null($x->initCode))
-            ->orderBy(fn ($x) => $x->field->isRequired ? 0 : 1);
+            ->filter(fn ($x) => !is_null($x->initCode) && $x->field->isRequired);
 
         $callArgs = $perField
+            ->flatten()
             ->filter(fn ($x) => $x->field->isRequired)
             ->map(fn ($x) => $x->var);
         if ($perField->any(fn ($x) => !$x->field->isRequired)) {
@@ -140,14 +137,38 @@ class TestNameValueProducer
 
     // TODO: Refactor this to share code with very similar code in GapicClientExamplesGenerator.php
     // TODO: Handle nesting - see PublishSeries.
-    public function fieldInit(MethodDetails $method, FieldDetails $field, callable $fnVarName, ?Variable $clientVar = null)
+    public function fieldInit(MethodDetails $method, FieldDetails $field, $fieldVar, string $fieldVarName, ?Variable $clientVar, Vector &$astAcc)
     {
         if (!$field->isRequired) {
-            return null;
+            $astAcc = $astAcc->append(null);
+            return;
         }
-        [$var, $name] = $fnVarName();
+
+        // This field is a non-primitive type. Descend into required sub-fields.
+        // Does not yet handle repeated message fields.
+        if ($field->isMessage && !$field->isEnum && !$field->isRepeated) {
+            $astAcc = $astAcc->append(AST::assign($fieldVar, $this->value($field, $fieldVarName)));
+
+            $msg = $this->catalog->msgsByFullname[$field->desc->desc->getMessageType()];
+            $allSubFields = Vector::new($msg->getField())->map(fn ($x) => new FieldDetails($this->catalog, $x));
+            $requiredSubFields = $allSubFields->filter(fn ($x) => $x->isRequired);
+            if (empty($requiredSubFields) && !$field->useResourceTestValue) {
+                $astAcc = $astAcc->append(AST::assign($fieldVar, $this->value($field, $fieldVarName)));
+                return;
+            }
+
+            foreach ($requiredSubFields as $subField) {
+                $subFieldVarName = Helpers::toCamelCase($field->name . "_" . $subField->name);
+                $subFieldVar = AST::var($subFieldVarName);
+                $this->fieldInit($method, $subField, $subFieldVar, $subFieldVarName, $clientVar, $astAcc);
+                $astAcc = $astAcc->append(AST::call($fieldVar, $subField->setter)($subFieldVar));
+            }
+            return;
+        }
+
         if (!$field->useResourceTestValue) {
-            return AST::assign($var, $this->value($field, $name));
+            $astAcc = $astAcc->append(AST::assign($fieldVar, $this->value($field, $fieldVarName)));
+            return;
         }
 
         // IMPORTANT: The template name getters are always generated with the first
@@ -165,7 +186,8 @@ class TestNameValueProducer
         if ($field->isRepeated) {
             $varValue = AST::array([$varValue]);
         }
-        return AST::assign($var, $varValue);
+        $astAcc = $astAcc->append(AST::assign($fieldVar, $varValue));
+        return;
     }
 
     // Reproduce exactly the Java test value generation:

--- a/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
+++ b/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
@@ -38,6 +38,7 @@ use Google\Cloud\Asset\V1\AssetServiceClient;
 use Google\Cloud\Asset\V1\BatchGetAssetsHistoryResponse;
 use Google\Cloud\Asset\V1\ExportAssetsResponse;
 use Google\Cloud\Asset\V1\Feed;
+use Google\Cloud\Asset\V1\FeedOutputConfig;
 use Google\Cloud\Asset\V1\IamPolicyAnalysisOutputConfig;
 use Google\Cloud\Asset\V1\IamPolicyAnalysisQuery;
 use Google\Cloud\Asset\V1\IamPolicySearchResult;
@@ -105,6 +106,8 @@ class AssetServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $analysisQuery = new IamPolicyAnalysisQuery();
+        $analysisQueryScope = 'analysisQueryScope-495018392';
+        $analysisQuery->setScope($analysisQueryScope);
         $response = $client->analyzeIamPolicy($analysisQuery);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -139,6 +142,8 @@ class AssetServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $analysisQuery = new IamPolicyAnalysisQuery();
+        $analysisQueryScope = 'analysisQueryScope-495018392';
+        $analysisQuery->setScope($analysisQueryScope);
         try {
             $client->analyzeIamPolicy($analysisQuery);
             // If the $client method call did not throw, fail the test
@@ -185,6 +190,8 @@ class AssetServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
         // Mock request
         $analysisQuery = new IamPolicyAnalysisQuery();
+        $analysisQueryScope = 'analysisQueryScope-495018392';
+        $analysisQuery->setScope($analysisQueryScope);
         $outputConfig = new IamPolicyAnalysisOutputConfig();
         $response = $client->analyzeIamPolicyLongrunning($analysisQuery, $outputConfig);
         $this->assertFalse($response->isDone());
@@ -254,6 +261,8 @@ class AssetServiceClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $analysisQuery = new IamPolicyAnalysisQuery();
+        $analysisQueryScope = 'analysisQueryScope-495018392';
+        $analysisQuery->setScope($analysisQueryScope);
         $outputConfig = new IamPolicyAnalysisOutputConfig();
         $response = $client->analyzeIamPolicyLongrunning($analysisQuery, $outputConfig);
         $this->assertFalse($response->isDone());
@@ -358,6 +367,10 @@ class AssetServiceClientTest extends GeneratedTest
         $parent = 'parent-995424086';
         $feedId = 'feedId-976011428';
         $feed = new Feed();
+        $feedName = 'feedName-192096951';
+        $feed->setName($feedName);
+        $feedFeedOutputConfig = new FeedOutputConfig();
+        $feed->setFeedOutputConfig($feedFeedOutputConfig);
         $response = $client->createFeed($parent, $feedId, $feed);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -398,6 +411,10 @@ class AssetServiceClientTest extends GeneratedTest
         $parent = 'parent-995424086';
         $feedId = 'feedId-976011428';
         $feed = new Feed();
+        $feedName = 'feedName-192096951';
+        $feed->setName($feedName);
+        $feedFeedOutputConfig = new FeedOutputConfig();
+        $feed->setFeedOutputConfig($feedFeedOutputConfig);
         try {
             $client->createFeed($parent, $feedId, $feed);
             // If the $client method call did not throw, fail the test
@@ -884,6 +901,10 @@ class AssetServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $feed = new Feed();
+        $feedName = 'feedName-192096951';
+        $feed->setName($feedName);
+        $feedFeedOutputConfig = new FeedOutputConfig();
+        $feed->setFeedOutputConfig($feedFeedOutputConfig);
         $updateMask = new FieldMask();
         $response = $client->updateFeed($feed, $updateMask);
         $this->assertEquals($expectedResponse, $response);
@@ -921,6 +942,10 @@ class AssetServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $feed = new Feed();
+        $feedName = 'feedName-192096951';
+        $feed->setName($feedName);
+        $feedFeedOutputConfig = new FeedOutputConfig();
+        $feed->setFeedOutputConfig($feedFeedOutputConfig);
         $updateMask = new FieldMask();
         try {
             $client->updateFeed($feed, $updateMask);

--- a/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
+++ b/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
@@ -153,8 +153,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -163,8 +163,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -228,7 +228,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
         // Mock response
         $name = 'name3373707';
-        $zone = 'zone3744684';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -238,7 +238,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
         $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -308,7 +308,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
         // Mock response
         $name = 'name3373707';
-        $zone = 'zone3744684';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -318,7 +318,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
         $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -387,8 +387,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -397,8 +397,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -461,8 +461,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -471,8 +471,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -535,7 +535,7 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
+        $name2 = 'name2-1052831874';
         $description = 'description-1724546052';
         $initialNodeCount = 1682564205;
         $loggingService = 'loggingService-1700501035';
@@ -546,7 +546,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $enableKubernetesAlpha = false;
         $labelFingerprint = 'labelFingerprint714995737';
         $selfLink = 'selfLink-1691268851';
-        $zone = 'zone3744684';
+        $zone2 = 'zone2-696322977';
         $endpoint = 'endpoint1741102485';
         $initialClusterVersion = 'initialClusterVersion-276373352';
         $currentMasterVersion = 'currentMasterVersion-920953983';
@@ -561,7 +561,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $enableTpu = false;
         $tpuIpv4CidrBlock = 'tpuIpv4CidrBlock1137906646';
         $expectedResponse = new Cluster();
-        $expectedResponse->setName($name);
+        $expectedResponse->setName($name2);
         $expectedResponse->setDescription($description);
         $expectedResponse->setInitialNodeCount($initialNodeCount);
         $expectedResponse->setLoggingService($loggingService);
@@ -572,7 +572,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $expectedResponse->setEnableKubernetesAlpha($enableKubernetesAlpha);
         $expectedResponse->setLabelFingerprint($labelFingerprint);
         $expectedResponse->setSelfLink($selfLink);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setEndpoint($endpoint);
         $expectedResponse->setInitialClusterVersion($initialClusterVersion);
         $expectedResponse->setCurrentMasterVersion($currentMasterVersion);
@@ -697,14 +697,14 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
+        $name2 = 'name2-1052831874';
         $initialNodeCount = 1682564205;
         $selfLink = 'selfLink-1691268851';
         $version = 'version351608024';
         $statusMessage = 'statusMessage-239442758';
         $podIpv4CidrSize = 1098768716;
         $expectedResponse = new NodePool();
-        $expectedResponse->setName($name);
+        $expectedResponse->setName($name2);
         $expectedResponse->setInitialNodeCount($initialNodeCount);
         $expectedResponse->setSelfLink($selfLink);
         $expectedResponse->setVersion($version);
@@ -765,8 +765,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -775,8 +775,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1133,8 +1133,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1143,8 +1143,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1207,8 +1207,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1217,8 +1217,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1287,8 +1287,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1297,8 +1297,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1371,8 +1371,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1381,8 +1381,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1451,8 +1451,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1461,8 +1461,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1531,8 +1531,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1541,8 +1541,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1611,7 +1611,7 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
+        $name2 = 'name2-1052831874';
         $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
@@ -1621,7 +1621,7 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
+        $expectedResponse->setName($name2);
         $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
@@ -1703,8 +1703,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1713,8 +1713,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1787,8 +1787,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1797,8 +1797,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1867,8 +1867,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1877,8 +1877,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -1947,8 +1947,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -1957,8 +1957,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -2027,8 +2027,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -2037,8 +2037,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -2107,8 +2107,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -2117,8 +2117,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -2187,8 +2187,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -2197,8 +2197,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -2261,8 +2261,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -2271,8 +2271,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -2341,8 +2341,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -2351,8 +2351,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);
@@ -2421,8 +2421,8 @@ class ClusterManagerClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
-        $zone = 'zone3744684';
+        $name2 = 'name2-1052831874';
+        $zone2 = 'zone2-696322977';
         $detail = 'detail-1335224239';
         $statusMessage = 'statusMessage-239442758';
         $selfLink = 'selfLink-1691268851';
@@ -2431,8 +2431,8 @@ class ClusterManagerClientTest extends GeneratedTest
         $startTime = 'startTime-1573145462';
         $endTime = 'endTime1725551537';
         $expectedResponse = new Operation();
-        $expectedResponse->setName($name);
-        $expectedResponse->setZone($zone);
+        $expectedResponse->setName($name2);
+        $expectedResponse->setZone($zone2);
         $expectedResponse->setDetail($detail);
         $expectedResponse->setStatusMessage($statusMessage);
         $expectedResponse->setSelfLink($selfLink);

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
@@ -32,7 +32,11 @@ use Google\ApiCore\Testing\MockTransport;
 
 use Google\Cloud\Dataproc\V1\AutoscalingPolicy;
 use Google\Cloud\Dataproc\V1\AutoscalingPolicyServiceClient;
+use Google\Cloud\Dataproc\V1\BasicAutoscalingAlgorithm;
+use Google\Cloud\Dataproc\V1\BasicYarnAutoscalingConfig;
+use Google\Cloud\Dataproc\V1\InstanceGroupAutoscalingPolicyConfig;
 use Google\Cloud\Dataproc\V1\ListAutoscalingPoliciesResponse;
+use Google\Protobuf\Duration;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;
 use stdClass;
@@ -91,6 +95,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $policy = new AutoscalingPolicy();
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
+        $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
+        $workerConfigMaxInstances = 339756550;
+        $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
+        $policy->setWorkerConfig($policyWorkerConfig);
         $response = $client->createAutoscalingPolicy($formattedParent, $policy);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -128,6 +146,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $policy = new AutoscalingPolicy();
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
+        $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
+        $workerConfigMaxInstances = 339756550;
+        $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
+        $policy->setWorkerConfig($policyWorkerConfig);
         try {
             $client->createAutoscalingPolicy($formattedParent, $policy);
             // If the $client method call did not throw, fail the test
@@ -359,6 +391,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $policy = new AutoscalingPolicy();
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
+        $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
+        $workerConfigMaxInstances = 339756550;
+        $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
+        $policy->setWorkerConfig($policyWorkerConfig);
         $response = $client->updateAutoscalingPolicy($policy);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -393,6 +439,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $policy = new AutoscalingPolicy();
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
+        $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
+        $workerConfigMaxInstances = 339756550;
+        $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
+        $policy->setWorkerConfig($policyWorkerConfig);
         try {
             $client->updateAutoscalingPolicy($policy);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/ClusterControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/ClusterControllerClientTest.php
@@ -32,8 +32,9 @@ use Google\ApiCore\Testing\GeneratedTest;
 
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\Cluster;
-use Google\Cloud\Dataproc\V1\ClusterControllerClient;
+use Google\Cloud\Dataproc\V1\ClusterConfig;
 
+use Google\Cloud\Dataproc\V1\ClusterControllerClient;
 use Google\Cloud\Dataproc\V1\DiagnoseClusterResults;
 use Google\Cloud\Dataproc\V1\ListClustersResponse;
 use Google\LongRunning\GetOperationRequest;
@@ -119,6 +120,12 @@ class ClusterControllerClientTest extends GeneratedTest
         $projectId = 'projectId-1969970175';
         $region = 'region-934795532';
         $cluster = new Cluster();
+        $clusterProjectId = 'clusterProjectId-927164102';
+        $cluster->setProjectId($clusterProjectId);
+        $clusterClusterName = 'clusterClusterName2146953547';
+        $cluster->setClusterName($clusterClusterName);
+        $clusterConfig = new ClusterConfig();
+        $cluster->setConfig($clusterConfig);
         $response = $client->createCluster($projectId, $region, $cluster);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -191,6 +198,12 @@ class ClusterControllerClientTest extends GeneratedTest
         $projectId = 'projectId-1969970175';
         $region = 'region-934795532';
         $cluster = new Cluster();
+        $clusterProjectId = 'clusterProjectId-927164102';
+        $cluster->setProjectId($clusterProjectId);
+        $clusterClusterName = 'clusterClusterName2146953547';
+        $cluster->setClusterName($clusterClusterName);
+        $clusterConfig = new ClusterConfig();
+        $cluster->setConfig($clusterConfig);
         $response = $client->createCluster($projectId, $region, $cluster);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -667,6 +680,12 @@ class ClusterControllerClientTest extends GeneratedTest
         $region = 'region-934795532';
         $clusterName = 'clusterName-1018081872';
         $cluster = new Cluster();
+        $clusterProjectId = 'clusterProjectId-927164102';
+        $cluster->setProjectId($clusterProjectId);
+        $clusterClusterName = 'clusterClusterName2146953547';
+        $cluster->setClusterName($clusterClusterName);
+        $clusterConfig = new ClusterConfig();
+        $cluster->setConfig($clusterConfig);
         $updateMask = new FieldMask();
         $response = $client->updateCluster($projectId, $region, $clusterName, $cluster, $updateMask);
         $this->assertFalse($response->isDone());
@@ -745,6 +764,12 @@ class ClusterControllerClientTest extends GeneratedTest
         $region = 'region-934795532';
         $clusterName = 'clusterName-1018081872';
         $cluster = new Cluster();
+        $clusterProjectId = 'clusterProjectId-927164102';
+        $cluster->setProjectId($clusterProjectId);
+        $clusterClusterName = 'clusterClusterName2146953547';
+        $cluster->setClusterName($clusterClusterName);
+        $clusterConfig = new ClusterConfig();
+        $cluster->setConfig($clusterConfig);
         $updateMask = new FieldMask();
         $response = $client->updateCluster($projectId, $region, $clusterName, $cluster, $updateMask);
         $this->assertFalse($response->isDone());

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/JobControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/JobControllerClientTest.php
@@ -34,6 +34,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\Job;
 use Google\Cloud\Dataproc\V1\JobControllerClient;
 
+use Google\Cloud\Dataproc\V1\JobPlacement;
 use Google\Cloud\Dataproc\V1\ListJobsResponse;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
@@ -403,6 +404,10 @@ class JobControllerClientTest extends GeneratedTest
         $projectId = 'projectId-1969970175';
         $region = 'region-934795532';
         $job = new Job();
+        $jobPlacement = new JobPlacement();
+        $placementClusterName = 'placementClusterName1028110208';
+        $jobPlacement->setClusterName($placementClusterName);
+        $job->setPlacement($jobPlacement);
         $response = $client->submitJob($projectId, $region, $job);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -443,6 +448,10 @@ class JobControllerClientTest extends GeneratedTest
         $projectId = 'projectId-1969970175';
         $region = 'region-934795532';
         $job = new Job();
+        $jobPlacement = new JobPlacement();
+        $placementClusterName = 'placementClusterName1028110208';
+        $jobPlacement->setClusterName($placementClusterName);
+        $job->setPlacement($jobPlacement);
         try {
             $client->submitJob($projectId, $region, $job);
             // If the $client method call did not throw, fail the test
@@ -499,6 +508,10 @@ class JobControllerClientTest extends GeneratedTest
         $projectId = 'projectId-1969970175';
         $region = 'region-934795532';
         $job = new Job();
+        $jobPlacement = new JobPlacement();
+        $placementClusterName = 'placementClusterName1028110208';
+        $jobPlacement->setClusterName($placementClusterName);
+        $job->setPlacement($jobPlacement);
         $response = $client->submitJobAsOperation($projectId, $region, $job);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -571,6 +584,10 @@ class JobControllerClientTest extends GeneratedTest
         $projectId = 'projectId-1969970175';
         $region = 'region-934795532';
         $job = new Job();
+        $jobPlacement = new JobPlacement();
+        $placementClusterName = 'placementClusterName1028110208';
+        $jobPlacement->setClusterName($placementClusterName);
+        $job->setPlacement($jobPlacement);
         $response = $client->submitJobAsOperation($projectId, $region, $job);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -619,6 +636,10 @@ class JobControllerClientTest extends GeneratedTest
         $region = 'region-934795532';
         $jobId = 'jobId-1154752291';
         $job = new Job();
+        $jobPlacement = new JobPlacement();
+        $placementClusterName = 'placementClusterName1028110208';
+        $jobPlacement->setClusterName($placementClusterName);
+        $job->setPlacement($jobPlacement);
         $updateMask = new FieldMask();
         $response = $client->updateJob($projectId, $region, $jobId, $job, $updateMask);
         $this->assertEquals($expectedResponse, $response);
@@ -665,6 +686,10 @@ class JobControllerClientTest extends GeneratedTest
         $region = 'region-934795532';
         $jobId = 'jobId-1154752291';
         $job = new Job();
+        $jobPlacement = new JobPlacement();
+        $placementClusterName = 'placementClusterName1028110208';
+        $jobPlacement->setClusterName($placementClusterName);
+        $job->setPlacement($jobPlacement);
         $updateMask = new FieldMask();
         try {
             $client->updateJob($projectId, $region, $jobId, $job, $updateMask);

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/WorkflowTemplateServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/WorkflowTemplateServiceClientTest.php
@@ -34,6 +34,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\ListWorkflowTemplatesResponse;
 use Google\Cloud\Dataproc\V1\WorkflowTemplate;
 
+use Google\Cloud\Dataproc\V1\WorkflowTemplatePlacement;
 use Google\Cloud\Dataproc\V1\WorkflowTemplateServiceClient;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
@@ -98,6 +99,12 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $template = new WorkflowTemplate();
+        $templateId = 'templateId1304010549';
+        $template->setId($templateId);
+        $templatePlacement = new WorkflowTemplatePlacement();
+        $template->setPlacement($templatePlacement);
+        $templateJobs = [];
+        $template->setJobs($templateJobs);
         $response = $client->createWorkflowTemplate($formattedParent, $template);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -135,6 +142,12 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $template = new WorkflowTemplate();
+        $templateId = 'templateId1304010549';
+        $template->setId($templateId);
+        $templatePlacement = new WorkflowTemplatePlacement();
+        $template->setPlacement($templatePlacement);
+        $templateJobs = [];
+        $template->setJobs($templateJobs);
         try {
             $client->createWorkflowTemplate($formattedParent, $template);
             // If the $client method call did not throw, fail the test
@@ -222,11 +235,11 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         // Mock response
         $id = 'id3355';
         $name2 = 'name2-1052831874';
-        $version = 351608024;
+        $version2 = 1407102325;
         $expectedResponse = new WorkflowTemplate();
         $expectedResponse->setId($id);
         $expectedResponse->setName($name2);
-        $expectedResponse->setVersion($version);
+        $expectedResponse->setVersion($version2);
         $transport->addResponse($expectedResponse);
         // Mock request
         $formattedName = $client->workflowTemplateName('[PROJECT]', '[REGION]', '[WORKFLOW_TEMPLATE]');
@@ -311,6 +324,12 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $template = new WorkflowTemplate();
+        $templateId = 'templateId1304010549';
+        $template->setId($templateId);
+        $templatePlacement = new WorkflowTemplatePlacement();
+        $template->setPlacement($templatePlacement);
+        $templateJobs = [];
+        $template->setJobs($templateJobs);
         $response = $client->instantiateInlineWorkflowTemplate($formattedParent, $template);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -380,6 +399,12 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $template = new WorkflowTemplate();
+        $templateId = 'templateId1304010549';
+        $template->setId($templateId);
+        $templatePlacement = new WorkflowTemplatePlacement();
+        $template->setPlacement($templatePlacement);
+        $templateJobs = [];
+        $template->setJobs($templateJobs);
         $response = $client->instantiateInlineWorkflowTemplate($formattedParent, $template);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -616,6 +641,12 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $template = new WorkflowTemplate();
+        $templateId = 'templateId1304010549';
+        $template->setId($templateId);
+        $templatePlacement = new WorkflowTemplatePlacement();
+        $template->setPlacement($templatePlacement);
+        $templateJobs = [];
+        $template->setJobs($templateJobs);
         $response = $client->updateWorkflowTemplate($template);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -650,6 +681,12 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $template = new WorkflowTemplate();
+        $templateId = 'templateId1304010549';
+        $template->setId($templateId);
+        $templatePlacement = new WorkflowTemplatePlacement();
+        $template->setPlacement($templatePlacement);
+        $templateJobs = [];
+        $template->setJobs($templateJobs);
         try {
             $client->updateWorkflowTemplate($template);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
+++ b/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
@@ -39,12 +39,14 @@ use Google\Cloud\Kms\V1\DecryptResponse;
 use Google\Cloud\Kms\V1\Digest;
 use Google\Cloud\Kms\V1\EncryptResponse;
 use Google\Cloud\Kms\V1\ImportJob;
+use Google\Cloud\Kms\V1\ImportJob\ImportMethod;
 use Google\Cloud\Kms\V1\KeyManagementServiceClient;
 use Google\Cloud\Kms\V1\KeyRing;
 use Google\Cloud\Kms\V1\ListCryptoKeysResponse;
 use Google\Cloud\Kms\V1\ListCryptoKeyVersionsResponse;
 use Google\Cloud\Kms\V1\ListImportJobsResponse;
 use Google\Cloud\Kms\V1\ListKeyRingsResponse;
+use Google\Cloud\Kms\V1\ProtectionLevel;
 use Google\Cloud\Kms\V1\PublicKey;
 use Google\Cloud\Location\ListLocationsResponse;
 use Google\Cloud\Location\Location;
@@ -391,6 +393,10 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $formattedParent = $client->keyRingName('[PROJECT]', '[LOCATION]', '[KEY_RING]');
         $importJobId = 'importJobId-1620773193';
         $importJob = new ImportJob();
+        $importJobImportMethod = ImportMethod::IMPORT_METHOD_UNSPECIFIED;
+        $importJob->setImportMethod($importJobImportMethod);
+        $importJobProtectionLevel = ProtectionLevel::PROTECTION_LEVEL_UNSPECIFIED;
+        $importJob->setProtectionLevel($importJobProtectionLevel);
         $response = $client->createImportJob($formattedParent, $importJobId, $importJob);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -431,6 +437,10 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $formattedParent = $client->keyRingName('[PROJECT]', '[LOCATION]', '[KEY_RING]');
         $importJobId = 'importJobId-1620773193';
         $importJob = new ImportJob();
+        $importJobImportMethod = ImportMethod::IMPORT_METHOD_UNSPECIFIED;
+        $importJob->setImportMethod($importJobImportMethod);
+        $importJobProtectionLevel = ProtectionLevel::PROTECTION_LEVEL_UNSPECIFIED;
+        $importJob->setProtectionLevel($importJobProtectionLevel);
         try {
             $client->createImportJob($formattedParent, $importJobId, $importJob);
             // If the $client method call did not throw, fail the test
@@ -1777,11 +1787,11 @@ class KeyManagementServiceClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $name = 'name3373707';
+        $name2 = 'name2-1052831874';
         $locationId = 'locationId552319461';
         $displayName = 'displayName1615086568';
         $expectedResponse = new Location();
-        $expectedResponse->setName($name);
+        $expectedResponse->setName($name2);
         $expectedResponse->setLocationId($locationId);
         $expectedResponse->setDisplayName($displayName);
         $transport->addResponse($expectedResponse);

--- a/tests/Integration/goldens/logging/tests/Unit/V2/ConfigServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/ConfigServiceV2ClientTest.php
@@ -181,6 +181,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $exclusion = new LogExclusion();
+        $exclusionName = 'exclusionName1004344697';
+        $exclusion->setName($exclusionName);
+        $exclusionFilter = 'exclusionFilter-1414044954';
+        $exclusion->setFilter($exclusionFilter);
         $response = $client->createExclusion($formattedParent, $exclusion);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -218,6 +222,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $exclusion = new LogExclusion();
+        $exclusionName = 'exclusionName1004344697';
+        $exclusion->setName($exclusionName);
+        $exclusionFilter = 'exclusionFilter-1414044954';
+        $exclusion->setFilter($exclusionFilter);
         try {
             $client->createExclusion($formattedParent, $exclusion);
             // If the $client method call did not throw, fail the test
@@ -261,6 +269,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $sink = new LogSink();
+        $sinkName = 'sinkName508775358';
+        $sink->setName($sinkName);
+        $sinkDestination = 'sinkDestination-1018870917';
+        $sink->setDestination($sinkDestination);
         $response = $client->createSink($formattedParent, $sink);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -298,6 +310,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $sink = new LogSink();
+        $sinkName = 'sinkName508775358';
+        $sink->setName($sinkName);
+        $sinkDestination = 'sinkDestination-1018870917';
+        $sink->setDestination($sinkDestination);
         try {
             $client->createSink($formattedParent, $sink);
             // If the $client method call did not throw, fail the test
@@ -1506,6 +1522,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedName = $client->logExclusionName('[PROJECT]', '[EXCLUSION]');
         $exclusion = new LogExclusion();
+        $exclusionName = 'exclusionName1004344697';
+        $exclusion->setName($exclusionName);
+        $exclusionFilter = 'exclusionFilter-1414044954';
+        $exclusion->setFilter($exclusionFilter);
         $updateMask = new FieldMask();
         $response = $client->updateExclusion($formattedName, $exclusion, $updateMask);
         $this->assertEquals($expectedResponse, $response);
@@ -1546,6 +1566,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedName = $client->logExclusionName('[PROJECT]', '[EXCLUSION]');
         $exclusion = new LogExclusion();
+        $exclusionName = 'exclusionName1004344697';
+        $exclusion->setName($exclusionName);
+        $exclusionFilter = 'exclusionFilter-1414044954';
+        $exclusion->setFilter($exclusionFilter);
         $updateMask = new FieldMask();
         try {
             $client->updateExclusion($formattedName, $exclusion, $updateMask);
@@ -1590,6 +1614,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedSinkName = $client->logSinkName('[PROJECT]', '[SINK]');
         $sink = new LogSink();
+        $sinkName = 'sinkName508775358';
+        $sink->setName($sinkName);
+        $sinkDestination = 'sinkDestination-1018870917';
+        $sink->setDestination($sinkDestination);
         $response = $client->updateSink($formattedSinkName, $sink);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -1627,6 +1655,10 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedSinkName = $client->logSinkName('[PROJECT]', '[SINK]');
         $sink = new LogSink();
+        $sinkName = 'sinkName508775358';
+        $sink->setName($sinkName);
+        $sinkDestination = 'sinkDestination-1018870917';
+        $sink->setDestination($sinkDestination);
         try {
             $client->updateSink($formattedSinkName, $sink);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/logging/tests/Unit/V2/MetricsServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/MetricsServiceV2ClientTest.php
@@ -95,6 +95,10 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $metric = new LogMetric();
+        $metricName = 'metricName-610759589';
+        $metric->setName($metricName);
+        $metricFilter = 'metricFilter1248897352';
+        $metric->setFilter($metricFilter);
         $response = $client->createLogMetric($formattedParent, $metric);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -132,6 +136,10 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $metric = new LogMetric();
+        $metricName = 'metricName-610759589';
+        $metric->setName($metricName);
+        $metricFilter = 'metricFilter1248897352';
+        $metric->setFilter($metricFilter);
         try {
             $client->createLogMetric($formattedParent, $metric);
             // If the $client method call did not throw, fail the test
@@ -372,6 +380,10 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedMetricName = $client->logMetricName('[PROJECT]', '[METRIC]');
         $metric = new LogMetric();
+        $metricName = 'metricName-610759589';
+        $metric->setName($metricName);
+        $metricFilter = 'metricFilter1248897352';
+        $metric->setFilter($metricFilter);
         $response = $client->updateLogMetric($formattedMetricName, $metric);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -409,6 +421,10 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         // Mock request
         $formattedMetricName = $client->logMetricName('[PROJECT]', '[METRIC]');
         $metric = new LogMetric();
+        $metricName = 'metricName-610759589';
+        $metric->setName($metricName);
+        $metricFilter = 'metricFilter1248897352';
+        $metric->setFilter($metricFilter);
         try {
             $client->updateLogMetric($formattedMetricName, $metric);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
+++ b/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
@@ -35,6 +35,7 @@ use Google\Cloud\Redis\V1\CloudRedisClient;
 use Google\Cloud\Redis\V1\InputConfig;
 
 use Google\Cloud\Redis\V1\Instance;
+use Google\Cloud\Redis\V1\Instance\Tier;
 use Google\Cloud\Redis\V1\ListInstancesResponse;
 use Google\Cloud\Redis\V1\OutputConfig;
 use Google\LongRunning\GetOperationRequest;
@@ -140,6 +141,12 @@ class CloudRedisClientTest extends GeneratedTest
         $formattedParent = $client->locationName('[PROJECT]', '[LOCATION]');
         $instanceId = 'instanceId-2101995259';
         $instance = new Instance();
+        $instanceName = 'instanceName-737857344';
+        $instance->setName($instanceName);
+        $instanceTier = Tier::TIER_UNSPECIFIED;
+        $instance->setTier($instanceTier);
+        $instanceMemorySizeGb = 193936814;
+        $instance->setMemorySizeGb($instanceMemorySizeGb);
         $response = $client->createInstance($formattedParent, $instanceId, $instance);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -212,6 +219,12 @@ class CloudRedisClientTest extends GeneratedTest
         $formattedParent = $client->locationName('[PROJECT]', '[LOCATION]');
         $instanceId = 'instanceId-2101995259';
         $instance = new Instance();
+        $instanceName = 'instanceName-737857344';
+        $instance->setName($instanceName);
+        $instanceTier = Tier::TIER_UNSPECIFIED;
+        $instance->setTier($instanceTier);
+        $instanceMemorySizeGb = 193936814;
+        $instance->setMemorySizeGb($instanceMemorySizeGb);
         $response = $client->createInstance($formattedParent, $instanceId, $instance);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1024,6 +1037,12 @@ class CloudRedisClientTest extends GeneratedTest
         // Mock request
         $updateMask = new FieldMask();
         $instance = new Instance();
+        $instanceName = 'instanceName-737857344';
+        $instance->setName($instanceName);
+        $instanceTier = Tier::TIER_UNSPECIFIED;
+        $instance->setTier($instanceTier);
+        $instanceMemorySizeGb = 193936814;
+        $instance->setMemorySizeGb($instanceMemorySizeGb);
         $response = $client->updateInstance($updateMask, $instance);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -1093,6 +1112,12 @@ class CloudRedisClientTest extends GeneratedTest
         // Mock request
         $updateMask = new FieldMask();
         $instance = new Instance();
+        $instanceName = 'instanceName-737857344';
+        $instance->setName($instanceName);
+        $instanceTier = Tier::TIER_UNSPECIFIED;
+        $instance->setTier($instanceTier);
+        $instanceMemorySizeGb = 193936814;
+        $instance->setMemorySizeGb($instanceMemorySizeGb);
         $response = $client->updateInstance($updateMask, $instance);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());

--- a/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
+++ b/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
@@ -113,6 +113,8 @@ class SpeechClientTest extends GeneratedTest
         $operationsTransport->addResponse($completeOperation);
         // Mock request
         $config = new RecognitionConfig();
+        $configLanguageCode = 'configLanguageCode-537965113';
+        $config->setLanguageCode($configLanguageCode);
         $audio = new RecognitionAudio();
         $response = $client->longRunningRecognize($config, $audio);
         $this->assertFalse($response->isDone());
@@ -182,6 +184,8 @@ class SpeechClientTest extends GeneratedTest
         $operationsTransport->addResponse(null, $status);
         // Mock request
         $config = new RecognitionConfig();
+        $configLanguageCode = 'configLanguageCode-537965113';
+        $config->setLanguageCode($configLanguageCode);
         $audio = new RecognitionAudio();
         $response = $client->longRunningRecognize($config, $audio);
         $this->assertFalse($response->isDone());
@@ -220,6 +224,8 @@ class SpeechClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $config = new RecognitionConfig();
+        $configLanguageCode = 'configLanguageCode-537965113';
+        $config->setLanguageCode($configLanguageCode);
         $audio = new RecognitionAudio();
         $response = $client->recognize($config, $audio);
         $this->assertEquals($expectedResponse, $response);
@@ -257,6 +263,8 @@ class SpeechClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $config = new RecognitionConfig();
+        $configLanguageCode = 'configLanguageCode-537965113';
+        $config->setLanguageCode($configLanguageCode);
         $audio = new RecognitionAudio();
         try {
             $client->recognize($config, $audio);

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/ApplicationServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/ApplicationServiceClientTest.php
@@ -31,9 +31,11 @@ use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 
 use Google\Cloud\Talent\V4beta1\Application;
+use Google\Cloud\Talent\V4beta1\Application\ApplicationStage;
 use Google\Cloud\Talent\V4beta1\ApplicationServiceClient;
 use Google\Cloud\Talent\V4beta1\ListApplicationsResponse;
 use Google\Protobuf\GPBEmpty;
+use Google\Protobuf\Timestamp;
 use Google\Rpc\Code;
 use stdClass;
 
@@ -101,6 +103,14 @@ class ApplicationServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->profileName('[PROJECT]', '[TENANT]', '[PROFILE]');
         $application = new Application();
+        $applicationExternalId = 'applicationExternalId-266656842';
+        $application->setExternalId($applicationExternalId);
+        $applicationJob = $client->jobName('[PROJECT]', '[TENANT]', '[JOB]');
+        $application->setJob($applicationJob);
+        $applicationStage = ApplicationStage::APPLICATION_STAGE_UNSPECIFIED;
+        $application->setStage($applicationStage);
+        $applicationCreateTime = new Timestamp();
+        $application->setCreateTime($applicationCreateTime);
         $response = $client->createApplication($formattedParent, $application);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -138,6 +148,14 @@ class ApplicationServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->profileName('[PROJECT]', '[TENANT]', '[PROFILE]');
         $application = new Application();
+        $applicationExternalId = 'applicationExternalId-266656842';
+        $application->setExternalId($applicationExternalId);
+        $applicationJob = $client->jobName('[PROJECT]', '[TENANT]', '[JOB]');
+        $application->setJob($applicationJob);
+        $applicationStage = ApplicationStage::APPLICATION_STAGE_UNSPECIFIED;
+        $application->setStage($applicationStage);
+        $applicationCreateTime = new Timestamp();
+        $application->setCreateTime($applicationCreateTime);
         try {
             $client->createApplication($formattedParent, $application);
             // If the $client method call did not throw, fail the test
@@ -389,6 +407,14 @@ class ApplicationServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $application = new Application();
+        $applicationExternalId = 'applicationExternalId-266656842';
+        $application->setExternalId($applicationExternalId);
+        $applicationJob = $client->jobName('[PROJECT]', '[TENANT]', '[JOB]');
+        $application->setJob($applicationJob);
+        $applicationStage = ApplicationStage::APPLICATION_STAGE_UNSPECIFIED;
+        $application->setStage($applicationStage);
+        $applicationCreateTime = new Timestamp();
+        $application->setCreateTime($applicationCreateTime);
         $response = $client->updateApplication($application);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -423,6 +449,14 @@ class ApplicationServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $application = new Application();
+        $applicationExternalId = 'applicationExternalId-266656842';
+        $application->setExternalId($applicationExternalId);
+        $applicationJob = $client->jobName('[PROJECT]', '[TENANT]', '[JOB]');
+        $application->setJob($applicationJob);
+        $applicationStage = ApplicationStage::APPLICATION_STAGE_UNSPECIFIED;
+        $application->setStage($applicationStage);
+        $applicationCreateTime = new Timestamp();
+        $application->setCreateTime($applicationCreateTime);
         try {
             $client->updateApplication($application);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompanyServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompanyServiceClientTest.php
@@ -107,6 +107,10 @@ class CompanyServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $company = new Company();
+        $companyDisplayName = 'companyDisplayName-686915152';
+        $company->setDisplayName($companyDisplayName);
+        $companyExternalId = 'companyExternalId855180963';
+        $company->setExternalId($companyExternalId);
         $response = $client->createCompany($formattedParent, $company);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -144,6 +148,10 @@ class CompanyServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $company = new Company();
+        $companyDisplayName = 'companyDisplayName-686915152';
+        $company->setDisplayName($companyDisplayName);
+        $companyExternalId = 'companyExternalId855180963';
+        $company->setExternalId($companyExternalId);
         try {
             $client->createCompany($formattedParent, $company);
             // If the $client method call did not throw, fail the test
@@ -407,6 +415,10 @@ class CompanyServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $company = new Company();
+        $companyDisplayName = 'companyDisplayName-686915152';
+        $company->setDisplayName($companyDisplayName);
+        $companyExternalId = 'companyExternalId855180963';
+        $company->setExternalId($companyExternalId);
         $response = $client->updateCompany($company);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -441,6 +453,10 @@ class CompanyServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $company = new Company();
+        $companyDisplayName = 'companyDisplayName-686915152';
+        $company->setDisplayName($companyDisplayName);
+        $companyExternalId = 'companyExternalId855180963';
+        $company->setExternalId($companyExternalId);
         try {
             $client->updateCompany($company);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/EventServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/EventServiceClientTest.php
@@ -31,6 +31,7 @@ use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\ClientEvent;
 use Google\Cloud\Talent\V4beta1\EventServiceClient;
+use Google\Protobuf\Timestamp;
 use Google\Rpc\Code;
 use stdClass;
 
@@ -90,6 +91,10 @@ class EventServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $clientEvent = new ClientEvent();
+        $clientEventEventId = 'clientEventEventId319230150';
+        $clientEvent->setEventId($clientEventEventId);
+        $clientEventCreateTime = new Timestamp();
+        $clientEvent->setCreateTime($clientEventCreateTime);
         $response = $client->createClientEvent($formattedParent, $clientEvent);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -127,6 +132,10 @@ class EventServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $clientEvent = new ClientEvent();
+        $clientEventEventId = 'clientEventEventId319230150';
+        $clientEvent->setEventId($clientEventEventId);
+        $clientEventCreateTime = new Timestamp();
+        $clientEvent->setCreateTime($clientEventCreateTime);
         try {
             $client->createClientEvent($formattedParent, $clientEvent);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/JobServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/JobServiceClientTest.php
@@ -435,6 +435,14 @@ class JobServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $job = new Job();
+        $jobCompany = $client->companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+        $job->setCompany($jobCompany);
+        $jobRequisitionId = 'jobRequisitionId-1718160870';
+        $job->setRequisitionId($jobRequisitionId);
+        $jobTitle = 'jobTitle-1625529189';
+        $job->setTitle($jobTitle);
+        $jobDescription = 'jobDescription-549074945';
+        $job->setDescription($jobDescription);
         $response = $client->createJob($formattedParent, $job);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -472,6 +480,14 @@ class JobServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $job = new Job();
+        $jobCompany = $client->companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+        $job->setCompany($jobCompany);
+        $jobRequisitionId = 'jobRequisitionId-1718160870';
+        $job->setRequisitionId($jobRequisitionId);
+        $jobTitle = 'jobTitle-1625529189';
+        $job->setTitle($jobTitle);
+        $jobDescription = 'jobDescription-549074945';
+        $job->setDescription($jobDescription);
         try {
             $client->createJob($formattedParent, $job);
             // If the $client method call did not throw, fail the test
@@ -911,6 +927,14 @@ class JobServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $job = new Job();
+        $jobCompany = $client->companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+        $job->setCompany($jobCompany);
+        $jobRequisitionId = 'jobRequisitionId-1718160870';
+        $job->setRequisitionId($jobRequisitionId);
+        $jobTitle = 'jobTitle-1625529189';
+        $job->setTitle($jobTitle);
+        $jobDescription = 'jobDescription-549074945';
+        $job->setDescription($jobDescription);
         $response = $client->updateJob($job);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -945,6 +969,14 @@ class JobServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $job = new Job();
+        $jobCompany = $client->companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+        $job->setCompany($jobCompany);
+        $jobRequisitionId = 'jobRequisitionId-1718160870';
+        $job->setRequisitionId($jobRequisitionId);
+        $jobTitle = 'jobTitle-1625529189';
+        $job->setTitle($jobTitle);
+        $jobDescription = 'jobDescription-549074945';
+        $job->setDescription($jobDescription);
         try {
             $client->updateJob($job);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/ProfileServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/ProfileServiceClientTest.php
@@ -376,7 +376,7 @@ class ProfileServiceClientTest extends GeneratedTest
         // Mock response
         $estimatedTotalSize = 1882144769;
         $nextPageToken = '';
-        $resultSetId = 'resultSetId-770306950';
+        $resultSetId2 = 'resultSetId2-1530601043';
         $histogramQueryResultsElement = new HistogramQueryResult();
         $histogramQueryResults = [
             $histogramQueryResultsElement,
@@ -384,7 +384,7 @@ class ProfileServiceClientTest extends GeneratedTest
         $expectedResponse = new SearchProfilesResponse();
         $expectedResponse->setEstimatedTotalSize($estimatedTotalSize);
         $expectedResponse->setNextPageToken($nextPageToken);
-        $expectedResponse->setResultSetId($resultSetId);
+        $expectedResponse->setResultSetId($resultSetId2);
         $expectedResponse->setHistogramQueryResults($histogramQueryResults);
         $transport->addResponse($expectedResponse);
         // Mock request

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/TenantServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/TenantServiceClientTest.php
@@ -91,6 +91,8 @@ class TenantServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $tenant = new Tenant();
+        $tenantExternalId = 'tenantExternalId-300736880';
+        $tenant->setExternalId($tenantExternalId);
         $response = $client->createTenant($formattedParent, $tenant);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -128,6 +130,8 @@ class TenantServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->projectName('[PROJECT]');
         $tenant = new Tenant();
+        $tenantExternalId = 'tenantExternalId-300736880';
+        $tenant->setExternalId($tenantExternalId);
         try {
             $client->createTenant($formattedParent, $tenant);
             // If the $client method call did not throw, fail the test
@@ -359,6 +363,8 @@ class TenantServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $tenant = new Tenant();
+        $tenantExternalId = 'tenantExternalId-300736880';
+        $tenant->setExternalId($tenantExternalId);
         $response = $client->updateTenant($tenant);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -393,6 +399,8 @@ class TenantServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $tenant = new Tenant();
+        $tenantExternalId = 'tenantExternalId-300736880';
+        $tenant->setExternalId($tenantExternalId);
         try {
             $client->updateTenant($tenant);
             // If the $client method call did not throw, fail the test

--- a/tests/Unit/ProtoTests/BasicDiregapic/library_rest.proto
+++ b/tests/Unit/ProtoTests/BasicDiregapic/library_rest.proto
@@ -130,20 +130,20 @@ service LibraryService {
     option (google.api.method_signature) = "name,book";
   }
 
-  //  TODO: Commented out for nesting handling.
-  // // Creates a series of books.
-  // rpc PublishSeries(PublishSeriesRequest) returns (PublishSeriesResponse) {
-  //   option (google.api.http) = {
-  //     post: "/v1:publish"
-  //     body: "*"
-  //     additional_bindings: {
-  //       post: "/v1/{shelf.name=shelves/*}:publish"
-  //       body: "*"
-  //     }
-  //   };
-  //   option (google.api.method_signature) =
-  //       "shelf,books,edition,series_uuid,publisher";
-  // }
+  // Creates a series of books.
+  // Tests PHP required nested fields.
+  rpc PublishSeries(PublishSeriesRequest) returns (PublishSeriesResponse) {
+    option (google.api.http) = {
+      post: "/v1:publish"
+      body: "*"
+      additional_bindings: {
+        post: "/v1/{shelf.name=shelves/*}:publish"
+        body: "*"
+      }
+    };
+    option (google.api.method_signature) =
+        "shelf,books,edition,series_uuid,publisher";
+  }
 
   // Creates an inventory. Tests singleton resources.
   rpc CreateInventory(CreateInventoryRequest) returns (InventoryResponse) {

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryServiceGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryServiceGapicClient.php
@@ -58,11 +58,11 @@ use Google\Protobuf\Timestamp;
 use Google\Protobuf\UInt32Value;
 use Google\Protobuf\UInt64Value;
 use Google\Protobuf\Value;
-
 use Testing\BasicDiregapic\AddCommentsRequest;
-use Testing\BasicDiregapic\AddTagRequest;
 
+use Testing\BasicDiregapic\AddTagRequest;
 use Testing\BasicDiregapic\AddTagResponse;
+
 use Testing\BasicDiregapic\ArchiveBooksRequest;
 use Testing\BasicDiregapic\ArchiveBooksResponse;
 use Testing\BasicDiregapic\BookFromAnywhereResponse;
@@ -83,10 +83,10 @@ use Testing\BasicDiregapic\GetBookRequest;
 use Testing\BasicDiregapic\GetShelfRequest;
 use Testing\BasicDiregapic\InventoryResponse;
 use Testing\BasicDiregapic\ListAggregatedShelvesRequest;
-
 use Testing\BasicDiregapic\ListAggregatedShelvesResponse;
 use Testing\BasicDiregapic\ListBooksRequest;
 use Testing\BasicDiregapic\ListBooksResponse;
+
 use Testing\BasicDiregapic\ListShelvesRequest;
 use Testing\BasicDiregapic\ListShelvesResponse;
 use Testing\BasicDiregapic\ListStringsRequest;
@@ -95,6 +95,9 @@ use Testing\BasicDiregapic\MergeShelvesRequest;
 use Testing\BasicDiregapic\MoveBookRequest;
 use Testing\BasicDiregapic\MoveBooksRequest;
 use Testing\BasicDiregapic\MoveBooksResponse;
+use Testing\BasicDiregapic\PublishSeriesRequest;
+use Testing\BasicDiregapic\PublishSeriesResponse;
+use Testing\BasicDiregapic\SeriesUuidResponse;
 use Testing\BasicDiregapic\ShelfResponse;
 use Testing\BasicDiregapic\SomeMessage;
 use Testing\BasicDiregapic\StringBuilder;
@@ -2107,6 +2110,71 @@ class LibraryServiceGapicClient
         }
 
         return $this->startCall('PrivateListShelves', BookResponse::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Creates a series of books.
+     * Tests PHP required nested fields.
+     *
+     * Sample code:
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * try {
+     *     $shelf = new ShelfResponse();
+     *     $books = [];
+     *     $seriesUuid = new SeriesUuidResponse();
+     *     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid);
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param ShelfResponse      $shelf        The shelf in which the series is created.
+     * @param BookResponse[]     $books        The books to publish in the series.
+     * @param SeriesUuidResponse $seriesUuid   Uniquely identifies the series to the publishing house.
+     * @param array              $optionalArgs {
+     *     Optional.
+     *
+     *     @type int $edition
+     *           The edition of the series
+     *     @type bool $reviewCopy
+     *           If the book is in a pre-publish state
+     *     @type string $publisher
+     *           The publisher of the series.
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a
+     *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
+     *           settings parameters. See the documentation on
+     *           {@see Google\ApiCore\RetrySettings} for example usage.
+     * }
+     *
+     * @return \Testing\BasicDiregapic\PublishSeriesResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function publishSeries($shelf, $books, $seriesUuid, array $optionalArgs = [])
+    {
+        $request = new PublishSeriesRequest();
+        $requestParamHeaders = [];
+        $request->setShelf($shelf);
+        $request->setBooks($books);
+        $request->setSeriesUuid($seriesUuid);
+        $requestParamHeaders['shelf.name'] = $shelf->getName();
+        if (isset($optionalArgs['edition'])) {
+            $request->setEdition($optionalArgs['edition']);
+        }
+
+        if (isset($optionalArgs['reviewCopy'])) {
+            $request->setReviewCopy($optionalArgs['reviewCopy']);
+        }
+
+        if (isset($optionalArgs['publisher'])) {
+            $request->setPublisher($optionalArgs['publisher']);
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('PublishSeries', PublishSeriesResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/gapic_metadata.json
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/gapic_metadata.json
@@ -135,6 +135,11 @@
                                 "privateListShelves"
                             ]
                         },
+                        "PublishSeries": {
+                            "methods": [
+                                "publishSeries"
+                            ]
+                        },
                         "SaveBook": {
                             "methods": [
                                 "saveBook"

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_client_config.json
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_client_config.json
@@ -145,6 +145,11 @@
                     "retry_codes_name": "idempotent",
                     "retry_params_name": "default"
                 },
+                "PublishSeries": {
+                    "timeout_millis": 60000,
+                    "retry_codes_name": "non_idempotent",
+                    "retry_params_name": "default"
+                },
                 "SaveBook": {
                     "timeout_millis": 60000,
                     "retry_codes_name": "non_idempotent",

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_rest_client_config.php
@@ -264,6 +264,26 @@ return [
                 'method' => 'get',
                 'uriTemplate' => '/v1/bookShelves',
             ],
+            'PublishSeries' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1:publish',
+                'body' => '*',
+                'additionalBindings' => [
+                    [
+                        'method' => 'post',
+                        'uriTemplate' => '/v1/{shelf.name=shelves/*}:publish',
+                        'body' => '*',
+                    ],
+                ],
+                'placeholders' => [
+                    'shelf.name' => [
+                        'getters' => [
+                            'getShelf',
+                            'getName',
+                        ],
+                    ],
+                ],
+            ],
             'SaveBook' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1:saveBook',

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/LibraryServiceClientTest.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/LibraryServiceClientTest.php
@@ -52,6 +52,8 @@ use Testing\BasicDiregapic\ListBooksResponse;
 use Testing\BasicDiregapic\ListShelvesResponse;
 use Testing\BasicDiregapic\ListStringsResponse;
 use Testing\BasicDiregapic\MoveBooksResponse;
+use Testing\BasicDiregapic\PublishSeriesResponse;
+use Testing\BasicDiregapic\SeriesUuidResponse;
 use Testing\BasicDiregapic\ShelfResponse;
 
 /**
@@ -303,6 +305,8 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $client->shelfName('[SHELF]');
         $book = new BookResponse();
+        $bookName = 'bookName2004454676';
+        $book->setName($bookName);
         $response = $client->createBook($formattedName, $book);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -340,6 +344,8 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $client->shelfName('[SHELF]');
         $book = new BookResponse();
+        $bookName = 'bookName2004454676';
+        $book->setName($bookName);
         try {
             $client->createBook($formattedName, $book);
             // If the $client method call did not throw, fail the test
@@ -450,6 +456,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $shelf = new ShelfResponse();
+        $shelfName = 'shelfName1796941781';
+        $shelf->setName($shelfName);
         $response = $client->createShelf($shelf);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -484,6 +492,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $shelf = new ShelfResponse();
+        $shelfName = 'shelfName1796941781';
+        $shelf->setName($shelfName);
         try {
             $client->createShelf($shelf);
             // If the $client method call did not throw, fail the test
@@ -1971,6 +1981,80 @@ class LibraryServiceClientTest extends GeneratedTest
     /**
      * @test
      */
+    public function publishSeriesTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new PublishSeriesResponse();
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $shelf = new ShelfResponse();
+        $shelfName = 'shelfName1796941781';
+        $shelf->setName($shelfName);
+        $books = [];
+        $seriesUuid = new SeriesUuidResponse();
+        $response = $client->publishSeries($shelf, $books, $seriesUuid);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.example.library.v1.LibraryService/PublishSeries', $actualFuncCall);
+        $actualValue = $actualRequestObject->getShelf();
+        $this->assertProtobufEquals($shelf, $actualValue);
+        $actualValue = $actualRequestObject->getBooks();
+        $this->assertProtobufEquals($books, $actualValue);
+        $actualValue = $actualRequestObject->getSeriesUuid();
+        $this->assertProtobufEquals($seriesUuid, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
+    public function publishSeriesExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $client = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $shelf = new ShelfResponse();
+        $shelfName = 'shelfName1796941781';
+        $shelf->setName($shelfName);
+        $books = [];
+        $seriesUuid = new SeriesUuidResponse();
+        try {
+            $client->publishSeries($shelf, $books, $seriesUuid);
+            // If the $client method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /**
+     * @test
+     */
     public function saveBookTest()
     {
         $transport = $this->createTransport();
@@ -2055,6 +2139,8 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $client->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book = new BookResponse();
+        $bookName = 'bookName2004454676';
+        $book->setName($bookName);
         $response = $client->updateBook($formattedName, $book);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -2092,6 +2178,8 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $client->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book = new BookResponse();
+        $bookName = 'bookName2004454676';
+        $book->setName($bookName);
         try {
             $client->updateBook($formattedName, $book);
             // If the $client method call did not throw, fail the test

--- a/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/BasicPaginatedClientTest.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/BasicPaginatedClientTest.php
@@ -81,7 +81,7 @@ class BasicPaginatedClientTest extends GeneratedTest
         ]);
         $this->assertTrue($transport->isExhausted());
         // Mock response
-        $pageSize = 883849137;
+        $pageSize2 = 1024500956;
         $nextPageToken = '';
         $pageToken2 = 649316932;
         $aField2 = false;
@@ -91,7 +91,7 @@ class BasicPaginatedClientTest extends GeneratedTest
             $theResultsElement,
         ];
         $expectedResponse = new Response();
-        $expectedResponse->setPageSize($pageSize);
+        $expectedResponse->setPageSize($pageSize2);
         $expectedResponse->setNextPageToken($nextPageToken);
         $expectedResponse->setPageToken($pageToken2);
         $expectedResponse->setAField($aField2);


### PR DESCRIPTION
Prior to this change, a required field's getter could have been called in the client, but not actually set in the generated test. This fix addresses that gap.