### PR TITLE
fix(regapic): Remove PHP 5 workaround for list_ method renaming [ggp]

### DIFF
--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -391,13 +391,6 @@ abstract class MethodDetails
         $this->testSuccessMethodName = $this->methodName . 'Test';
         $this->testExceptionMethodName = $this->methodName . 'ExceptionTest';
 
-        // PHP 7.2 compatibility.
-        // Order matters, so that we can set the test names appropriately.
-        // TODO(miraleung): Remove this logic when client libraries support PHP 7.2+.
-        if ($this->methodName === 'list') {
-            $this->methodName = 'list_';
-        }
-
         $this->requestType = Type::fromMessage($this->inputMsg->desc);
         $this->responseType = Type::fromMessage($outputMsg->desc);
         $this->hasEmptyResponse = $this->responseType->getFullname() === '\Google\Protobuf\GPBEmpty';

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
@@ -416,7 +416,7 @@ class AddressesGapicClient
      *     $project = 'project';
      *     $region = 'region';
      *     // Iterate over pages of elements
-     *     $pagedResponse = $addressesClient->list_($orderBy, $project, $region);
+     *     $pagedResponse = $addressesClient->list($orderBy, $project, $region);
      *     foreach ($pagedResponse->iteratePages() as $page) {
      *         foreach ($page as $element) {
      *             // doSomethingWith($element);
@@ -424,7 +424,7 @@ class AddressesGapicClient
      *     }
      *     // Alternatively:
      *     // Iterate through all elements
-     *     $pagedResponse = $addressesClient->list_($orderBy, $project, $region);
+     *     $pagedResponse = $addressesClient->list($orderBy, $project, $region);
      *     foreach ($pagedResponse->iterateAllElements() as $element) {
      *         // doSomethingWith($element);
      *     }
@@ -469,7 +469,7 @@ class AddressesGapicClient
      *
      * @throws ApiException if the remote call fails
      */
-    public function list_($orderBy, $project, $region, array $optionalArgs = [])
+    public function list($orderBy, $project, $region, array $optionalArgs = [])
     {
         $request = new ListAddressesRequest();
         $requestParamHeaders = [];

--- a/tests/Integration/goldens/compute_small/src/V1/gapic_metadata.json
+++ b/tests/Integration/goldens/compute_small/src/V1/gapic_metadata.json
@@ -27,7 +27,7 @@
                         },
                         "List": {
                             "methods": [
-                                "list_"
+                                "list"
                             ]
                         }
                     }

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
@@ -398,7 +398,7 @@ class AddressesClientTest extends GeneratedTest
         $orderBy = 'orderBy1234304744';
         $project = 'project-309310695';
         $region = 'region-934795532';
-        $response = $client->list_($orderBy, $project, $region);
+        $response = $client->list($orderBy, $project, $region);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
         $this->assertSame(1, count($resources));
@@ -442,7 +442,7 @@ class AddressesClientTest extends GeneratedTest
         $project = 'project-309310695';
         $region = 'region-934795532';
         try {
-            $client->list_($orderBy, $project, $region);
+            $client->list($orderBy, $project, $region);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {


### PR DESCRIPTION
For GCE in conjunction with [the PHP 7 upgrade PR](https://github.com/googleapis/google-cloud-php/pull/3962/files).