### PR TITLE
chore: only use tools/protoc if enabled

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,4 +27,4 @@ jobs:
         composer dump-autoload;
 
     - name: Run tests
-      run: ./vendor/bin/phpunit --bootstrap tests/Unit/autoload.php tests/Unit
+      run: USE_TOOLS_PROTOC=true ./vendor/bin/phpunit --bootstrap tests/Unit/autoload.php tests/Unit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,6 +68,14 @@
     ./vendor/bin/phpunit --bootstrap tests/unit/autoload.php tests/Unit
     ```
 
+    If you do not have `protoc` installed, run with `USE_TOOLS_PROTOC=true`.
+
+    ```
+    USE_TOOLS_PROTOC=true ./vendor/bin/phpunit --bootstrap tests/unit/autoload.php tests/Unit
+    ```
+
+    This uses the Linux-only `protoc` binary checked into the repository.
+
 -   Monolith integration tests. These may take 5 minutes or so to run.
 
     ```

--- a/build_proto.sh
+++ b/build_proto.sh
@@ -2,5 +2,10 @@
 
 # Build PHP code from protos; for protos where PHP files are not currently available.
 
-./tools/protoc -I./protobuf/src -I./googleapis -I./grpc-proto --php_out=./src ./grpc-proto/grpc/service_config/service_config.proto
-./tools/protoc --php_out=./src ./plugin.proto
+p="protoc"
+if [[ ! -z ${USE_TOOLS_PROTOC+x} ]]; then
+    p="./tools/protoc"
+fi
+
+$p -I./protobuf/src -I./googleapis -I./grpc-proto --php_out=./src ./grpc-proto/grpc/service_config/service_config.proto
+$p --php_out=./src ./plugin.proto

--- a/tests/Tools/ProtoLoader.php
+++ b/tests/Tools/ProtoLoader.php
@@ -39,7 +39,7 @@ class ProtoLoader
         $cwd = getcwd();
         $protoc = "protoc";
         $useToolsProtoc = getenv("USE_TOOLS_PROTOC");
-        if ($useToolsProtoc && $useToolsProtoc == "true") {
+        if (filter_var($useToolsProtoc, FILTER_VALIDATE_BOOLEAN)) {
             $protoc = "{$cwd}/tools/protoc";
         }
         $descRes = tmpfile();

--- a/tests/Tools/ProtoLoader.php
+++ b/tests/Tools/ProtoLoader.php
@@ -38,7 +38,8 @@ class ProtoLoader
         // Assumes test are executed from within the repo root directory.
         $cwd = getcwd();
         $protoc = "protoc";
-        if (getenv("USE_TOOLS_PROTOC")) {
+        $useToolsProtoc = getenv("USE_TOOLS_PROTOC");
+        if ($useToolsProtoc && $useToolsProtoc == "true") {
             $protoc = "{$cwd}/tools/protoc";
         }
         $descRes = tmpfile();

--- a/tests/Tools/ProtoLoader.php
+++ b/tests/Tools/ProtoLoader.php
@@ -37,7 +37,10 @@ class ProtoLoader
         // Set up required file locations and create tmp output file for protoc invocation.
         // Assumes test are executed from within the repo root directory.
         $cwd = getcwd();
-        $protoc = "{$cwd}/tools/protoc";
+        $protoc = "protoc";
+        if (getenv("USE_TOOLS_PROTOC")) {
+            $protoc = "{$cwd}/tools/protoc";
+        }
         $descRes = tmpfile();
         $descFilename = stream_get_meta_data($descRes)['uri'];
         $input = "{$cwd}/tests/Unit/{$protoPath}";
@@ -67,7 +70,7 @@ class ProtoLoader
      *
      * @return FileDescriptorProto
      */
-    public function loadDescriptor(string $protoPath): FileDescriptorProto
+    public static function loadDescriptor(string $protoPath): FileDescriptorProto
     {
         // Load descriptor bytes into a DescriptorSet.
         $descBytes = static::loadDescriptorBytes($protoPath);


### PR DESCRIPTION
The `tools/protoc` binary is not executable on mac os, my guess is because it is a linux binary. So instead of always using that, all scripts/execs default to using `protoc` (local installation in `PATH`) unless `USE_TOOLS_PROTOC` is set.

Also fixes a function that was non-static but called in a static context.