### PR TITLE
chore(tests): fix unit golden updater

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,6 +76,16 @@
 
     This uses the Linux-only `protoc` binary checked into the repository.
 
+    Updating unit test goldens:
+
+    ```
+    php tests/Unit/ProtoTests/GoldenUpdateMain.php
+    ```
+
+    Then follow the prompts for which tests to update.
+
+    If a new unit test case is added, make sure to add it to the `UNIT_TESTS` list in [GoldenUpdateMain.php](tests/Unit/ProtoTests/GoldenUpdateMain.php).
+
 -   Monolith integration tests. These may take 5 minutes or so to run.
 
     ```

--- a/tests/Unit/ProtoTests/GoldenUpdateMain.php
+++ b/tests/Unit/ProtoTests/GoldenUpdateMain.php
@@ -83,8 +83,6 @@ $optionString = implode("\n", array_map(
     array_keys(UNIT_TESTS)
 ));
 
-$fp = fopen('php:://stdin', 'r');
-$lastLine = false;
 $selection = -1;
 while ($selection < 0 || $selection > sizeof(array_keys(UNIT_TESTS))) {
     print("============ Unit tests ==========\n$optionString\n\nSelect golden to update (0 for all): ");

--- a/tests/Unit/ProtoTests/UnitGoldenUpdater.php
+++ b/tests/Unit/ProtoTests/UnitGoldenUpdater.php
@@ -41,10 +41,20 @@ class UnitGoldenUpdater
                 }
             }
             reset($fileSysObjects);
+        } else {
+            // Create the output directory if it does not exist yet.
+            mkdir($outputPath, 0777, true);
         }
         foreach ($codeIterator as [$relativeFilename, $code]) {
-            $filename = "$outputPath/$relativeFilename";
             print("\twriting $relativeFilename\n");
+            $filename = "$outputPath/$relativeFilename";
+            
+            // Create the directory structure if it does not exist yet.
+            $d = dirname($filename);
+            if (!is_dir($d)) {
+                mkdir($d, 0777, true);
+            }
+
             file_put_contents($filename, $code);
         }
     }


### PR DESCRIPTION
Adds development instructions on how to update the unit test golden/baseline files, removes two unused variables `GoldenUpdateMain.php`, fixes `UnitGoldenUpdater.php` to create missing baseline directory structure which enables _creation_ of baselines for new test cases not only updates for existing ones.