### PR TITLE
fix: catalog services in ProtoCatalog

### DIFF
--- a/src/Utils/ProtoCatalog.php
+++ b/src/Utils/ProtoCatalog.php
@@ -29,7 +29,7 @@ class ProtoCatalog
     /** @var Map *Readonly* Map<string, DescriptorProto> of all proto msgs by full name. */
     public Map $msgsByFullname;
 
-    /** @var Map *Readonly* Map<string, EnumDescriptorProto> of all enums by faull name. */
+    /** @var Map *Readonly* Map<string, EnumDescriptorProto> of all enums by full name. */
     public Map $enumsByFullname;
 
     /** @var Map *Readonly* Map<string, ResourceDescriptor> of all resources by type name (urn). */
@@ -47,6 +47,9 @@ class ProtoCatalog
     /** @var Map *Readonly* Map<string, Vector<ResourceDescriptor>> of all child/parent resources. */
     public Map $parentResourceByChildType;
 
+    /** @var Map *Readonly* Map<string, ServiceDescriptorProto> of all services by full name. */
+    public Map $servicesByFullname;
+
     private static function msgPlusNested(DescriptorProto $desc): Vector
     {
         return Vector::new($desc->getNestedType())
@@ -61,6 +64,19 @@ class ProtoCatalog
      */
     public function __construct(Vector $fileDescs)
     {
+        // Flatten into pairs of [proto package, ServiceDescriptorProto], because each
+        // FileDescriptorProto can contain multiple services, so each must be paired
+        // with the parent file proto package.
+        $allServices = $fileDescs
+            ->flatMap(fn ($x) => Vector::new($x->getService())
+                ->map(fn ($s) => [$x->getPackage(), $s]));
+        // Convert pairs into map of fully-qualified proto element name and ServiceDescriptorProto.
+        $this->servicesByFullname = $allServices->toMap(
+            // Key: fully-qualified service name.
+            fn ($x) => '.' . $x[0] . '.' . $x[1]->getName(),
+            // Value: ServiceDescriptorProto.
+            fn($x) => $x[1]);
+
         $allMsgs = $fileDescs
             ->flatMap(fn ($x) => Vector::new($x->getMessageType()))
             ->flatMap(fn ($x) => static::msgPlusNested($x));

--- a/src/Utils/ProtoCatalog.php
+++ b/src/Utils/ProtoCatalog.php
@@ -65,17 +65,18 @@ class ProtoCatalog
     public function __construct(Vector $fileDescs)
     {
         // Flatten into pairs of [proto package, ServiceDescriptorProto], because each
-        // FileDescriptorProto can contain multiple services, so each must be paired
-        // with the parent file proto package.
+        // FileDescriptorProto can contain multiple services, so each service must be
+        // paired with the parent file proto package.
         $allServices = $fileDescs
-            ->flatMap(fn ($x) => Vector::new($x->getService())
-                ->map(fn ($s) => [$x->getPackage(), $s]));
+            ->flatMap(fn ($x) =>
+                Vector::new($x->getService())->map(fn ($s) => [$x->getPackage(), $s]));
+
         // Convert pairs into map of fully-qualified proto element name and ServiceDescriptorProto.
         $this->servicesByFullname = $allServices->toMap(
             // Key: fully-qualified service name.
             fn ($x) => ".{$x[0]}.{$x[1]->getName()}",
             // Value: ServiceDescriptorProto.
-            fn($x) => $x[1]);
+            fn ($x) => $x[1]);
 
         $allMsgs = $fileDescs
             ->flatMap(fn ($x) => Vector::new($x->getMessageType()))

--- a/src/Utils/ProtoCatalog.php
+++ b/src/Utils/ProtoCatalog.php
@@ -73,7 +73,7 @@ class ProtoCatalog
         // Convert pairs into map of fully-qualified proto element name and ServiceDescriptorProto.
         $this->servicesByFullname = $allServices->toMap(
             // Key: fully-qualified service name.
-            fn ($x) => '.' . $x[0] . '.' . $x[1]->getName(),
+            fn ($x) => ".{$x[0]}.{$x[1]->getName()}",
             // Value: ServiceDescriptorProto.
             fn($x) => $x[1]);
 

--- a/tests/Unit/Utils/ProtoHelpersTest.php
+++ b/tests/Unit/Utils/ProtoHelpersTest.php
@@ -23,6 +23,7 @@ use Google\Generator\Collections\Vector;
 use Google\Generator\Tests\Tools\ProtoLoader;
 use Google\Generator\Utils\ProtoHelpers;
 use Google\Generator\Utils\ProtoAugmenter;
+use Google\Generator\Utils\ProtoCatalog;
 
 final class ProtoHelpersTest extends TestCase
 {
@@ -55,5 +56,25 @@ final class ProtoHelpersTest extends TestCase
         $this->assertEquals(['Inner 1', 'Inner 2'], $inner->leadingComments->toArray());
         $innerField = $inner->getField()[0];
         $this->assertEquals(['Inner field 1', 'Inner field 2'], $innerField->leadingComments->toArray());
+    }
+
+    public function testProtoCatalog(): void
+    {
+        $file = ProtoLoader::loadDescriptor('Utils/catalog.proto');
+        $files = Vector::new([$file]);
+        // ProtoCatalog depends on the FileDescriptorProtos already being augmented.
+        ProtoAugmenter::Augment($files);
+        $catalog = new ProtoCatalog($files);
+
+        $msg = $catalog->msgsByFullname['.foo.Msg'];
+        $this->assertEquals('Msg', $msg->GetName());
+        $msg = $catalog->msgsByFullname['.foo.Msg.InnerMsg'];
+        $this->assertEquals('InnerMsg', $msg->GetName());
+        $enm = $catalog->enumsByFullname['.foo.Enm'];
+        $this->assertEquals('Enm', $enm->getName());
+        $enm = $catalog->enumsByFullname['.foo.Msg.InnerEnm'];
+        $this->assertEquals('InnerEnm', $enm->getName());
+        $svc = $catalog->servicesByFullname['.foo.Svc'];
+        $this->assertEquals('Svc', $svc->GetName());
     }
 }

--- a/tests/Unit/Utils/catalog.proto
+++ b/tests/Unit/Utils/catalog.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+// Test proto for reading source comments
+package foo;
+
+// Svc 1
+// Svc 2
+service Svc {
+    // Method 1
+    // Method 2
+    rpc AMethod(Msg) returns(Msg);
+}
+
+// Msg 1
+// Msg 2
+message Msg {
+    // Inner 1
+    // Inner 2
+    message InnerMsg {
+        // Inner field 1
+        // Inner field 2
+        int32 a_number = 1;
+    }
+
+    // Field 1
+    // Field 2
+    string a_string = 1;
+
+    // Inner enum
+    enum InnerEnm {
+        INNER_ENM1 = 0;
+        INNER_ENM2 = 1;
+    }
+}
+
+// Enum
+enum Enm {
+    ENM_1 = 0;
+    ENM_2 = 1;
+}


### PR DESCRIPTION
This adds a mapping of fully-qualified proto element name to `ServiceDescriptorProto` so that we can look up services by name. This will be useful for DIREGAPIC LRO implementation because a service can name it's Operation service via the `google.cloud.operation_service` method-level annotation. This is just a string value, so we will need to look it up to get the service information.