### PR TITLE
fix: enable ignore_unknown in config file parsers

### DIFF
--- a/src/Utils/GrpcServiceConfig.php
+++ b/src/Utils/GrpcServiceConfig.php
@@ -31,7 +31,7 @@ class GrpcServiceConfig
         } else {
             $this->isPresent = true;
             $config = new ServiceConfig();
-            $config->mergeFromJsonString($json);
+            $config->mergeFromJsonString($json, /* ignore_unknown */true);
             $this->methods = Vector::new($config->getMethodConfig());
         }
     }

--- a/src/Utils/ServiceYamlConfig.php
+++ b/src/Utils/ServiceYamlConfig.php
@@ -61,7 +61,7 @@ class ServiceYamlConfig
         if (!is_null($serviceYaml)) {
             $service = new Service();
             $serviceYaml = static::fixYaml($serviceYaml);
-            $service->mergeFromJsonString(json_encode(Yaml::parse($serviceYaml)));
+            $service->mergeFromJsonString(json_encode(Yaml::parse($serviceYaml)), /* ignore_unknown */true);
             $http = $service->getHttp();
             if (!is_null($http)) {
                 $this->httpRules = Vector::new($http->getRules());


### PR DESCRIPTION
This just ignores the unknown fields in a JSON/YAML blob when parsing config files. Specifically, the `ServiceYamlConfig.php` doesn't have a `type` field (which it doesn't need), but this field may appear in the YAML files. At some point, the default was changed in `google/protobuf` and in order to upgrade (see #385) we need to explicitly set `ignore_unknown = true`.