### PR TITLE
fix: catalog proto service to proto file

### DIFF
--- a/tests/Unit/Utils/ProtoHelpersTest.php
+++ b/tests/Unit/Utils/ProtoHelpersTest.php
@@ -76,5 +76,7 @@ final class ProtoHelpersTest extends TestCase
         $this->assertEquals('InnerEnm', $enm->getName());
         $svc = $catalog->servicesByFullname['.foo.Svc'];
         $this->assertEquals('Svc', $svc->GetName());
+        $f = $catalog->filesByService[$svc];
+        $this->assertStringContainsString('catalog.proto', $f->GetName());
     }
 }


### PR DESCRIPTION
Add a mapping of `ServiceDescriptorProto` to `FileDescriptorProto` to `ProtoCatalog`. This is especially useful when a reference to a `ServiceDescriptorProto` is available, and a `FileDescriptorProto` is necessary in order to convert that into `ServiceDetails`. This is essentially a parent file lookup.

This is necessary for DIREGAPIC LRO support, because the "Resource" service client needs to be able to configure the "Operations" service client named in the annotations. 