### PR TITLE
fix: remove extraneous message in custom lro tests

### DIFF
--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -847,9 +847,7 @@ class UnitTestsGenerator
         $expectedExceptionMessage = AST::var('expectedExceptionMessage');
         [$requestPerField, $requestCallArgs] = $prod->perFieldRequest($method);
         $response = AST::var('response');
-        $expectedOperationsRequestObject = AST::var('expectedOperationsRequestObject');
         $ex = AST::var('ex');
-        $pollingMethod = $method->operationPollingMethod;
         [$initCode, $operationsTransport, $client, $transport] = $this->customOpTestInit($method, $method->testExceptionMethodName);
         return AST::method($method->testExceptionMethodName)
             ->withAccess(Access::PUBLIC)
@@ -871,12 +869,6 @@ class UnitTestsGenerator
                 AST::assign($response, $client->instanceCall(AST::method($method->methodName))($requestCallArgs)),
                 ($this->assertFalse)($response->isDone()),
                 ($this->assertNull)($response->getResult()),
-                AST::assign($expectedOperationsRequestObject, AST::new($this->ctx->type($pollingMethod->requestType))()),
-                $expectedOperationsRequestObject->setName("customOperations/{$method->testExceptionMethodName}"),
-                $method->operationRequestFields->mapValues(
-                    fn ($pollField, $reqField) => $expectedOperationsRequestObject->instanceCall($pollField->setter)(AST::var($reqField->name))
-                )
-                    ->values(),
                 AST::try(
                     $response->pollUntilComplete(AST::array([
                         'initialPollDelayMillis' => 1,

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
@@ -258,10 +258,6 @@ class AddressesClientTest extends GeneratedTest
         $response = $client->delete($address, $project, $region);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
-        $expectedOperationsRequestObject = new GetRegionOperationRequest();
-        $expectedOperationsRequestObject->setName('customOperations/deleteExceptionTest');
-        $expectedOperationsRequestObject->setProject($project);
-        $expectedOperationsRequestObject->setRegion($region);
         try {
             $response->pollUntilComplete([
                 'initialPollDelayMillis' => 1,
@@ -385,10 +381,6 @@ class AddressesClientTest extends GeneratedTest
         $response = $client->insert($addressResource, $project, $region);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
-        $expectedOperationsRequestObject = new GetRegionOperationRequest();
-        $expectedOperationsRequestObject->setName('customOperations/insertExceptionTest');
-        $expectedOperationsRequestObject->setProject($project);
-        $expectedOperationsRequestObject->setRegion($region);
         try {
             $response->pollUntilComplete([
                 'initialPollDelayMillis' => 1,

--- a/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/CustomLroClientTest.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/CustomLroClientTest.php
@@ -170,10 +170,6 @@ class CustomLroClientTest extends GeneratedTest
         $response = $client->createFoo($project, $region);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
-        $expectedOperationsRequestObject = new \Testing\CustomLro\GetOperationRequest();
-        $expectedOperationsRequestObject->setName('customOperations/createFooExceptionTest');
-        $expectedOperationsRequestObject->setProject($project);
-        $expectedOperationsRequestObject->setRegion($region);
         try {
             $response->pollUntilComplete([
                 'initialPollDelayMillis' => 1,


### PR DESCRIPTION
Generated unit tests for the exception case of Custom LRO methods contained an extraneous request message object and its construction. The variable was never used after it was constructed because the test focuses on asserting that an exception happens. The existing LRO exception tests don't use it either. Might want to circle back in a separate PR to clean up that one too.