### PR TITLE
fix: only expect required request fields on op

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -113,8 +113,7 @@ class FieldDetails
         $this->typeSingular = Type::fromField($catalog, $desc, false);
         $this->getter = new PhpMethod($desc->getGetter());
         $this->setter = new PhpMethod($desc->getSetter());
-        $this->isRequired = ProtoHelpers::getCustomOptionRepeated($desc, CustomOptions::GOOGLE_API_FIELDBEHAVIOR)
-            ->contains(CustomOptions::GOOGLE_API_FIELDBEHAVIOR_REQUIRED);
+        $this->isRequired = ProtoHelpers::isRequired($field);
         $this->isMessage = $field->getType() == GPBType::MESSAGE;
         $this->fullname = $this->isMessage ? $field->getTypeName() : null;
         $this->isEnum = $field->getType() === GPBType::ENUM;

--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -357,6 +357,7 @@ abstract class MethodDetails
                     );
                     $this->operationRequestFields = Vector::new($inputMsg->getField())
                         ->filter(fn ($x) => ProtoHelpers::isOperationRequestField($x))
+                        ->filter(fn ($x) => ProtoHelpers::isRequired($x))
                         ->toMap(
                             fn ($x) => $pollingFields[ProtoHelpers::operationRequestField($x)],
                             fn ($x) => new FieldDetails($catalog, $inputMsg, $x)

--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -818,7 +818,7 @@ class UnitTestsGenerator
                     fn ($reqField, $resField) => $expectedOperationsRequestObject->instanceCall($reqField->setter)($completeOperation->instanceCall($resField->getter)())
                 )
                     ->values(),
-                $method->operationRequestFields->filter(fn($pollField, $reqField) => $reqField->isRequired)->mapValues(
+                $method->operationRequestFields->mapValues(
                     fn ($pollField, $reqField) => $expectedOperationsRequestObject->instanceCall($pollField->setter)(AST::var($reqField->name))
                 )
                     ->values(),

--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -818,7 +818,7 @@ class UnitTestsGenerator
                     fn ($reqField, $resField) => $expectedOperationsRequestObject->instanceCall($reqField->setter)($completeOperation->instanceCall($resField->getter)())
                 )
                     ->values(),
-                $method->operationRequestFields->mapValues(
+                $method->operationRequestFields->filter(fn($pollField, $reqField) => $reqField->isRequired)->mapValues(
                     fn ($pollField, $reqField) => $expectedOperationsRequestObject->instanceCall($pollField->setter)(AST::var($reqField->name))
                 )
                     ->values(),

--- a/src/Utils/ProtoHelpers.php
+++ b/src/Utils/ProtoHelpers.php
@@ -235,6 +235,12 @@ class ProtoHelpers
         return $result;
     }
 
+    public static function isRequired(FieldDescriptorProto $field)
+    {
+        return ProtoHelpers::getCustomOptionRepeated($field, CustomOptions::GOOGLE_API_FIELDBEHAVIOR)
+            ->contains(CustomOptions::GOOGLE_API_FIELDBEHAVIOR_REQUIRED);
+    }
+
     public static function operationService(MethodDescriptorProto $method)
     {
         return static::getCustomOption($method, CustomOptions::GOOGLE_CLOUD_OPERATION_SERVICE);

--- a/tests/Unit/ProtoTests/CustomLro/custom_lro.proto
+++ b/tests/Unit/ProtoTests/CustomLro/custom_lro.proto
@@ -68,7 +68,10 @@ message CustomOperationResponse {
 }
 
 message CreateFooRequest {
-    string foo = 1;
+    // Since this is not REQUIRED, it will be ignored. Otherwise, runtime errors
+    // will occur when the field is not set, and because it appears before the
+    // REQUIRED fields.
+    string foo = 1 [(google.cloud.operation_request_field) = "foo"];
 
     string project = 2 [
         (google.cloud.operation_request_field) = "project",
@@ -90,6 +93,9 @@ message GetOperationRequest {
 
   // Name of the region for this request.
   string region = 3 [(google.api.field_behavior) = REQUIRED];
+
+  // The foo from the initial request.
+  string foo = 4;
 }
 
 message CancelOperationRequest {

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
@@ -300,6 +300,9 @@ class CustomLroGapicClient
      *     Optional.
      *
      *     @type string $foo
+     *           Since this is not REQUIRED, it will be ignored. Otherwise, runtime errors
+     *           will occur when the field is not set, and because it appears before the
+     *           REQUIRED fields.
      *     @type RetrySettings|array $retrySettings
      *           Retry settings to use for this call. Can be a
      *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
@@ -267,6 +267,8 @@ class CustomLroOperationsGapicClient
      * @param array  $optionalArgs {
      *     Optional.
      *
+     *     @type string $foo
+     *           The foo from the initial request.
      *     @type RetrySettings|array $retrySettings
      *           Retry settings to use for this call. Can be a
      *           {@see Google\ApiCore\RetrySettings} object, or an associative array of retry
@@ -284,6 +286,10 @@ class CustomLroOperationsGapicClient
         $request->setOperation($operation);
         $request->setProject($project);
         $request->setRegion($region);
+        if (isset($optionalArgs['foo'])) {
+            $request->setFoo($optionalArgs['foo']);
+        }
+
         return $this->startCall('Get', CustomOperationResponse::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/autoload.php
+++ b/tests/Unit/autoload.php
@@ -35,6 +35,8 @@ class FakeMessage extends \Google\Protobuf\Internal\Message
                 return '';
             case 'HttpErrorStatusCode':
                 return '';
+            case 'Foo':
+                return '';
             default:
                 throw new \Exception("No default value available for field: '{$name}'");
         }


### PR DESCRIPTION
Only those `operation_request_fields` annotated as `REQUIRED` will be honored until further notice.

Also adds a `ProtoHelpers` function for checking `REQUIRED` field_behavior.

Note: compute_small does not have a test for this so I added a non-REQUIRED field to the unit test proto to ensure it was not included.