### PR TITLE
chore: remove main branch

### DIFF
--- a/.github/workflows/bazel_example.yml
+++ b/.github/workflows/bazel_example.yml
@@ -2,9 +2,9 @@ name: Bazel Build
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,9 +2,9 @@ name: PhpUnit tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
I added both branches for a second so that the checks could pass against master before the branch was renamed.

now they can be removed.