### PR TITLE
fix(diregapic): use camelCase field name in custom op test

### DIFF
--- a/src/Generation/UnitTestsGenerator.php
+++ b/src/Generation/UnitTestsGenerator.php
@@ -819,7 +819,7 @@ class UnitTestsGenerator
                 )
                     ->values(),
                 $method->operationRequestFields->mapValues(
-                    fn ($pollField, $reqField) => $expectedOperationsRequestObject->instanceCall($pollField->setter)(AST::var($reqField->name))
+                    fn ($pollField, $reqField) => $expectedOperationsRequestObject->instanceCall($pollField->setter)(AST::var($reqField->camelName))
                 )
                     ->values(),
                 $response->pollUntilComplete(AST::array([


### PR DESCRIPTION
Accidentally used plain field `name` which for field names with `_` in them, isn't the proper variable name. Using `camelCase` is the right thing.