### PR TITLE
fix(gapic): only wrap top-level required oneof in tests

### DIFF
--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
@@ -29,11 +29,12 @@ use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 
 use Google\Cloud\Dataproc\V1\AutoscalingPolicy;
-use Google\Cloud\Dataproc\V1\AutoscalingPolicy\AlgorithmOneof;
 use Google\Cloud\Dataproc\V1\AutoscalingPolicyServiceClient;
 use Google\Cloud\Dataproc\V1\BasicAutoscalingAlgorithm;
+use Google\Cloud\Dataproc\V1\BasicYarnAutoscalingConfig;
 use Google\Cloud\Dataproc\V1\InstanceGroupAutoscalingPolicyConfig;
 use Google\Cloud\Dataproc\V1\ListAutoscalingPoliciesResponse;
+use Google\Protobuf\Duration;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;
 use stdClass;
@@ -92,13 +93,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $policy = new AutoscalingPolicy();
-        $algorithm = new AlgorithmOneof();
-        $algorithm->setBasicAlgorithm(new BasicAutoscalingAlgorithm());
-        $policy->setBasicAlgorithm($algorithm);
         $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
         $workerConfigMaxInstances = 339756550;
         $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
         $policy->setWorkerConfig($policyWorkerConfig);
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
         $response = $client->createAutoscalingPolicy($formattedParent, $policy);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -136,13 +144,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->regionName('[PROJECT]', '[REGION]');
         $policy = new AutoscalingPolicy();
-        $algorithm = new AlgorithmOneof();
-        $algorithm->setBasicAlgorithm(new BasicAutoscalingAlgorithm());
-        $policy->setBasicAlgorithm($algorithm);
         $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
         $workerConfigMaxInstances = 339756550;
         $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
         $policy->setWorkerConfig($policyWorkerConfig);
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
         try {
             $client->createAutoscalingPolicy($formattedParent, $policy);
             // If the $client method call did not throw, fail the test
@@ -374,13 +389,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $transport->addResponse($expectedResponse);
         // Mock request
         $policy = new AutoscalingPolicy();
-        $algorithm = new AlgorithmOneof();
-        $algorithm->setBasicAlgorithm(new BasicAutoscalingAlgorithm());
-        $policy->setBasicAlgorithm($algorithm);
         $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
         $workerConfigMaxInstances = 339756550;
         $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
         $policy->setWorkerConfig($policyWorkerConfig);
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
         $response = $client->updateAutoscalingPolicy($policy);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -415,13 +437,20 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $transport->addResponse(null, $status);
         // Mock request
         $policy = new AutoscalingPolicy();
-        $algorithm = new AlgorithmOneof();
-        $algorithm->setBasicAlgorithm(new BasicAutoscalingAlgorithm());
-        $policy->setBasicAlgorithm($algorithm);
         $policyWorkerConfig = new InstanceGroupAutoscalingPolicyConfig();
         $workerConfigMaxInstances = 339756550;
         $policyWorkerConfig->setMaxInstances($workerConfigMaxInstances);
         $policy->setWorkerConfig($policyWorkerConfig);
+        $policyBasicAlgorithm = new BasicAutoscalingAlgorithm();
+        $basicAlgorithmYarnConfig = new BasicYarnAutoscalingConfig();
+        $yarnConfigGracefulDecommissionTimeout = new Duration();
+        $basicAlgorithmYarnConfig->setGracefulDecommissionTimeout($yarnConfigGracefulDecommissionTimeout);
+        $yarnConfigScaleUpFactor = -4.1551534E7;
+        $basicAlgorithmYarnConfig->setScaleUpFactor($yarnConfigScaleUpFactor);
+        $yarnConfigScaleDownFactor = -1.72221005E8;
+        $basicAlgorithmYarnConfig->setScaleDownFactor($yarnConfigScaleDownFactor);
+        $policyBasicAlgorithm->setYarnConfig($basicAlgorithmYarnConfig);
+        $policy->setBasicAlgorithm($policyBasicAlgorithm);
         try {
             $client->updateAutoscalingPolicy($policy);
             // If the $client method call did not throw, fail the test

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/CompletionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/CompletionServiceClientTest.php
@@ -33,7 +33,6 @@ use Google\Cloud\Retail\V2alpha\BigQuerySource;
 
 use Google\Cloud\Retail\V2alpha\CompleteQueryResponse;
 use Google\Cloud\Retail\V2alpha\CompletionDataInputConfig;
-use Google\Cloud\Retail\V2alpha\CompletionDataInputConfig\SourceOneof;
 use Google\Cloud\Retail\V2alpha\CompletionServiceClient;
 use Google\Cloud\Retail\V2alpha\ImportCompletionDataResponse;
 use Google\LongRunning\GetOperationRequest;
@@ -178,9 +177,12 @@ class CompletionServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->catalogName('[PROJECT]', '[LOCATION]', '[CATALOG]');
         $inputConfig = new CompletionDataInputConfig();
-        $source = new SourceOneof();
-        $source->setBigQuerySource(new BigQuerySource());
-        $inputConfig->setBigQuerySource($source);
+        $inputConfigBigQuerySource = new BigQuerySource();
+        $bigQuerySourceDatasetId = 'bigQuerySourceDatasetId-567522032';
+        $inputConfigBigQuerySource->setDatasetId($bigQuerySourceDatasetId);
+        $bigQuerySourceTableId = 'bigQuerySourceTableId1074792998';
+        $inputConfigBigQuerySource->setTableId($bigQuerySourceTableId);
+        $inputConfig->setBigQuerySource($inputConfigBigQuerySource);
         $response = $client->importCompletionData($formattedParent, $inputConfig);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -250,9 +252,12 @@ class CompletionServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->catalogName('[PROJECT]', '[LOCATION]', '[CATALOG]');
         $inputConfig = new CompletionDataInputConfig();
-        $source = new SourceOneof();
-        $source->setBigQuerySource(new BigQuerySource());
-        $inputConfig->setBigQuerySource($source);
+        $inputConfigBigQuerySource = new BigQuerySource();
+        $bigQuerySourceDatasetId = 'bigQuerySourceDatasetId-567522032';
+        $inputConfigBigQuerySource->setDatasetId($bigQuerySourceDatasetId);
+        $bigQuerySourceTableId = 'bigQuerySourceTableId1074792998';
+        $inputConfigBigQuerySource->setTableId($bigQuerySourceTableId);
+        $inputConfig->setBigQuerySource($inputConfigBigQuerySource);
         $response = $client->importCompletionData($formattedParent, $inputConfig);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/UserEventServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/UserEventServiceClientTest.php
@@ -31,15 +31,12 @@ use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 
-use Google\Cloud\Retail\V2alpha\BigQuerySource;
-use Google\Cloud\Retail\V2alpha\GcsSource;
 use Google\Cloud\Retail\V2alpha\ImportUserEventsResponse;
 use Google\Cloud\Retail\V2alpha\PurgeUserEventsResponse;
 use Google\Cloud\Retail\V2alpha\RejoinUserEventsResponse;
 use Google\Cloud\Retail\V2alpha\UserEvent;
 use Google\Cloud\Retail\V2alpha\UserEventInlineSource;
 use Google\Cloud\Retail\V2alpha\UserEventInputConfig;
-use Google\Cloud\Retail\V2alpha\UserEventInputConfig\SourceOneof;
 use Google\Cloud\Retail\V2alpha\UserEventServiceClient;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
@@ -185,15 +182,10 @@ class UserEventServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->catalogName('[PROJECT]', '[LOCATION]', '[CATALOG]');
         $inputConfig = new UserEventInputConfig();
-        $source = new SourceOneof();
-        $source->setUserEventInlineSource(new UserEventInlineSource());
-        $inputConfig->setUserEventInlineSource($source);
-        $source = new SourceOneof();
-        $source->setGcsSource(new GcsSource());
-        $inputConfig->setGcsSource($source);
-        $source = new SourceOneof();
-        $source->setBigQuerySource(new BigQuerySource());
-        $inputConfig->setBigQuerySource($source);
+        $inputConfigUserEventInlineSource = new UserEventInlineSource();
+        $userEventInlineSourceUserEvents = [];
+        $inputConfigUserEventInlineSource->setUserEvents($userEventInlineSourceUserEvents);
+        $inputConfig->setUserEventInlineSource($inputConfigUserEventInlineSource);
         $response = $client->importUserEvents($formattedParent, $inputConfig);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());
@@ -263,15 +255,10 @@ class UserEventServiceClientTest extends GeneratedTest
         // Mock request
         $formattedParent = $client->catalogName('[PROJECT]', '[LOCATION]', '[CATALOG]');
         $inputConfig = new UserEventInputConfig();
-        $source = new SourceOneof();
-        $source->setUserEventInlineSource(new UserEventInlineSource());
-        $inputConfig->setUserEventInlineSource($source);
-        $source = new SourceOneof();
-        $source->setGcsSource(new GcsSource());
-        $inputConfig->setGcsSource($source);
-        $source = new SourceOneof();
-        $source->setBigQuerySource(new BigQuerySource());
-        $inputConfig->setBigQuerySource($source);
+        $inputConfigUserEventInlineSource = new UserEventInlineSource();
+        $userEventInlineSourceUserEvents = [];
+        $inputConfigUserEventInlineSource->setUserEvents($userEventInlineSourceUserEvents);
+        $inputConfig->setUserEventInlineSource($inputConfigUserEventInlineSource);
         $response = $client->importUserEvents($formattedParent, $inputConfig);
         $this->assertFalse($response->isDone());
         $this->assertNull($response->getResult());

--- a/tests/Unit/ProtoTests/BasicOneof/basic-oneof.proto
+++ b/tests/Unit/ProtoTests/BasicOneof/basic-oneof.proto
@@ -60,6 +60,16 @@ message Request {
     // An optional count.
     int32 optional_count = 11;
   }
+
+  message Other {
+    oneof other_of {
+      string first = 1 [(google.api.field_behavior) = REQUIRED];
+
+      string second = 2 [(google.api.field_behavior) = REQUIRED];
+    }
+  }
+
+  Other other = 12 [(google.api.field_behavior) = REQUIRED];
 }
 
 message Response {}

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
@@ -33,6 +33,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\BasicOneof\Request;
+use Testing\BasicOneof\Request\Other;
 use Testing\BasicOneof\Request\SupplementaryDataOneof;
 use Testing\BasicOneof\Response;
 
@@ -46,7 +47,8 @@ use Testing\BasicOneof\Response;
  * $basicOneofClient = new BasicOneofClient();
  * try {
  *     $supplementaryData = (new SupplementaryDataOneof())->setExtraDescription('extra_description');
- *     $response = $basicOneofClient->aMethod($supplementaryData);
+ *     $other = new Other();
+ *     $response = $basicOneofClient->aMethod($supplementaryData, $other);
  * } finally {
  *     $basicOneofClient->close();
  * }
@@ -171,13 +173,15 @@ class BasicOneofGapicClient
      * $basicOneofClient = new BasicOneofClient();
      * try {
      *     $supplementaryData = (new SupplementaryDataOneof())->setExtraDescription('extra_description');
-     *     $response = $basicOneofClient->aMethod($supplementaryData);
+     *     $other = new Other();
+     *     $response = $basicOneofClient->aMethod($supplementaryData, $other);
      * } finally {
      *     $basicOneofClient->close();
      * }
      * ```
      *
      * @param SupplementaryDataOneof $supplementaryData An instance of the wrapper class for the required proto oneof supplementary_data.
+     * @param Other                  $other
      * @param array                  $optionalArgs      {
      *     Optional.
      *
@@ -197,7 +201,7 @@ class BasicOneofGapicClient
      *
      * @throws ApiException if the remote call fails
      */
-    public function aMethod($supplementaryData, array $optionalArgs = [])
+    public function aMethod($supplementaryData, $other, array $optionalArgs = [])
     {
         $request = new Request();
         if ($supplementaryData->isExtraDescription()) {
@@ -219,6 +223,7 @@ class BasicOneofGapicClient
         }
 
         
+        $request->setOther($other);
         if (isset($optionalArgs['anInt'])) {
             $request->setAnInt($optionalArgs['anInt']);
         }

--- a/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/BasicOneofClientTest.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/BasicOneofClientTest.php
@@ -31,6 +31,7 @@ use Google\Rpc\Code;
 use stdClass;
 use Testing\BasicOneof\BasicOneofClient;
 use Testing\BasicOneof\Request;
+use Testing\BasicOneof\Request\Other;
 use Testing\BasicOneof\Request\SupplementaryDataOneof;
 use Testing\BasicOneof\Response;
 
@@ -84,7 +85,10 @@ class BasicOneofClientTest extends GeneratedTest
         // Mock request
         $supplementaryData = new SupplementaryDataOneof();
         $supplementaryData->setExtraDescription('extraDescription-1352933811');
-        $response = $client->aMethod($supplementaryData);
+        $other = new Other();
+        $otherFirst = 'otherFirst-205632128';
+        $other->setFirst($otherFirst);
+        $response = $client->aMethod($supplementaryData, $other);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -93,6 +97,8 @@ class BasicOneofClientTest extends GeneratedTest
         $this->assertSame('/testing.basiconeof.BasicOneof/AMethod', $actualFuncCall);
         $actualValue = $actualRequestObject->getExtraDescription();
         $this->assertTrue($supplementaryData->isExtraDescription());
+        $actualValue = $actualRequestObject->getOther();
+        $this->assertProtobufEquals($other, $actualValue);
         $this->assertTrue($transport->isExhausted());
     }
 
@@ -119,8 +125,11 @@ class BasicOneofClientTest extends GeneratedTest
         // Mock request
         $supplementaryData = new SupplementaryDataOneof();
         $supplementaryData->setExtraDescription('extraDescription-1352933811');
+        $other = new Other();
+        $otherFirst = 'otherFirst-205632128';
+        $other->setFirst($otherFirst);
         try {
-            $client->aMethod($supplementaryData);
+            $client->aMethod($supplementaryData, $other);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {


### PR DESCRIPTION
Ensures that only top-level "required" oneof fields are wrapped in generated unit tests.
Ensures that only the first of the "required" oneof fields are generated in unit tests.
Update integration test baselines.
Add sub-message "required" oneof to BasicOneOf test.