### PR TITLE
fix(bazel): configure php with curl if rebuilding

### DIFF
--- a/rules_php_gapic/php_repo.bzl
+++ b/rules_php_gapic/php_repo.bzl
@@ -71,6 +71,7 @@ exports_files(glob(include = ["bin/*", "lib/**"], exclude_directories = 0))
             "--enable-json",
             "--enable-filter",
             "--enable-tokenizer",
+            "--with-curl",
             "--with-libxml",
             "--enable-xml",
             "--enable-dom",


### PR DESCRIPTION
Ensures that if the PHP binary is rebuilt at build time, the proper options are included, specifically `--with-curl`.