### PR TITLE
fix: better fix for ignoring required synthetic oneofs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "google/protobuf": "^3.18",
         "friendsofphp/php-cs-fixer": "^2.16",
         "symfony/yaml": "^5.2"

--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -180,8 +180,9 @@ class FieldDetails
         }
         // Use fancy fooName() methods only if this isn't a wildcard pattern.
         $this->useResourceTestValue = !is_null($this->resourceDetails) && count($this->resourceDetails->patterns) > 0;
-        $this->oneOfIndex = $field->hasOneofIndex() ? $field->getOneofIndex() : null;
-        $this->isOneOf = $field->hasOneofIndex();
+        // Ignore synthetic oneofs created by proto3_optional fields.
+        $this->isOneOf = $field->hasOneofIndex() && !$field->getProto3Optional();
+        $this->oneOfIndex = $this->isOneOf ? $field->getOneofIndex() : null;
     }
 
     private function determineIsRequired(DescriptorProto $containingMessage, FieldDescriptorProto $field)

--- a/src/Generation/OneofWrapperGenerator.php
+++ b/src/Generation/OneofWrapperGenerator.php
@@ -65,7 +65,6 @@ class OneofWrapperGenerator
             $currOneofFieldNames = Vector::new([]) ;
             foreach ($method->requiredFields as $requiredField) {
                 if (!$requiredField->isOneOf
-                    || $requiredField->desc->getProto3Optional()
                     || ($requiredField->oneOfIndex === $currOneofIndex && $currOneofFieldNames->contains($requiredField->name))) {
                     continue;
                 }

--- a/tests/Unit/ProtoTests/BasicOneof/basic-oneof.proto
+++ b/tests/Unit/ProtoTests/BasicOneof/basic-oneof.proto
@@ -70,6 +70,8 @@ message Request {
   }
 
   Other other = 12 [(google.api.field_behavior) = REQUIRED];
+
+  optional string required_optional = 13 [(google.api.field_behavior) = REQUIRED];
 }
 
 message Response {}

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
@@ -48,7 +48,8 @@ use Testing\BasicOneof\Response;
  * try {
  *     $supplementaryData = (new SupplementaryDataOneof())->setExtraDescription('extra_description');
  *     $other = new Other();
- *     $response = $basicOneofClient->aMethod($supplementaryData, $other);
+ *     $requiredOptional = 'required_optional';
+ *     $response = $basicOneofClient->aMethod($supplementaryData, $other, $requiredOptional);
  * } finally {
  *     $basicOneofClient->close();
  * }
@@ -174,7 +175,8 @@ class BasicOneofGapicClient
      * try {
      *     $supplementaryData = (new SupplementaryDataOneof())->setExtraDescription('extra_description');
      *     $other = new Other();
-     *     $response = $basicOneofClient->aMethod($supplementaryData, $other);
+     *     $requiredOptional = 'required_optional';
+     *     $response = $basicOneofClient->aMethod($supplementaryData, $other, $requiredOptional);
      * } finally {
      *     $basicOneofClient->close();
      * }
@@ -182,6 +184,7 @@ class BasicOneofGapicClient
      *
      * @param SupplementaryDataOneof $supplementaryData An instance of the wrapper class for the required proto oneof supplementary_data.
      * @param Other                  $other
+     * @param string                 $requiredOptional
      * @param array                  $optionalArgs      {
      *     Optional.
      *
@@ -201,7 +204,7 @@ class BasicOneofGapicClient
      *
      * @throws ApiException if the remote call fails
      */
-    public function aMethod($supplementaryData, $other, array $optionalArgs = [])
+    public function aMethod($supplementaryData, $other, $requiredOptional, array $optionalArgs = [])
     {
         $request = new Request();
         if ($supplementaryData->isExtraDescription()) {
@@ -224,6 +227,7 @@ class BasicOneofGapicClient
 
         
         $request->setOther($other);
+        $request->setRequiredOptional($requiredOptional);
         if (isset($optionalArgs['anInt'])) {
             $request->setAnInt($optionalArgs['anInt']);
         }

--- a/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/BasicOneofClientTest.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/BasicOneofClientTest.php
@@ -88,7 +88,8 @@ class BasicOneofClientTest extends GeneratedTest
         $other = new Other();
         $otherFirst = 'otherFirst-205632128';
         $other->setFirst($otherFirst);
-        $response = $client->aMethod($supplementaryData, $other);
+        $requiredOptional = 'requiredOptional987493376';
+        $response = $client->aMethod($supplementaryData, $other, $requiredOptional);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -99,6 +100,8 @@ class BasicOneofClientTest extends GeneratedTest
         $this->assertTrue($supplementaryData->isExtraDescription());
         $actualValue = $actualRequestObject->getOther();
         $this->assertProtobufEquals($other, $actualValue);
+        $actualValue = $actualRequestObject->getRequiredOptional();
+        $this->assertProtobufEquals($requiredOptional, $actualValue);
         $this->assertTrue($transport->isExhausted());
     }
 
@@ -128,8 +131,9 @@ class BasicOneofClientTest extends GeneratedTest
         $other = new Other();
         $otherFirst = 'otherFirst-205632128';
         $other->setFirst($otherFirst);
+        $requiredOptional = 'requiredOptional987493376';
         try {
-            $client->aMethod($supplementaryData, $other);
+            $client->aMethod($supplementaryData, $other, $requiredOptional);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {


### PR DESCRIPTION
This is a better fix for #475 than #476, ignoring the synthetic `oneof` at the FieldDetails level rather than everywhere the field is checked as a `oneof`.

Also allow use of PHP 8.x with the generator.