### PR TITLE
feat: numeric enum option generation

### DIFF
--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -62,11 +62,11 @@ php_gapic_library(
     gapic_yaml = ":example-gapic.yaml",
     grpc_service_config = ":example-grpc-service-config.json",
     service_yaml = ":example-service.yaml",
+    rest_numeric_enums = True,
     deps = [
         ":example_php_grpc",
         ":example_php_proto",
     ],
-    rest_numeric_enums = True,
 )
 
 php_gapic_assembly_pkg(

--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -66,6 +66,7 @@ php_gapic_library(
         ":example_php_grpc",
         ":example_php_proto",
     ],
+    rest_numeric_enums = True,
 )
 
 php_gapic_assembly_pkg(

--- a/bazel_example/BUILD.bazel
+++ b/bazel_example/BUILD.bazel
@@ -62,7 +62,6 @@ php_gapic_library(
     gapic_yaml = ":example-gapic.yaml",
     grpc_service_config = ":example-grpc-service-config.json",
     service_yaml = ":example-service.yaml",
-    rest_numeric_enums = True,
     deps = [
         ":example_php_grpc",
         ":example_php_proto",

--- a/rules_php_gapic/php_gapic.bzl
+++ b/rules_php_gapic/php_gapic.bzl
@@ -76,7 +76,8 @@ def php_gapic_srcjar(
     plugin_args = ["metadata"]  # Generate the gapic_metadata.json file.
     plugin_args.append("transport=%s" % transport)
     
-    if rest_numeric_enums: # Generate REGAPIC param for enum response encoding.
+    # Generate REGAPIC param for requesting response enums be JSON-encoded as numbers, not strings.
+    if rest_numeric_enums:
         plugin_args.append("rest-numeric-enums")
 
     proto_custom_library(

--- a/rules_php_gapic/php_gapic.bzl
+++ b/rules_php_gapic/php_gapic.bzl
@@ -52,6 +52,7 @@ def php_gapic_srcjar(
         service_yaml = None,
         grpc_service_config = None,
         transport = None,
+        rest_numeric_enums = False,
         **kwargs):
     plugin_file_args = {}
     if gapic_yaml:
@@ -69,9 +70,13 @@ def php_gapic_srcjar(
     if transport != "grpc+rest" and transport != "rest":
         fail("Error: Only 'grpc+rest' or 'rest' transports are supported")
 
+
     # Set plugin arguments.
     plugin_args = ["metadata"]  # Generate the gapic_metadata.json file.
     plugin_args.append("transport=%s" % transport)
+    
+    if rest_numeric_enums: # Generate REGAPIC param for enum response encoding.
+        plugin_args.append("rest-numeric-enums")
 
     proto_custom_library(
         name = name,
@@ -105,6 +110,7 @@ def php_gapic_library(
         service_yaml = None,
         grpc_service_config = None,
         transport = None,
+        rest_numeric_enums = False,
         **kwargs):
     srcjar_name = "%s_srcjar" % name
 

--- a/rules_php_gapic/php_gapic.bzl
+++ b/rules_php_gapic/php_gapic.bzl
@@ -121,6 +121,7 @@ def php_gapic_library(
         service_yaml = service_yaml,
         grpc_service_config = grpc_service_config,
         transport = transport,
+        rest_numeric_enums = rest_numeric_enums,
         **kwargs
     )
 

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -157,7 +157,7 @@ class CodeGenerator
             foreach ($singlePackageFileDescs as $fileDesc) {
                 foreach ($fileDesc->getService() as $index => $service) {
                     $serviceDetails =
-                        new ServiceDetails($catalog, $namespaces[0], $fileDesc->getPackage(), $service, $fileDesc, $transportType, $numericEnums);
+                        new ServiceDetails($catalog, $namespaces[0], $fileDesc->getPackage(), $service, $fileDesc, $transportType);
                     $serviceName = $serviceDetails->serviceName;
                     if (!in_array($serviceName, self::MIXIN_SERVICES)) {
                         $servicesToGenerate[] = $serviceDetails;
@@ -309,7 +309,7 @@ class CodeGenerator
             $code = Formatter::format($code);
             yield ["src/{$version}resources/{$service->descriptorConfigFilename}", $code];
             // Resource: rest_client_config.php
-            $code = ResourcesGenerator::generateRestConfig($service, $serviceYamlConfig);
+            $code = ResourcesGenerator::generateRestConfig($service, $serviceYamlConfig, $numericEnums);
             $code = Formatter::format($code);
             yield ["src/{$version}resources/{$service->restConfigFilename}", $code];
             // Resource: client_config.json

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -93,7 +93,8 @@ class CodeGenerator
      * @param ?string $grpcServiceConfigJson Optional grpc-serv-config json string.
      * @param ?string $gapicYaml Optional gapic configuration yaml string.
      * @param ?string $serviceYaml Optional service configuration yaml string.
-     * @param bool $numericEnums Optional whether to generate the numeric-enums JSON encoding system parameter.
+     * @param bool $numericEnums Optional whether to include in requests the system parameter enabling JSON-encoded
+     *     responses to encode enum values as numbers.
      * @param int $licenseYear The year to use in license headers.
      *
      * @return array[] [0] (string) is relative path; [1] (string) is file content.

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -181,7 +181,7 @@ class ResourcesGenerator
         return AST::array($methodDetails);
     }
 
-    public static function generateRestConfig(ServiceDetails $serviceDetails, ServiceYamlConfig $serviceYamlConfig): string
+    public static function generateRestConfig(ServiceDetails $serviceDetails, ServiceYamlConfig $serviceYamlConfig, $numericEnums = false): string
     {
         $allInterfaces = static::compileRestConfigInterfaces($serviceDetails, $serviceYamlConfig);
         if ($serviceDetails->hasCustomOp) {
@@ -198,11 +198,17 @@ class ResourcesGenerator
             $opInter = static::compileRestConfigInterfaces($customOpDetails, $serviceYamlConfig);
             $allInterfaces = array_merge($allInterfaces, $opInter);
         }
+
+        $config = [
+            'interfaces' => AST::array($allInterfaces)
+        ];
+
+        if ($numericEnums) {
+            $config['numericEnums'] = true;
+        }
         
         $return = AST::return(
-            AST::array([
-                'interfaces' => AST::array($allInterfaces)
-            ])
+            AST::array($config)
         );
         return "<?php\n\n{$return->toCode()};";
     }

--- a/src/Main.php
+++ b/src/Main.php
@@ -138,7 +138,7 @@ if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
     $descBytes = file_get_contents($opts['descriptor']);
     $package = $opts['package'];
     $outputDir = $opts['output'];
-    [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata] = readOptions($opts);
+    [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata, $numericEnums] = readOptions($opts);
 
     // Generate PHP code.
     $files = CodeGenerator::generateFromDescriptor(
@@ -148,7 +148,8 @@ if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
         $generateGapicMetadata,
         $grpcServiceConfig,
         $gapicYaml,
-        $serviceYaml
+        $serviceYaml,
+        $numericEnums
     );
 
     if (is_null($outputDir)) {
@@ -218,6 +219,7 @@ function readOptions($opts, $sideLoadedRootDir = null)
 
     // Flip the flag value because PHP is weird: the presence of the --metadata flag evaluates to false.
     $generateGapicMetadata =  (isset($opts['metadata']) && !$opts['metadata']);
+    $numericEnums =  (isset($opts['rest-numeric-enums']) && !$opts['rest-numeric-enums']);
 
-    return [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata];
+    return [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata, $numericEnums];
 }

--- a/tests/Tools/GeneratorUtils.php
+++ b/tests/Tools/GeneratorUtils.php
@@ -44,6 +44,7 @@ class GeneratorUtils
         $grpcServiceConfigJson = ConfigLoader::loadConfig("{$protoDirName}/grpc-service-config.json");
         $gapicYaml = ConfigLoader::loadConfig("{$protoDirName}/{$baseName}_gapic.yaml");
         $serviceYaml = ConfigLoader::loadConfig("{$protoDirName}/{$baseName}_service.yaml");
+        $numericEnums = true;
 
         $licenseYear = 2022; // Avoid updating tests all the time.
         $generateGapicMetadata = true;
@@ -55,6 +56,7 @@ class GeneratorUtils
             $grpcServiceConfigJson,
             $gapicYaml,
             $serviceYaml,
+            $numericEnums,
             $licenseYear
         );
         return $codeIterator;

--- a/tests/Unit/ProtoTests/Basic/out/src/resources/basic_rest_client_config.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/resources/basic_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.basic.Basic' => [
             'AMethod' => [

--- a/tests/Unit/ProtoTests/Basic/out/src/resources/basic_rest_client_config.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/resources/basic_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.basic.Basic' => [
             'AMethod' => [
@@ -16,4 +15,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_rest_client_config.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [],
 ];

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_rest_client_config.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [],
 ];

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'google.example.library.v1.LibraryService' => [
             'AddComments' => [
@@ -336,4 +335,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'google.example.library.v1.LibraryService' => [
             'AddComments' => [

--- a/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.basiclro.BasicLro' => [
             'Method1' => [
@@ -21,4 +20,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.basiclro.BasicLro' => [
             'Method1' => [

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.basiconeof.BasicOneof' => [
             'AMethod' => [

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.basiconeof.BasicOneof' => [
             'AMethod' => [
@@ -11,4 +10,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.basicpaginated.BasicPaginated' => [
             'MethodPaginated' => [

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.basicpaginated.BasicPaginated' => [
             'MethodPaginated' => [
@@ -11,4 +10,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.basicserverstreaming.BasicServerStreaming' => [
             'MethodServer' => [

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.basicserverstreaming.BasicServerStreaming' => [
             'MethodServer' => [
@@ -11,4 +10,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_rest_client_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.customlro.CustomLroOperations' => [
             'Cancel' => [

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_rest_client_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.customlro.CustomLroOperations' => [
             'Cancel' => [
@@ -23,4 +22,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_rest_client_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.customlro.CustomLro' => [
             'CreateFoo' => [

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_rest_client_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.customlro.CustomLro' => [
             'CreateFoo' => [
@@ -30,4 +29,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_rest_client_config.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_rest_client_config.php
@@ -1,5 +1,6 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [],
 ];

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_rest_client_config.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_rest_client_config.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_rest_client_config.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1' => [
             'Method1A' => [

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_rest_client_config.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1' => [
             'Method1A' => [
@@ -26,4 +25,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.resourcenames.ResourceNames' => [
             'FileLevelChildTypeRefMethod' => [
@@ -46,4 +45,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.resourcenames.ResourceNames' => [
             'FileLevelChildTypeRefMethod' => [

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_rest_client_config.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_rest_client_config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'numericEnums' => true,
     'interfaces' => [
         'testing.routingheaders.RoutingHeaders' => [
             'DeleteMethod' => [

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_rest_client_config.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_rest_client_config.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'numericEnums' => true,
     'interfaces' => [
         'testing.routingheaders.RoutingHeaders' => [
             'DeleteMethod' => [
@@ -180,4 +179,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];


### PR DESCRIPTION
Adds support for the `rest-numeric-enums` plugin option that enables generation of the `numericEnums` flag in the REST descriptor config supported in https://github.com/googleapis/gax-php/pull/395.