### PR TITLE
fix: continue to support php 7.4

### DIFF
--- a/src/Collections/Map.php
+++ b/src/Collections/Map.php
@@ -146,7 +146,7 @@ class Map implements \IteratorAggregate, \Countable, \ArrayAccess
     }
 
     /** @inheritDoc */
-    public function offsetGet($key): mixed
+    public function offsetGet($key)
     {
         [$exists, $value] = static::Apply($this->data, $key, 0, null);
         if ($exists) {

--- a/src/Collections/Vector.php
+++ b/src/Collections/Vector.php
@@ -120,7 +120,7 @@ class Vector implements \IteratorAggregate, \Countable, \ArrayAccess, Equality
     }
 
     /** @inheritDoc */
-    public function offsetGet($offset): mixed
+    public function offsetGet($offset)
     {
         return $this->data[$offset < 0 ? count($this->data) + $offset : $offset];
     }


### PR DESCRIPTION
The mixed type declaration was introduced in PHP 8