### PR TITLE
chore(deps): update min gax-php to 1.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "google/gax": "^1.10"
+        "google/gax": "^1.16"
     }
 }


### PR DESCRIPTION
Update minimum version of gax-php used by the generator (tests) in order to capture new `Call::{RPC}_TYPE` constants necessary for #504.