### PR TITLE
chore(ast): support array, vector, handle map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ composer.lock
 # Vim
 *.sw*
 *.vim
+
+# VS Code
+.vscode

--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -92,8 +92,15 @@ abstract class AST
             return $x->toCode();
         } elseif ($x instanceof ResolvedType) {
             return $x->toCode();
+        }  elseif (is_array($x)) {
+            return AST::array($x)->toCode();
+        } else if ($x instanceof Vector) {
+            return AST::array($x->toArray())->toCode();
+        } else if ($x instanceof Map) {
+            throw new \Exception("Cannot convert Map to PHP code.");
         } else {
-            throw new \Exception('Cannot convert to PHP code.');
+            $t = gettype($x);
+            throw new \Exception("Cannot convert $t to PHP code.");
         }
     }
 


### PR DESCRIPTION
Support "codifying" `array` and `Vector` types by wrapping them in the corresponding `AST` expression, just like how primitives are handled. Specifically handle `Map` rather than having it be reported as `object`. Include the type of the element that can't be handled in the exception.

With this change, we no longer need to wrap every `array` or `Vector` in an `AST::array` or convert `vector->toArray()` then wrap it - this is done by the AST. Makes code generation helpers easier to test by not requiring that AST Expressions be passed around between function calls, saving code generation/AST wrapping until necessary.