### PR TITLE
feat: generate call config descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ composer.lock
 # Vim
 *.sw*
 *.vim
+
+# VS Code
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ composer.lock
 # Vim
 *.sw*
 *.vim
-
-# VS Code
-.vscode

--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -92,15 +92,8 @@ abstract class AST
             return $x->toCode();
         } elseif ($x instanceof ResolvedType) {
             return $x->toCode();
-        } elseif (is_array($x)) {
-            return AST::array($x)->toCode();
-        } else if ($x instanceof Vector) {
-            return AST::array($x->toArray())->toCode();
-        } else if ($x instanceof Map) {
-            throw new \Exception("Cannot convert Map to PHP code.");
         } else {
-            $t = gettype($x);
-            throw new \Exception("Cannot convert $t to PHP code.");
+            throw new \Exception('Cannot convert to PHP code.');
         }
     }
 

--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -92,8 +92,15 @@ abstract class AST
             return $x->toCode();
         } elseif ($x instanceof ResolvedType) {
             return $x->toCode();
+        } elseif (is_array($x)) {
+            return AST::array($x)->toCode();
+        } else if ($x instanceof Vector) {
+            return AST::array($x->toArray())->toCode();
+        } else if ($x instanceof Map) {
+            throw new \Exception("Cannot convert Map to PHP code.");
         } else {
-            throw new \Exception('Cannot convert to PHP code.');
+            $t = gettype($x);
+            throw new \Exception("Cannot convert $t to PHP code.");
         }
     }
 

--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -528,6 +528,7 @@ abstract class MethodDetails
         $this->httpRule = ProtoHelpers::getCustomOption($desc, CustomOptions::GOOGLE_API_HTTP, HttpRule::class);
         $this->restMethod = is_null($this->httpRule) ? null : $this->httpRule->getPattern();
         // DO NOT SORT - currently in reverse order of the first-seen variables.
+        // TODO(v2): Use ProtoHelpers::implicitParamsDescriptor here instead.
         $this->restRoutingHeaders = is_null($this->httpRule) ? null : ProtoHelpers::restPlaceholders($this->catalog, $this->httpRule, $this->inputMsg);
 
         if ($desc->hasOptions() && $desc->getOptions()->hasDeprecated()) {

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -48,6 +48,8 @@ class ResourcesGenerator
                 case MethodDetails::CUSTOM_OP:
                     $descriptor = [
                         'callType' => AST::literal('\Google\ApiCore\Call::LONGRUNNING_CALL'),
+                        // Include the responseType for Custom Operations because they define their own operation class.
+                        'responseType' => $method->responseType->getFullName(true),
                         'longRunning' => static::customOperationDescriptor($serviceDetails, $method)
                     ];
                     break;

--- a/src/Generation/ResourcesGenerator.php
+++ b/src/Generation/ResourcesGenerator.php
@@ -126,11 +126,10 @@ class ResourcesGenerator
                     ];
                     break;
             }
-            if ($method->routingParameters) {
-                $headerParams = ProtoHelpers::headerParamsDescriptor($method->routingParameters);
-                if ($headerParams) {
-                    $descriptor['headerParams'] = $headerParams;
-                }
+            
+            $headerParams = ProtoHelpers::headerParamsDescriptor($method);
+            if ($headerParams) {
+                $descriptor['headerParams'] = $headerParams;
             }
 
             return Map::new($descriptor);

--- a/src/Utils/ProtoHelpers.php
+++ b/src/Utils/ProtoHelpers.php
@@ -316,6 +316,8 @@ class ProtoHelpers
      */
     public static function restPlaceholders(ProtoCatalog $catalog, HttpRule $httpRule, ?DescriptorProto $msg): Map
     {
+        // TODO(v2): merge this with implicitParamsDescriptor as we won't need to generate an intermediate
+        // representation, because GAPIC will no longer do the header injection.
         $uriTemplateGetter = Helpers::toCamelCase("get_{$httpRule->getPattern()}");
         $restUriTemplate = $httpRule->$uriTemplateGetter();
         if ($restUriTemplate === '') {

--- a/src/Utils/ProtoHelpers.php
+++ b/src/Utils/ProtoHelpers.php
@@ -119,7 +119,7 @@ class ProtoHelpers
     public static function headerParamsDescriptor(MethodDetails $method): array
     {
         if ($method->restRoutingHeaders && !$method->routingParameters) {
-            return static::implicitHeaderParamsDescriptor($method->restRoutingHeaders ?? Map::new());
+            return static::implicitParamsDescriptor($method->restRoutingHeaders ?? Map::new());
         }
 
         return static::routingParamsDescriptor($method->routingParameters ?? Map::new());
@@ -132,7 +132,7 @@ class ProtoHelpers
      * 
      * @return array
      */
-    public static function implicitHeaderParamsDescriptor(Map $implicitParams): array
+    public static function implicitParamsDescriptor(Map $implicitParams): array
     {
         return $implicitParams->keys()
             ->map(fn($key) => [

--- a/tests/Integration/goldens/asset/src/V1/resources/asset_service_descriptor_config.php
+++ b/tests/Integration/goldens/asset/src/V1/resources/asset_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.asset.v1.AssetService' => [
             'AnalyzeIamPolicyLongrunning' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Asset\V1\AnalyzeIamPolicyLongrunningResponse',
                     'metadataReturnType' => '\Google\Cloud\Asset\V1\AnalyzeIamPolicyLongrunningMetadata',
@@ -12,8 +13,18 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getAnalysisQuery',
+                            'getScope',
+                        ],
+                        'keyName' => 'analysis_query.scope',
+                    ],
+                ],
             ],
             'ExportAssets' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Asset\V1\ExportAssetsResponse',
                     'metadataReturnType' => '\Google\Cloud\Asset\V1\ExportAssetsRequest',
@@ -22,8 +33,91 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'AnalyzeIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\AnalyzeIamPolicyResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getAnalysisQuery',
+                            'getScope',
+                        ],
+                        'keyName' => 'analysis_query.scope',
+                    ],
+                ],
+            ],
+            'AnalyzeMove' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\AnalyzeMoveResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'BatchGetAssetsHistory' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\BatchGetAssetsHistoryResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateFeed' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\Feed',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteFeed' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetFeed' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\Feed',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListAssets' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\ListAssetsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -32,8 +126,30 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getAssets',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'ListFeeds' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\ListFeedsResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'SearchAllIamPolicies' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\SearchAllIamPoliciesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -42,8 +158,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getResults',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getScope',
+                        ],
+                        'keyName' => 'scope',
+                    ],
+                ],
             ],
             'SearchAllResources' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\SearchAllResourcesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -51,6 +177,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getResults',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getScope',
+                        ],
+                        'keyName' => 'scope',
+                    ],
+                ],
+            ],
+            'UpdateFeed' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Asset\V1\Feed',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getFeed',
+                            'getName',
+                        ],
+                        'keyName' => 'feed.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/compute_small/src/V1/resources/addresses_descriptor_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/addresses_descriptor_config.php
@@ -5,6 +5,7 @@ return [
         'google.cloud.compute.v1.Addresses' => [
             'Delete' => [
                 'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
+                'responseType' => 'Google\Cloud\Compute\V1\Operation',
                 'longRunning' => [
                     'additionalArgumentMethods' => [
                         'getProject',
@@ -42,6 +43,7 @@ return [
             ],
             'Insert' => [
                 'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
+                'responseType' => 'Google\Cloud\Compute\V1\Operation',
                 'longRunning' => [
                     'additionalArgumentMethods' => [
                         'getProject',

--- a/tests/Integration/goldens/compute_small/src/V1/resources/addresses_descriptor_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/addresses_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.compute.v1.Addresses' => [
             'Delete' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'additionalArgumentMethods' => [
                         'getProject',
@@ -17,9 +18,30 @@ return [
                     'operationNameMethod' => 'getName',
                     'operationStatusMethod' => 'getStatus',
                     'operationStatusDoneValue' => \Google\Cloud\Compute\V1\Operation\Status::DONE,
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProject',
+                        ],
+                        'keyName' => 'project',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getAddress',
+                        ],
+                        'keyName' => 'address',
+                    ],
                 ],
             ],
             'Insert' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'additionalArgumentMethods' => [
                         'getProject',
@@ -34,8 +56,24 @@ return [
                     'operationStatusMethod' => 'getStatus',
                     'operationStatusDoneValue' => \Google\Cloud\Compute\V1\Operation\Status::DONE,
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProject',
+                        ],
+                        'keyName' => 'project',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                ],
             ],
             'AggregatedList' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Compute\V1\AddressAggregatedList',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -44,8 +82,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getItems',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProject',
+                        ],
+                        'keyName' => 'project',
+                    ],
+                ],
             ],
             'List' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Compute\V1\AddressList',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -53,6 +101,20 @@ return [
                     'requestPageSizeSetMethod' => 'setMaxResults',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getItems',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProject',
+                        ],
+                        'keyName' => 'project',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/compute_small/src/V1/resources/region_operations_descriptor_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/region_operations_descriptor_config.php
@@ -2,6 +2,31 @@
 
 return [
     'interfaces' => [
-        'google.cloud.compute.v1.RegionOperations' => [],
+        'google.cloud.compute.v1.RegionOperations' => [
+            'Get' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Compute\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProject',
+                        ],
+                        'keyName' => 'project',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getOperation',
+                        ],
+                        'keyName' => 'operation',
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/tests/Integration/goldens/container/src/V1/resources/cluster_manager_descriptor_config.php
+++ b/tests/Integration/goldens/container/src/V1/resources/cluster_manager_descriptor_config.php
@@ -3,7 +3,399 @@
 return [
     'interfaces' => [
         'google.container.v1.ClusterManager' => [
+            'CancelOperation' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getOperationId',
+                        ],
+                        'keyName' => 'operation_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'CompleteIPRotation' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'CreateCluster' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateNodePool' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteCluster' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'DeleteNodePool' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetCluster' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Cluster',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetJSONWebKeys' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\GetJSONWebKeysResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'GetNodePool' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\NodePool',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetOperation' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getOperationId',
+                        ],
+                        'keyName' => 'operation_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetServerConfig' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\ServerConfig',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'ListClusters' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\ListClustersResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'ListNodePools' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\ListNodePoolsResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'ListOperations' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\ListOperationsResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
             'ListUsableSubnetworks' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\ListUsableSubnetworksResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +403,554 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getSubnetworks',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'RollbackNodePoolUpgrade' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetAddonsConfig' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetLabels' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetLegacyAbac' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetLocations' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetLoggingService' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetMaintenancePolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetMasterAuth' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetMonitoringService' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetNetworkPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetNodePoolAutoscaling' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetNodePoolManagement' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetNodePoolSize' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'StartIPRotation' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateCluster' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateMaster' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateNodePool' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Container\V1\Operation',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getZone',
+                        ],
+                        'keyName' => 'zone',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterId',
+                        ],
+                        'keyName' => 'cluster_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNodePoolId',
+                        ],
+                        'keyName' => 'node_pool_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/dataproc/src/V1/resources/autoscaling_policy_service_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/autoscaling_policy_service_descriptor_config.php
@@ -3,7 +3,45 @@
 return [
     'interfaces' => [
         'google.cloud.dataproc.v1.AutoscalingPolicyService' => [
+            'CreateAutoscalingPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\AutoscalingPolicy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteAutoscalingPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetAutoscalingPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\AutoscalingPolicy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
             'ListAutoscalingPolicies' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\ListAutoscalingPoliciesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +49,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getPolicies',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateAutoscalingPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\AutoscalingPolicy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getPolicy',
+                            'getName',
+                        ],
+                        'keyName' => 'policy.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/dataproc/src/V1/resources/cluster_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/cluster_controller_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.dataproc.v1.ClusterController' => [
             'CreateCluster' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Dataproc\V1\Cluster',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\ClusterOperationMetadata',
@@ -12,8 +13,23 @@ return [
                     'maxPollDelayMillis' => '10000',
                     'totalPollTimeoutMillis' => '900000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                ],
             ],
             'DeleteCluster' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Protobuf\GPBEmpty',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\ClusterOperationMetadata',
@@ -22,8 +38,29 @@ return [
                     'maxPollDelayMillis' => '10000',
                     'totalPollTimeoutMillis' => '900000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterName',
+                        ],
+                        'keyName' => 'cluster_name',
+                    ],
+                ],
             ],
             'DiagnoseCluster' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Dataproc\V1\DiagnoseClusterResults',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\ClusterOperationMetadata',
@@ -32,8 +69,29 @@ return [
                     'maxPollDelayMillis' => '10000',
                     'totalPollTimeoutMillis' => '30000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterName',
+                        ],
+                        'keyName' => 'cluster_name',
+                    ],
+                ],
             ],
             'StartCluster' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Dataproc\V1\Cluster',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\ClusterOperationMetadata',
@@ -41,9 +99,30 @@ return [
                     'pollDelayMultiplier' => '1.5',
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterName',
+                        ],
+                        'keyName' => 'cluster_name',
+                    ],
                 ],
             ],
             'StopCluster' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Dataproc\V1\Cluster',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\ClusterOperationMetadata',
@@ -52,8 +131,29 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterName',
+                        ],
+                        'keyName' => 'cluster_name',
+                    ],
+                ],
             ],
             'UpdateCluster' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Dataproc\V1\Cluster',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\ClusterOperationMetadata',
@@ -62,8 +162,54 @@ return [
                     'maxPollDelayMillis' => '10000',
                     'totalPollTimeoutMillis' => '900000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterName',
+                        ],
+                        'keyName' => 'cluster_name',
+                    ],
+                ],
+            ],
+            'GetCluster' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\Cluster',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getClusterName',
+                        ],
+                        'keyName' => 'cluster_name',
+                    ],
+                ],
             ],
             'ListClusters' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\ListClustersResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -71,6 +217,20 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getClusters',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/dataproc/src/V1/resources/job_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/job_controller_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.dataproc.v1.JobController' => [
             'SubmitJobAsOperation' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Dataproc\V1\Job',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\JobMetadata',
@@ -12,8 +13,96 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                ],
+            ],
+            'CancelJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getJobId',
+                        ],
+                        'keyName' => 'job_id',
+                    ],
+                ],
+            ],
+            'DeleteJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getJobId',
+                        ],
+                        'keyName' => 'job_id',
+                    ],
+                ],
+            ],
+            'GetJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getJobId',
+                        ],
+                        'keyName' => 'job_id',
+                    ],
+                ],
             ],
             'ListJobs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\ListJobsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -21,6 +110,62 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getJobs',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                ],
+            ],
+            'SubmitJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                ],
+            ],
+            'UpdateJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProjectId',
+                        ],
+                        'keyName' => 'project_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getRegion',
+                        ],
+                        'keyName' => 'region',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getJobId',
+                        ],
+                        'keyName' => 'job_id',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/dataproc/src/V1/resources/workflow_template_service_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/workflow_template_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.dataproc.v1.WorkflowTemplateService' => [
             'InstantiateInlineWorkflowTemplate' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Protobuf\GPBEmpty',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\WorkflowMetadata',
@@ -11,9 +12,18 @@ return [
                     'pollDelayMultiplier' => '2.0',
                     'maxPollDelayMillis' => '10000',
                     'totalPollTimeoutMillis' => '43200000',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
                 ],
             ],
             'InstantiateWorkflowTemplate' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Protobuf\GPBEmpty',
                     'metadataReturnType' => '\Google\Cloud\Dataproc\V1\WorkflowMetadata',
@@ -22,8 +32,54 @@ return [
                     'maxPollDelayMillis' => '10000',
                     'totalPollTimeoutMillis' => '43200000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'CreateWorkflowTemplate' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\WorkflowTemplate',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteWorkflowTemplate' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetWorkflowTemplate' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\WorkflowTemplate',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListWorkflowTemplates' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\ListWorkflowTemplatesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -31,6 +87,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getTemplates',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateWorkflowTemplate' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Dataproc\V1\WorkflowTemplate',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getTemplate',
+                            'getName',
+                        ],
+                        'keyName' => 'template.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/functions/src/V1/resources/cloud_functions_service_descriptor_config.php
+++ b/tests/Integration/goldens/functions/src/V1/resources/cloud_functions_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.functions.v1.CloudFunctionsService' => [
             'CreateFunction' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Functions\V1\CloudFunction',
                     'metadataReturnType' => '\Google\Cloud\Functions\V1\OperationMetadataV1',
@@ -12,8 +13,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getLocation',
+                        ],
+                        'keyName' => 'location',
+                    ],
+                ],
             ],
             'DeleteFunction' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Protobuf\GPBEmpty',
                     'metadataReturnType' => '\Google\Cloud\Functions\V1\OperationMetadataV1',
@@ -22,8 +32,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'UpdateFunction' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Functions\V1\CloudFunction',
                     'metadataReturnType' => '\Google\Cloud\Functions\V1\OperationMetadataV1',
@@ -32,8 +51,79 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getFunction',
+                            'getName',
+                        ],
+                        'keyName' => 'function.name',
+                    ],
+                ],
+            ],
+            'CallFunction' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Functions\V1\CallFunctionResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GenerateDownloadUrl' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Functions\V1\GenerateDownloadUrlResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GenerateUploadUrl' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Functions\V1\GenerateUploadUrlResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'GetFunction' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Functions\V1\CloudFunction',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
             ],
             'ListFunctions' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Functions\V1\ListFunctionsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -41,6 +131,38 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getFunctions',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'SetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'TestIamPermissions' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\TestIamPermissionsResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/iam/src/V1/resources/iam_policy_descriptor_config.php
+++ b/tests/Integration/goldens/iam/src/V1/resources/iam_policy_descriptor_config.php
@@ -2,6 +2,43 @@
 
 return [
     'interfaces' => [
-        'google.iam.v1.IAMPolicy' => [],
+        'google.iam.v1.IAMPolicy' => [
+            'GetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'SetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'TestIamPermissions' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\TestIamPermissionsResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/tests/Integration/goldens/kms/src/V1/resources/key_management_service_descriptor_config.php
+++ b/tests/Integration/goldens/kms/src/V1/resources/key_management_service_descriptor_config.php
@@ -3,7 +3,201 @@
 return [
     'interfaces' => [
         'google.cloud.kms.v1.KeyManagementService' => [
+            'AsymmetricDecrypt' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\AsymmetricDecryptResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'AsymmetricSign' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\AsymmetricSignResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'CreateCryptoKey' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKey',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateCryptoKeyVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKeyVersion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateImportJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\ImportJob',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateKeyRing' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\KeyRing',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'Decrypt' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\DecryptResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'DestroyCryptoKeyVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKeyVersion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'Encrypt' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\EncryptResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetCryptoKey' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKey',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetCryptoKeyVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKeyVersion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'GetImportJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\ImportJob',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetKeyRing' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\KeyRing',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetPublicKey' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\PublicKey',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'ImportCryptoKeyVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKeyVersion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
             'ListCryptoKeyVersions' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\ListCryptoKeyVersionsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -12,8 +206,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getCryptoKeyVersions',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListCryptoKeys' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\ListCryptoKeysResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -22,8 +226,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getCryptoKeys',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListImportJobs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\ListImportJobsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -32,8 +246,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getImportJobs',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListKeyRings' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\ListKeyRingsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -42,8 +266,80 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getKeyRings',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'RestoreCryptoKeyVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKeyVersion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateCryptoKey' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKey',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCryptoKey',
+                            'getName',
+                        ],
+                        'keyName' => 'crypto_key.name',
+                    ],
+                ],
+            ],
+            'UpdateCryptoKeyPrimaryVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKey',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateCryptoKeyVersion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Kms\V1\CryptoKeyVersion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCryptoKeyVersion',
+                            'getName',
+                        ],
+                        'keyName' => 'crypto_key_version.name',
+                    ],
+                ],
+            ],
+            'GetLocation' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Location\Location',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListLocations' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Location\ListLocationsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -51,6 +347,14 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getLocations',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/logging/src/V2/resources/config_service_v2_descriptor_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/config_service_v2_descriptor_config.php
@@ -3,7 +3,165 @@
 return [
     'interfaces' => [
         'google.logging.v2.ConfigServiceV2' => [
+            'CreateBucket' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogBucket',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateExclusion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogExclusion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateSink' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogSink',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateView' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogView',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteBucket' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'DeleteExclusion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'DeleteSink' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSinkName',
+                        ],
+                        'keyName' => 'sink_name',
+                    ],
+                ],
+            ],
+            'DeleteView' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetBucket' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogBucket',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetCmekSettings' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\CmekSettings',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetExclusion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogExclusion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetSink' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogSink',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSinkName',
+                        ],
+                        'keyName' => 'sink_name',
+                    ],
+                ],
+            ],
+            'GetView' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogView',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
             'ListBuckets' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListBucketsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -12,8 +170,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getBuckets',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListExclusions' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListExclusionsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -22,8 +190,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getExclusions',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListSinks' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListSinksResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -32,8 +210,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getSinks',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListViews' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListViewsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -41,6 +229,86 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getViews',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UndeleteBucket' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateBucket' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogBucket',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateCmekSettings' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\CmekSettings',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateExclusion' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogExclusion',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'UpdateSink' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogSink',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSinkName',
+                        ],
+                        'keyName' => 'sink_name',
+                    ],
+                ],
+            ],
+            'UpdateView' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogView',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/logging/src/V2/resources/logging_service_v2_descriptor_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/logging_service_v2_descriptor_config.php
@@ -3,7 +3,21 @@
 return [
     'interfaces' => [
         'google.logging.v2.LoggingServiceV2' => [
+            'DeleteLog' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getLogName',
+                        ],
+                        'keyName' => 'log_name',
+                    ],
+                ],
+            ],
             'ListLogEntries' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListLogEntriesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -14,6 +28,8 @@ return [
                 ],
             ],
             'ListLogs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListLogsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -22,8 +38,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getLogNames',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListMonitoredResourceDescriptors' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListMonitoredResourceDescriptorsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -34,9 +60,15 @@ return [
                 ],
             ],
             'TailLogEntries' => [
+                'callType' => \Google\ApiCore\Call::BIDI_STREAMING_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\TailLogEntriesResponse',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'BidiStreaming',
                 ],
+            ],
+            'WriteLogEntries' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\WriteLogEntriesResponse',
             ],
         ],
     ],

--- a/tests/Integration/goldens/logging/src/V2/resources/metrics_service_v2_descriptor_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/metrics_service_v2_descriptor_config.php
@@ -3,7 +3,45 @@
 return [
     'interfaces' => [
         'google.logging.v2.MetricsServiceV2' => [
+            'CreateLogMetric' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogMetric',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteLogMetric' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getMetricName',
+                        ],
+                        'keyName' => 'metric_name',
+                    ],
+                ],
+            ],
+            'GetLogMetric' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogMetric',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getMetricName',
+                        ],
+                        'keyName' => 'metric_name',
+                    ],
+                ],
+            ],
             'ListLogMetrics' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\ListLogMetricsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +49,26 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getMetrics',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateLogMetric' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Logging\V2\LogMetric',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getMetricName',
+                        ],
+                        'keyName' => 'metric_name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/redis/src/V1/resources/cloud_redis_descriptor_config.php
+++ b/tests/Integration/goldens/redis/src/V1/resources/cloud_redis_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.redis.v1.CloudRedis' => [
             'CreateInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Redis\V1\Instance',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -12,8 +13,17 @@ return [
                     'maxPollDelayMillis' => '360000',
                     'totalPollTimeoutMillis' => '7200000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'DeleteInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Protobuf\GPBEmpty',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -22,8 +32,17 @@ return [
                     'maxPollDelayMillis' => '360000',
                     'totalPollTimeoutMillis' => '1200000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ExportInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Redis\V1\Instance',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -32,8 +51,17 @@ return [
                     'maxPollDelayMillis' => '360000',
                     'totalPollTimeoutMillis' => '18000000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'FailoverInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Redis\V1\Instance',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -42,8 +70,17 @@ return [
                     'maxPollDelayMillis' => '360000',
                     'totalPollTimeoutMillis' => '1200000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ImportInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Redis\V1\Instance',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -52,8 +89,17 @@ return [
                     'maxPollDelayMillis' => '360000',
                     'totalPollTimeoutMillis' => '18000000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'UpdateInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Redis\V1\Instance',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -62,8 +108,18 @@ return [
                     'maxPollDelayMillis' => '360000',
                     'totalPollTimeoutMillis' => '7200000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getInstance',
+                            'getName',
+                        ],
+                        'keyName' => 'instance.name',
+                    ],
+                ],
             ],
             'UpgradeInstance' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Redis\V1\Instance',
                     'metadataReturnType' => '\Google\Cloud\Redis\V1\OperationMetadata',
@@ -72,8 +128,30 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetInstance' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Redis\V1\Instance',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListInstances' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Redis\V1\ListInstancesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -81,6 +159,14 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getInstances',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/catalog_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/catalog_service_descriptor_config.php
@@ -3,7 +3,21 @@
 return [
     'interfaces' => [
         'google.cloud.retail.v2alpha.CatalogService' => [
+            'GetDefaultBranch' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\GetDefaultBranchResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCatalog',
+                        ],
+                        'keyName' => 'catalog',
+                    ],
+                ],
+            ],
             'ListCatalogs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\ListCatalogsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +25,39 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getCatalogs',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'SetDefaultBranch' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCatalog',
+                        ],
+                        'keyName' => 'catalog',
+                    ],
+                ],
+            ],
+            'UpdateCatalog' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\Catalog',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCatalog',
+                            'getName',
+                        ],
+                        'keyName' => 'catalog.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/completion_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/completion_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.retail.v2alpha.CompletionService' => [
             'ImportCompletionData' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\ImportCompletionDataResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\ImportMetadata',
@@ -11,6 +12,26 @@ return [
                     'pollDelayMultiplier' => '1.5',
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CompleteQuery' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\CompleteQueryResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCatalog',
+                        ],
+                        'keyName' => 'catalog',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/prediction_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/prediction_service_descriptor_config.php
@@ -2,6 +2,19 @@
 
 return [
     'interfaces' => [
-        'google.cloud.retail.v2alpha.PredictionService' => [],
+        'google.cloud.retail.v2alpha.PredictionService' => [
+            'Predict' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\PredictResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getPlacement',
+                        ],
+                        'keyName' => 'placement',
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/product_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/product_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.retail.v2alpha.ProductService' => [
             'AddFulfillmentPlaces' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\AddFulfillmentPlacesResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\AddFulfillmentPlacesMetadata',
@@ -12,8 +13,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProduct',
+                        ],
+                        'keyName' => 'product',
+                    ],
+                ],
             ],
             'ImportProducts' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\ImportProductsResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\ImportMetadata',
@@ -22,8 +32,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'RemoveFulfillmentPlaces' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\RemoveFulfillmentPlacesResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\RemoveFulfillmentPlacesMetadata',
@@ -32,8 +51,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProduct',
+                        ],
+                        'keyName' => 'product',
+                    ],
+                ],
             ],
             'SetInventory' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\SetInventoryResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\SetInventoryMetadata',
@@ -42,8 +70,55 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getInventory',
+                            'getName',
+                        ],
+                        'keyName' => 'inventory.name',
+                    ],
+                ],
+            ],
+            'CreateProduct' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\Product',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteProduct' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetProduct' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\Product',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListProducts' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\ListProductsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -51,6 +126,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getProducts',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateProduct' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\Product',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProduct',
+                            'getName',
+                        ],
+                        'keyName' => 'product.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/search_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/search_service_descriptor_config.php
@@ -4,6 +4,8 @@ return [
     'interfaces' => [
         'google.cloud.retail.v2alpha.SearchService' => [
             'Search' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\SearchResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +13,14 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getResults',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getPlacement',
+                        ],
+                        'keyName' => 'placement',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/user_event_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/user_event_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.retail.v2alpha.UserEventService' => [
             'ImportUserEvents' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\ImportUserEventsResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\ImportMetadata',
@@ -12,8 +13,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'PurgeUserEvents' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\PurgeUserEventsResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\PurgeMetadata',
@@ -22,8 +32,17 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'RejoinUserEvents' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Retail\V2alpha\RejoinUserEventsResponse',
                     'metadataReturnType' => '\Google\Cloud\Retail\V2alpha\RejoinUserEventsMetadata',
@@ -31,6 +50,38 @@ return [
                     'pollDelayMultiplier' => '1.5',
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CollectUserEvent' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Api\HttpBody',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'WriteUserEvent' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Retail\V2alpha\UserEvent',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/securitycenter/src/V1/resources/security_center_descriptor_config.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/resources/security_center_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.securitycenter.v1.SecurityCenter' => [
             'RunAssetDiscovery' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\SecurityCenter\V1\RunAssetDiscoveryResponse',
                     'metadataReturnType' => '\Google\Protobuf\GPBEmpty',
@@ -12,8 +13,114 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateFinding' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\Finding',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateNotificationConfig' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\NotificationConfig',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateSource' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\Source',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteNotificationConfig' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'GetNotificationConfig' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\NotificationConfig',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetOrganizationSettings' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\OrganizationSettings',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetSource' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\Source',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GroupAssets' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\GroupAssetsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -21,9 +128,19 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getGroupByResults',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
                 ],
             ],
             'GroupFindings' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\GroupFindingsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -32,8 +149,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getGroupByResults',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListAssets' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\ListAssetsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -42,8 +169,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getListAssetsResults',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListFindings' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\ListFindingsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -52,8 +189,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getListFindingsResults',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListNotificationConfigs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\ListNotificationConfigsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -62,8 +209,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getNotificationConfigs',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'ListSources' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\ListSourcesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -71,6 +228,115 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getSources',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'SetFindingState' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\Finding',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'SetIamPolicy' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\Policy',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'TestIamPermissions' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Iam\V1\TestIamPermissionsResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
+            ],
+            'UpdateFinding' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\Finding',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getFinding',
+                            'getName',
+                        ],
+                        'keyName' => 'finding.name',
+                    ],
+                ],
+            ],
+            'UpdateNotificationConfig' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\NotificationConfig',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getNotificationConfig',
+                            'getName',
+                        ],
+                        'keyName' => 'notification_config.name',
+                    ],
+                ],
+            ],
+            'UpdateOrganizationSettings' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\OrganizationSettings',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getOrganizationSettings',
+                            'getName',
+                        ],
+                        'keyName' => 'organization_settings.name',
+                    ],
+                ],
+            ],
+            'UpdateSecurityMarks' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\SecurityMarks',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSecurityMarks',
+                            'getName',
+                        ],
+                        'keyName' => 'security_marks.name',
+                    ],
+                ],
+            ],
+            'UpdateSource' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\SecurityCenter\V1\Source',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSource',
+                            'getName',
+                        ],
+                        'keyName' => 'source.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/speech/src/V1/resources/speech_descriptor_config.php
+++ b/tests/Integration/goldens/speech/src/V1/resources/speech_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.speech.v1.Speech' => [
             'LongRunningRecognize' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Speech\V1\LongRunningRecognizeResponse',
                     'metadataReturnType' => '\Google\Cloud\Speech\V1\LongRunningRecognizeMetadata',
@@ -13,7 +14,13 @@ return [
                     'totalPollTimeoutMillis' => '300000',
                 ],
             ],
+            'Recognize' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Speech\V1\RecognizeResponse',
+            ],
             'StreamingRecognize' => [
+                'callType' => \Google\ApiCore\Call::BIDI_STREAMING_CALL,
+                'responseType' => 'Google\Cloud\Speech\V1\StreamingRecognizeResponse',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'BidiStreaming',
                 ],

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/application_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/application_service_descriptor_config.php
@@ -3,7 +3,45 @@
 return [
     'interfaces' => [
         'google.cloud.talent.v4beta1.ApplicationService' => [
+            'CreateApplication' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Application',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteApplication' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetApplication' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Application',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
             'ListApplications' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\ListApplicationsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +49,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getApplications',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateApplication' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Application',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getApplication',
+                            'getName',
+                        ],
+                        'keyName' => 'application.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/company_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/company_service_descriptor_config.php
@@ -3,7 +3,45 @@
 return [
     'interfaces' => [
         'google.cloud.talent.v4beta1.CompanyService' => [
+            'CreateCompany' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Company',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteCompany' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetCompany' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Company',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
             'ListCompanies' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\ListCompaniesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +49,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getCompanies',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateCompany' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Company',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getCompany',
+                            'getName',
+                        ],
+                        'keyName' => 'company.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/completion_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/completion_descriptor_config.php
@@ -2,6 +2,19 @@
 
 return [
     'interfaces' => [
-        'google.cloud.talent.v4beta1.Completion' => [],
+        'google.cloud.talent.v4beta1.Completion' => [
+            'CompleteQuery' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\CompleteQueryResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/event_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/event_service_descriptor_config.php
@@ -2,6 +2,19 @@
 
 return [
     'interfaces' => [
-        'google.cloud.talent.v4beta1.EventService' => [],
+        'google.cloud.talent.v4beta1.EventService' => [
+            'CreateClientEvent' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\ClientEvent',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/job_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/job_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.talent.v4beta1.JobService' => [
             'BatchCreateJobs' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Talent\V4beta1\JobOperationResult',
                     'metadataReturnType' => '\Google\Cloud\Talent\V4beta1\BatchOperationMetadata',
@@ -11,9 +12,18 @@ return [
                     'pollDelayMultiplier' => '1.5',
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
                 ],
             ],
             'BatchUpdateJobs' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\Talent\V4beta1\JobOperationResult',
                     'metadataReturnType' => '\Google\Cloud\Talent\V4beta1\BatchOperationMetadata',
@@ -22,8 +32,66 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'BatchDeleteJobs' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'CreateJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListJobs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\ListJobsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -32,8 +100,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getJobs',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'SearchJobs' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\SearchJobsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -42,8 +120,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getMatchingJobs',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'SearchJobsForAlert' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\SearchJobsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -51,6 +139,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getMatchingJobs',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateJob' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Job',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getJob',
+                            'getName',
+                        ],
+                        'keyName' => 'job.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/profile_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/profile_service_descriptor_config.php
@@ -3,7 +3,45 @@
 return [
     'interfaces' => [
         'google.cloud.talent.v4beta1.ProfileService' => [
+            'CreateProfile' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Profile',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteProfile' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetProfile' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Profile',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
             'ListProfiles' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\ListProfilesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -12,8 +50,18 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getProfiles',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'SearchProfiles' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\SearchProfilesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -21,6 +69,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getHistogramQueryResults',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateProfile' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Profile',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getProfile',
+                            'getName',
+                        ],
+                        'keyName' => 'profile.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/tenant_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/tenant_service_descriptor_config.php
@@ -3,7 +3,45 @@
 return [
     'interfaces' => [
         'google.cloud.talent.v4beta1.TenantService' => [
+            'CreateTenant' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Tenant',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'DeleteTenant' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
+            'GetTenant' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Tenant',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
+            ],
             'ListTenants' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\ListTenantsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -11,6 +49,27 @@ return [
                     'requestPageSizeSetMethod' => 'setPageSize',
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getTenants',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
+            ],
+            'UpdateTenant' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Cloud\Talent\V4beta1\Tenant',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getTenant',
+                            'getName',
+                        ],
+                        'keyName' => 'tenant.name',
+                    ],
                 ],
             ],
         ],

--- a/tests/Integration/goldens/videointelligence/src/V1/resources/video_intelligence_service_descriptor_config.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/resources/video_intelligence_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.cloud.videointelligence.v1.VideoIntelligenceService' => [
             'AnnotateVideo' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Cloud\VideoIntelligence\V1\AnnotateVideoResponse',
                     'metadataReturnType' => '\Google\Cloud\VideoIntelligence\V1\AnnotateVideoProgress',

--- a/tests/Unit/ProtoTests/Basic/out/src/resources/basic_descriptor_config.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/resources/basic_descriptor_config.php
@@ -2,6 +2,15 @@
 
 return [
     'interfaces' => [
-        'testing.basic.Basic' => [],
+        'testing.basic.Basic' => [
+            'AMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\Basic\Response',
+            ],
+            'MethodWithArgs' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\Basic\Response',
+            ],
+        ],
     ],
 ];

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_descriptor_config.php
@@ -4,11 +4,15 @@ return [
     'interfaces' => [
         'testing.basicbidistreaming.BasicBidiStreaming' => [
             'MethodBidi' => [
+                'callType' => \Google\ApiCore\Call::BIDI_STREAMING_CALL,
+                'responseType' => 'Testing\BasicBidiStreaming\Response',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'BidiStreaming',
                 ],
             ],
             'MethodEmpty' => [
+                'callType' => \Google\ApiCore\Call::BIDI_STREAMING_CALL,
+                'responseType' => 'Testing\BasicBidiStreaming\Response',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'BidiStreaming',
                 ],

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_descriptor_config.php
@@ -4,11 +4,15 @@ return [
     'interfaces' => [
         'testing.basicclientstreaming.BasicClientStreaming' => [
             'MethodClient' => [
+                'callType' => \Google\ApiCore\Call::CLIENT_STREAMING_CALL,
+                'responseType' => 'Testing\BasicClientStreaming\Response',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ClientStreaming',
                 ],
             ],
             'MethodEmpty' => [
+                'callType' => \Google\ApiCore\Call::CLIENT_STREAMING_CALL,
+                'responseType' => 'Testing\BasicClientStreaming\Response',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ClientStreaming',
                 ],

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'google.example.library.v1.LibraryService' => [
             'GetBigBook' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Testing\BasicDiregapic\BookResponse',
                     'metadataReturnType' => '\Testing\BasicDiregapic\GetBigBookMetadata',
@@ -14,6 +15,7 @@ return [
                 ],
             ],
             'GetBigNothing' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Google\Protobuf\GPBEmpty',
                     'metadataReturnType' => '\Testing\BasicDiregapic\GetBigBookMetadata',
@@ -24,6 +26,7 @@ return [
                 ],
             ],
             'LongRunningArchiveBooks' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Testing\BasicDiregapic\ArchiveBooksResponse',
                     'metadataReturnType' => '\Testing\BasicDiregapic\ArchiveBooksMetadata',
@@ -33,7 +36,41 @@ return [
                     'totalPollTimeoutMillis' => '300000',
                 ],
             ],
+            'AddComments' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+            'AddTag' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\AddTagResponse',
+            ],
+            'ArchiveBooks' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ArchiveBooksResponse',
+            ],
+            'CreateBook' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookResponse',
+            ],
+            'CreateInventory' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\InventoryResponse',
+            ],
+            'CreateShelf' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ShelfResponse',
+            ],
+            'DeleteBook' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+            'DeleteShelf' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
             'FindRelatedBooks' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Testing\BasicDiregapic\FindRelatedBooksResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -43,7 +80,29 @@ return [
                     'resourcesGetMethod' => 'getNames',
                 ],
             ],
+            'GetBook' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookResponse',
+            ],
+            'GetBookFromAbsolutelyAnywhere' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookFromAnywhereResponse',
+            ],
+            'GetBookFromAnywhere' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookFromAnywhereResponse',
+            ],
+            'GetBookFromArchive' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookFromArchiveResponse',
+            ],
+            'GetShelf' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ShelfResponse',
+            ],
             'ListAggregatedShelves' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ListAggregatedShelvesResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -54,6 +113,8 @@ return [
                 ],
             ],
             'ListBooks' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ListBooksResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -63,7 +124,13 @@ return [
                     'resourcesGetMethod' => 'getBooks',
                 ],
             ],
+            'ListShelves' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ListShelvesResponse',
+            ],
             'ListStrings' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ListStringsResponse',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',
@@ -72,6 +139,38 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getStrings',
                 ],
+            ],
+            'MergeShelves' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\ShelfResponse',
+            ],
+            'MoveBook' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookResponse',
+            ],
+            'MoveBooks' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\MoveBooksResponse',
+            ],
+            'PrivateListShelves' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookResponse',
+            ],
+            'PublishSeries' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\PublishSeriesResponse',
+            ],
+            'SaveBook' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+            'UpdateBook' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicDiregapic\BookResponse',
+            ],
+            'UpdateBookIndex' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
             ],
         ],
     ],

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_service_descriptor_config.php
@@ -13,6 +13,14 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetBigNothing' => [
                 'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
@@ -23,6 +31,14 @@ return [
                     'pollDelayMultiplier' => '1.5',
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
+                ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
                 ],
             ],
             'LongRunningArchiveBooks' => [
@@ -35,26 +51,74 @@ return [
                     'maxPollDelayMillis' => '5000',
                     'totalPollTimeoutMillis' => '300000',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSource',
+                        ],
+                        'keyName' => 'source',
+                    ],
+                ],
             ],
             'AddComments' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'AddTag' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\AddTagResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getResource',
+                        ],
+                        'keyName' => 'resource',
+                    ],
+                ],
             ],
             'ArchiveBooks' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\ArchiveBooksResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSource',
+                        ],
+                        'keyName' => 'source',
+                    ],
+                ],
             ],
             'CreateBook' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'CreateInventory' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\InventoryResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getParent',
+                        ],
+                        'keyName' => 'parent',
+                    ],
+                ],
             ],
             'CreateShelf' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
@@ -63,10 +127,26 @@ return [
             'DeleteBook' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'DeleteShelf' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'FindRelatedBooks' => [
                 'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
@@ -83,22 +163,68 @@ return [
             'GetBook' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetBookFromAbsolutelyAnywhere' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookFromAnywhereResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getAltBookName',
+                        ],
+                        'keyName' => 'alt_book_name',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetBookFromAnywhere' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookFromAnywhereResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetBookFromArchive' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookFromArchiveResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetShelf' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\ShelfResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListAggregatedShelves' => [
                 'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
@@ -123,6 +249,14 @@ return [
                     'responsePageTokenGetMethod' => 'getNextPageToken',
                     'resourcesGetMethod' => 'getBooks',
                 ],
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'ListShelves' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
@@ -143,14 +277,38 @@ return [
             'MergeShelves' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\ShelfResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'MoveBook' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'MoveBooks' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\MoveBooksResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getSource',
+                        ],
+                        'keyName' => 'source',
+                    ],
+                ],
             ],
             'PrivateListShelves' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
@@ -159,6 +317,15 @@ return [
             'PublishSeries' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\PublishSeriesResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getShelf',
+                            'getName',
+                        ],
+                        'keyName' => 'shelf.name',
+                    ],
+                ],
             ],
             'SaveBook' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
@@ -167,10 +334,26 @@ return [
             'UpdateBook' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\BasicDiregapic\BookResponse',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'UpdateBookIndex' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Google\Protobuf\GPBEmpty',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
         ],
     ],

--- a/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'testing.basiclro.BasicLro' => [
             'Method1' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Testing\BasicLro\LroResponse',
                     'metadataReturnType' => '\Testing\BasicLro\LroMetadata',
@@ -12,6 +13,14 @@ return [
                     'maxPollDelayMillis' => '45000',
                     'totalPollTimeoutMillis' => '86400000',
                 ],
+            ],
+            'MethodNonLro1' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicLro\Request',
+            ],
+            'MethodNonLro2' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicLro\Request',
             ],
         ],
     ],

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_descriptor_config.php
@@ -2,6 +2,11 @@
 
 return [
     'interfaces' => [
-        'testing.basiconeof.BasicOneof' => [],
+        'testing.basiconeof.BasicOneof' => [
+            'AMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\BasicOneof\Response',
+            ],
+        ],
     ],
 ];

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_descriptor_config.php
@@ -4,6 +4,8 @@ return [
     'interfaces' => [
         'testing.basicpaginated.BasicPaginated' => [
             'MethodPaginated' => [
+                'callType' => \Google\ApiCore\Call::PAGINATED_CALL,
+                'responseType' => 'Testing\BasicPaginated\Response',
                 'pageStreaming' => [
                     'requestPageTokenGetMethod' => 'getPageToken',
                     'requestPageTokenSetMethod' => 'setPageToken',

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_descriptor_config.php
@@ -4,11 +4,15 @@ return [
     'interfaces' => [
         'testing.basicserverstreaming.BasicServerStreaming' => [
             'MethodEmpty' => [
+                'callType' => \Google\ApiCore\Call::SERVER_STREAMING_CALL,
+                'responseType' => 'Testing\BasicServerStreaming\Response',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ServerStreaming',
                 ],
             ],
             'MethodServer' => [
+                'callType' => \Google\ApiCore\Call::SERVER_STREAMING_CALL,
+                'responseType' => 'Testing\BasicServerStreaming\Response',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ServerStreaming',
                 ],

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_descriptor_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'testing.customlro.CustomLro' => [
             'CreateFoo' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'additionalArgumentMethods' => [
                         'getProject',

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_descriptor_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_descriptor_config.php
@@ -5,6 +5,7 @@ return [
         'testing.customlro.CustomLro' => [
             'CreateFoo' => [
                 'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
+                'responseType' => 'Testing\CustomLro\CustomOperationResponse',
                 'longRunning' => [
                     'additionalArgumentMethods' => [
                         'getProject',

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_descriptor_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_descriptor_config.php
@@ -2,6 +2,19 @@
 
 return [
     'interfaces' => [
-        'testing.customlro.CustomLroOperations' => [],
+        'testing.customlro.CustomLroOperations' => [
+            'Cancel' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+            'Delete' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+            'Get' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\CustomLro\CustomOperationResponse',
+            ],
+        ],
     ],
 ];

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_descriptor_config.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_descriptor_config.php
@@ -2,6 +2,15 @@
 
 return [
     'interfaces' => [
-        'testing.deprecated_service.DeprecatedService' => [],
+        'testing.deprecated_service.DeprecatedService' => [
+            'FastFibonacci' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+            'SlowFibonacci' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Google\Protobuf\GPBEmpty',
+            ],
+        ],
     ],
 ];

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_descriptor_config.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_descriptor_config.php
@@ -4,6 +4,7 @@ return [
     'interfaces' => [
         'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1' => [
             'Method1BLro' => [
+                'callType' => \Google\ApiCore\Call::LONGRUNNING_CALL,
                 'longRunning' => [
                     'operationReturnType' => '\Testing\GrpcServiceConfig\LroResponse',
                     'metadataReturnType' => '\Testing\GrpcServiceConfig\LroMetadata',
@@ -13,12 +14,28 @@ return [
                     'totalPollTimeoutMillis' => '300000',
                 ],
             ],
+            'Method1A' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\GrpcServiceConfig\Response1',
+            ],
             'Method1BidiStreaming' => [
+                'callType' => \Google\ApiCore\Call::BIDI_STREAMING_CALL,
+                'responseType' => 'Testing\GrpcServiceConfig\Response1',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'BidiStreaming',
                 ],
             ],
+            'Method1CServiceLevelRetry' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\GrpcServiceConfig\Response1',
+            ],
+            'Method1DTimeoutOnlyRetry' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\GrpcServiceConfig\Response1',
+            ],
             'Method1ServerStreaming' => [
+                'callType' => \Google\ApiCore\Call::SERVER_STREAMING_CALL,
+                'responseType' => 'Testing\GrpcServiceConfig\Response1',
                 'grpcStreaming' => [
                     'grpcStreamingType' => 'ServerStreaming',
                 ],

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_descriptor_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_descriptor_config.php
@@ -2,6 +2,39 @@
 
 return [
     'interfaces' => [
-        'testing.resourcenames.ResourceNames' => [],
+        'testing.resourcenames.ResourceNames' => [
+            'FileLevelChildTypeRefMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'FileLevelTypeRefMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'MultiPatternMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'SinglePatternMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'WildcardChildReferenceMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'WildcardMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'WildcardMultiMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+            'WildcardReferenceMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
+        ],
     ],
 ];

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_descriptor_config.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_descriptor_config.php
@@ -6,10 +6,26 @@ return [
             'DeleteMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'GetNoPlaceholdersMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
@@ -18,30 +34,144 @@ return [
             'GetNoTemplateMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'NestedMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getNest1',
+                            'getNest2',
+                            'getName',
+                        ],
+                        'keyName' => 'nest1.nest2.name',
+                    ],
+                ],
             ],
             'NestedMultiMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getNest1',
+                            'getNest2',
+                            'getName',
+                        ],
+                        'keyName' => 'nest1.nest2.name',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getAnotherName',
+                        ],
+                        'keyName' => 'another_name',
+                    ],
+                ],
             ],
             'OrderingMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getA',
+                        ],
+                        'keyName' => 'a',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getC',
+                        ],
+                        'keyName' => 'c',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getAa',
+                        ],
+                        'keyName' => 'aa',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getB',
+                        ],
+                        'keyName' => 'b',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getD',
+                        ],
+                        'keyName' => 'd',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getAId',
+                        ],
+                        'keyName' => 'a_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getBId',
+                        ],
+                        'keyName' => 'b_id',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getE',
+                        ],
+                        'keyName' => 'e',
+                    ],
+                ],
             ],
             'PatchMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'PostMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'PutMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                    ],
+                ],
             ],
             'RoutingRuleWithOutParameters' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_descriptor_config.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_descriptor_config.php
@@ -2,6 +2,104 @@
 
 return [
     'interfaces' => [
-        'testing.routingheaders.RoutingHeaders' => [],
+        'testing.routingheaders.RoutingHeaders' => [
+            'DeleteMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'GetMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'GetNoPlaceholdersMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'GetNoTemplateMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'NestedMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'NestedMultiMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'OrderingMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'PatchMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'PostMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'PutMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'RoutingRuleWithOutParameters' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+            ],
+            'RoutingRuleWithParameters' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\RoutingHeaders\Response',
+                'headerParams' => [
+                    [
+                        'fieldAccessors' => [
+                            'getName',
+                        ],
+                        'keyName' => 'name',
+                        'matchers' => [
+                            '/^(?<name>projects\/[^\/]+)\/foos$/',
+                        ],
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getAnotherName',
+                        ],
+                        'keyName' => 'foo_name',
+                        'matchers' => [
+                            '/^(?<foo_name>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/',
+                            '/^(?<foo_name>projects\/[^\/]+\/foos\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/',
+                        ],
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getAnotherName',
+                        ],
+                        'keyName' => 'bar_name',
+                        'matchers' => [
+                            '/^projects\/[^\/]+\/foos\/[^\/]+\/(?<bar_name>bars\/[^\/]+)(?:\/.*)?$/',
+                        ],
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNest1',
+                            'getNest2',
+                            'getName',
+                        ],
+                        'keyName' => 'nested_name',
+                    ],
+                    [
+                        'fieldAccessors' => [
+                            'getNest1',
+                            'getNest2',
+                            'getName',
+                        ],
+                        'keyName' => 'part_of_nested',
+                        'matchers' => [
+                            '/^(?<part_of_nested>projects\/[^\/]+)\/bars$/',
+                        ],
+                    ],
+                ],
+            ],
+        ],
     ],
 ];

--- a/tests/Unit/Utils/ProtoHelpersTest.php
+++ b/tests/Unit/Utils/ProtoHelpersTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Google\Generator\Tests\Unit\Utils;
 
+use Google\Generator\Collections\Map;
 use PHPUnit\Framework\TestCase;
 use Google\Generator\Collections\Vector;
 use Google\Generator\Tests\Tools\ProtoLoader;
@@ -78,5 +79,64 @@ final class ProtoHelpersTest extends TestCase
         $this->assertEquals('Svc', $svc->GetName());
         $f = $catalog->filesByService[$svc];
         $this->assertStringContainsString('catalog.proto', $f->GetName());
+    }
+
+    public function testHeaderParamsDescriptor(): void
+    {
+        $routingParams = [
+            'foo' => Vector::new([
+                [
+                    'getter' => ['getFoo'],
+                    'key' => 'foo',
+                ],
+                [
+                    'getter' => ['getFoo'],
+                    'key' => 'foo_name',
+                ],
+                [
+                    'getter' => ['getFoo'],
+                    'key' => 'foo',
+                    'regex' => '/^(?<foo>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/'
+                ]
+            ]),
+            'bar.baz' => Vector::new([
+                [
+                    'getter' => ['getBar', 'getBaz'],
+                    'key' => 'baz',
+                    'regex' => '/^(?<baz>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/'
+                ],
+                [
+                    'getter' => ['getBar', 'getBaz'],
+                    'key' => 'bar_baz',
+                ],
+                [
+                    'getter' => ['getBar', 'getBaz'],
+                    'key' => 'baz',
+                    'regex' => '/^(?<bar>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/'
+                ]
+            ])
+        ];
+        $expected = [
+            [
+                'fieldAccessors' => ['getFoo'],
+                'keyName' => 'foo',
+                'matchers' => ['/^(?<foo>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/']
+            ],
+            [
+                'fieldAccessors' => ['getFoo'],
+                'keyName' => 'foo_name'
+            ],
+            [
+                'fieldAccessors' => ['getBar', 'getBaz'],
+                'keyName' => 'baz',
+                'matchers' => ['/^(?<baz>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/', '/^(?<bar>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/']
+            ],
+            [
+                'fieldAccessors' => ['getBar', 'getBaz'],
+                'keyName' => 'bar_baz'
+            ]
+        ];
+        $actual = ProtoHelpers::headerParamsDescriptor(Map::new($routingParams));
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Unit/Utils/ProtoHelpersTest.php
+++ b/tests/Unit/Utils/ProtoHelpersTest.php
@@ -81,7 +81,7 @@ final class ProtoHelpersTest extends TestCase
         $this->assertStringContainsString('catalog.proto', $f->GetName());
     }
 
-    public function testHeaderParamsDescriptor(): void
+    public function testRoutingParamsDescriptor(): void
     {
         $routingParams = [
             'foo' => Vector::new([
@@ -136,7 +136,27 @@ final class ProtoHelpersTest extends TestCase
                 'keyName' => 'bar_baz'
             ]
         ];
-        $actual = ProtoHelpers::headerParamsDescriptor(Map::new($routingParams));
+        $actual = ProtoHelpers::routingParamsDescriptor(Map::new($routingParams));
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testImplicitHeaderParamsDescriptor(): void
+    {
+        $implicitHeaderParams = [
+            'foo' => Vector::new(['getFoo']),
+            'bar.baz' => Vector::new(['getBar', 'getBaz'])
+        ];
+        $expected = [
+            [
+                'fieldAccessors' => ['getFoo'],
+                'keyName' => 'foo',
+            ],
+            [
+                'fieldAccessors' => ['getBar', 'getBaz'],
+                'keyName' => 'bar.baz',
+            ]
+        ];
+        $actual = ProtoHelpers::implicitHeaderParamsDescriptor(Map::new($implicitHeaderParams));
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Unit/Utils/ProtoHelpersTest.php
+++ b/tests/Unit/Utils/ProtoHelpersTest.php
@@ -140,9 +140,9 @@ final class ProtoHelpersTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testImplicitHeaderParamsDescriptor(): void
+    public function testImplicitParamsDescriptor(): void
     {
-        $implicitHeaderParams = [
+        $implicitParams = [
             'foo' => Vector::new(['getFoo']),
             'bar.baz' => Vector::new(['getBar', 'getBaz'])
         ];
@@ -156,7 +156,7 @@ final class ProtoHelpersTest extends TestCase
                 'keyName' => 'bar.baz',
             ]
         ];
-        $actual = ProtoHelpers::implicitHeaderParamsDescriptor(Map::new($implicitHeaderParams));
+        $actual = ProtoHelpers::implicitParamsDescriptor(Map::new($implicitParams));
         $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
Add generation of the following descriptor config fields:
* `callType`: populated with `\Google\ApiCore\Call::{RPC}_TYPE` constant
* `responseType`: populated with the response message PHP type name
* `headerParams`: (if configured) populated with the header request params (implicit or explicit) config

These descriptor config fields are only used by `GapicClientTrait->startApiCall`, none of the existing production code paths as of today. This is a backwards compatible change. 