### PR TITLE
fix(regapic): enable numeric enums by default in Bazel

### DIFF
--- a/rules_php_gapic/php_gapic.bzl
+++ b/rules_php_gapic/php_gapic.bzl
@@ -112,7 +112,7 @@ def php_gapic_library(
         service_yaml = None,
         grpc_service_config = None,
         transport = None,
-        rest_numeric_enums = False,
+        rest_numeric_enums = True,
         generator_binary = Label("//rules_php_gapic:php_gapic_generator_binary"),
         **kwargs):
     srcjar_name = "%s_srcjar" % name


### PR DESCRIPTION
Enable generation of numeric enum encoding system parameter for REST by default. 