### PR TITLE
fix: remove no longer required formatting of imports in tests

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -332,9 +332,6 @@ class CodeGenerator
             $file = UnitTestsGenerator::generate($ctx, $service);
             $code = $file->toCode();
             $code = Formatter::format($code);
-            // TODO(vNext): Remove these non-standard 'use' ordering.
-            $code = Formatter::moveUseTo($code, $service->emptyClientType->getFullname(true), 0);
-            $code = Formatter::moveUseTo($code, 'stdClass', -1);
             yield ["tests/Unit/{$version}{$service->unitTestsType->name}.php", $code];
             // Resource: descriptor_config.php
             $code = ResourcesGenerator::generateDescriptorConfig($service, $gapicYamlConfig);

--- a/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
+++ b/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Asset\Tests\Unit\V1;
 
-use Google\Cloud\Asset\V1\AssetServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -32,6 +31,7 @@ use Google\Cloud\Asset\V1\AnalyzeIamPolicyLongrunningResponse;
 use Google\Cloud\Asset\V1\AnalyzeIamPolicyResponse;
 use Google\Cloud\Asset\V1\AnalyzeMoveResponse;
 use Google\Cloud\Asset\V1\Asset;
+use Google\Cloud\Asset\V1\AssetServiceClient;
 use Google\Cloud\Asset\V1\BatchGetAssetsHistoryResponse;
 use Google\Cloud\Asset\V1\ContentType;
 use Google\Cloud\Asset\V1\ExportAssetsResponse;

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Compute\Tests\Unit\V1;
 
-use Google\Cloud\Compute\V1\AddressesClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
@@ -30,6 +29,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Compute\V1\Address;
 use Google\Cloud\Compute\V1\AddressAggregatedList;
 use Google\Cloud\Compute\V1\AddressList;
+use Google\Cloud\Compute\V1\AddressesClient;
 use Google\Cloud\Compute\V1\AddressesScopedList;
 use Google\Cloud\Compute\V1\GetRegionOperationRequest;
 use Google\Cloud\Compute\V1\Operation;

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/RegionOperationsClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/RegionOperationsClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Compute\Tests\Unit\V1;
 
-use Google\Cloud\Compute\V1\RegionOperationsClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Compute\V1\Operation;
+use Google\Cloud\Compute\V1\RegionOperationsClient;
 use Google\Rpc\Code;
 use stdClass;
 

--- a/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
+++ b/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Google\Cloud\Container\Tests\Unit\V1;
 
-use Google\Cloud\Container\V1\ClusterManagerClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Container\V1\AddonsConfig;
 use Google\Cloud\Container\V1\Cluster;
+use Google\Cloud\Container\V1\ClusterManagerClient;
 use Google\Cloud\Container\V1\ClusterUpdate;
 use Google\Cloud\Container\V1\GetJSONWebKeysResponse;
 use Google\Cloud\Container\V1\ListClustersResponse;

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Dataproc\Tests\Unit\V1;
 
-use Google\Cloud\Dataproc\V1\AutoscalingPolicyServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\AutoscalingPolicy;
+use Google\Cloud\Dataproc\V1\AutoscalingPolicyServiceClient;
 use Google\Cloud\Dataproc\V1\BasicAutoscalingAlgorithm;
 use Google\Cloud\Dataproc\V1\BasicYarnAutoscalingConfig;
 use Google\Cloud\Dataproc\V1\InstanceGroupAutoscalingPolicyConfig;

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/ClusterControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/ClusterControllerClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Dataproc\Tests\Unit\V1;
 
-use Google\Cloud\Dataproc\V1\ClusterControllerClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -30,6 +29,7 @@ use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\Cluster;
 use Google\Cloud\Dataproc\V1\ClusterConfig;
+use Google\Cloud\Dataproc\V1\ClusterControllerClient;
 use Google\Cloud\Dataproc\V1\DiagnoseClusterResults;
 use Google\Cloud\Dataproc\V1\ListClustersResponse;
 use Google\LongRunning\GetOperationRequest;

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/JobControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/JobControllerClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Google\Cloud\Dataproc\Tests\Unit\V1;
 
-use Google\Cloud\Dataproc\V1\JobControllerClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\Job;
+use Google\Cloud\Dataproc\V1\JobControllerClient;
 use Google\Cloud\Dataproc\V1\JobPlacement;
 use Google\Cloud\Dataproc\V1\ListJobsResponse;
 use Google\LongRunning\GetOperationRequest;

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/WorkflowTemplateServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/WorkflowTemplateServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Dataproc\Tests\Unit\V1;
 
-use Google\Cloud\Dataproc\V1\WorkflowTemplateServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -31,6 +30,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Dataproc\V1\ListWorkflowTemplatesResponse;
 use Google\Cloud\Dataproc\V1\WorkflowTemplate;
 use Google\Cloud\Dataproc\V1\WorkflowTemplatePlacement;
+use Google\Cloud\Dataproc\V1\WorkflowTemplateServiceClient;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Any;

--- a/tests/Integration/goldens/functions/tests/Unit/V1/CloudFunctionsServiceClientTest.php
+++ b/tests/Integration/goldens/functions/tests/Unit/V1/CloudFunctionsServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Functions\Tests\Unit\V1;
 
-use Google\Cloud\Functions\V1\CloudFunctionsServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -30,6 +29,7 @@ use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Functions\V1\CallFunctionResponse;
 use Google\Cloud\Functions\V1\CloudFunction;
+use Google\Cloud\Functions\V1\CloudFunctionsServiceClient;
 use Google\Cloud\Functions\V1\GenerateDownloadUrlResponse;
 use Google\Cloud\Functions\V1\GenerateUploadUrlResponse;
 use Google\Cloud\Functions\V1\ListFunctionsResponse;

--- a/tests/Integration/goldens/iam/tests/Unit/V1/IAMPolicyClientTest.php
+++ b/tests/Integration/goldens/iam/tests/Unit/V1/IAMPolicyClientTest.php
@@ -22,11 +22,11 @@
 
 namespace Google\Cloud\Iam\Tests\Unit\V1;
 
-use Google\Cloud\Iam\V1\IAMPolicyClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
+use Google\Cloud\Iam\V1\IAMPolicyClient;
 use Google\Cloud\Iam\V1\Policy;
 use Google\Cloud\Iam\V1\TestIamPermissionsResponse;
 use Google\Rpc\Code;

--- a/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
+++ b/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Kms\Tests\Unit\V1;
 
-use Google\Cloud\Kms\V1\KeyManagementServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
@@ -38,6 +37,7 @@ use Google\Cloud\Kms\V1\Digest;
 use Google\Cloud\Kms\V1\EncryptResponse;
 use Google\Cloud\Kms\V1\ImportJob;
 use Google\Cloud\Kms\V1\ImportJob\ImportMethod;
+use Google\Cloud\Kms\V1\KeyManagementServiceClient;
 use Google\Cloud\Kms\V1\KeyRing;
 use Google\Cloud\Kms\V1\ListCryptoKeyVersionsResponse;
 use Google\Cloud\Kms\V1\ListCryptoKeysResponse;

--- a/tests/Integration/goldens/logging/tests/Unit/V2/ConfigServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/ConfigServiceV2ClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Logging\Tests\Unit\V2;
 
-use Google\Cloud\Logging\V2\ConfigServiceV2Client;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Logging\V2\CmekSettings;
+use Google\Cloud\Logging\V2\ConfigServiceV2Client;
 use Google\Cloud\Logging\V2\ListBucketsResponse;
 use Google\Cloud\Logging\V2\ListExclusionsResponse;
 use Google\Cloud\Logging\V2\ListSinksResponse;

--- a/tests/Integration/goldens/logging/tests/Unit/V2/LoggingServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/LoggingServiceV2ClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Logging\Tests\Unit\V2;
 
-use Google\Cloud\Logging\V2\LoggingServiceV2Client;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\BidiStream;
 use Google\ApiCore\CredentialsWrapper;
@@ -33,6 +32,7 @@ use Google\Cloud\Logging\V2\ListLogEntriesResponse;
 use Google\Cloud\Logging\V2\ListLogsResponse;
 use Google\Cloud\Logging\V2\ListMonitoredResourceDescriptorsResponse;
 use Google\Cloud\Logging\V2\LogEntry;
+use Google\Cloud\Logging\V2\LoggingServiceV2Client;
 use Google\Cloud\Logging\V2\TailLogEntriesRequest;
 use Google\Cloud\Logging\V2\TailLogEntriesResponse;
 use Google\Cloud\Logging\V2\WriteLogEntriesResponse;

--- a/tests/Integration/goldens/logging/tests/Unit/V2/MetricsServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/MetricsServiceV2ClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Google\Cloud\Logging\Tests\Unit\V2;
 
-use Google\Cloud\Logging\V2\MetricsServiceV2Client;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Logging\V2\ListLogMetricsResponse;
 use Google\Cloud\Logging\V2\LogMetric;
+use Google\Cloud\Logging\V2\MetricsServiceV2Client;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;
 use stdClass;

--- a/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
+++ b/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Redis\Tests\Unit\V1;
 
-use Google\Cloud\Redis\V1\CloudRedisClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
+use Google\Cloud\Redis\V1\CloudRedisClient;
 use Google\Cloud\Redis\V1\InputConfig;
 use Google\Cloud\Redis\V1\Instance;
 use Google\Cloud\Redis\V1\Instance\Tier;

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/CatalogServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/CatalogServiceClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Retail\Tests\Unit\V2alpha;
 
-use Google\Cloud\Retail\V2alpha\CatalogServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Retail\V2alpha\Catalog;
+use Google\Cloud\Retail\V2alpha\CatalogServiceClient;
 use Google\Cloud\Retail\V2alpha\GetDefaultBranchResponse;
 use Google\Cloud\Retail\V2alpha\ListCatalogsResponse;
 use Google\Cloud\Retail\V2alpha\ProductLevelConfig;

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/CompletionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/CompletionServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Retail\Tests\Unit\V2alpha;
 
-use Google\Cloud\Retail\V2alpha\CompletionServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -31,6 +30,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Retail\V2alpha\BigQuerySource;
 use Google\Cloud\Retail\V2alpha\CompleteQueryResponse;
 use Google\Cloud\Retail\V2alpha\CompletionDataInputConfig;
+use Google\Cloud\Retail\V2alpha\CompletionServiceClient;
 use Google\Cloud\Retail\V2alpha\ImportCompletionDataResponse;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/PredictionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/PredictionServiceClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Retail\Tests\Unit\V2alpha;
 
-use Google\Cloud\Retail\V2alpha\PredictionServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Retail\V2alpha\PredictResponse;
+use Google\Cloud\Retail\V2alpha\PredictionServiceClient;
 use Google\Cloud\Retail\V2alpha\UserEvent;
 use Google\Rpc\Code;
 use stdClass;

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/ProductServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/ProductServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Retail\Tests\Unit\V2alpha;
 
-use Google\Cloud\Retail\V2alpha\ProductServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -33,6 +32,7 @@ use Google\Cloud\Retail\V2alpha\ImportProductsResponse;
 use Google\Cloud\Retail\V2alpha\ListProductsResponse;
 use Google\Cloud\Retail\V2alpha\Product;
 use Google\Cloud\Retail\V2alpha\ProductInputConfig;
+use Google\Cloud\Retail\V2alpha\ProductServiceClient;
 use Google\Cloud\Retail\V2alpha\RemoveFulfillmentPlacesResponse;
 use Google\Cloud\Retail\V2alpha\SetInventoryResponse;
 use Google\LongRunning\GetOperationRequest;

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/SearchServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/SearchServiceClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Google\Cloud\Retail\Tests\Unit\V2alpha;
 
-use Google\Cloud\Retail\V2alpha\SearchServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Retail\V2alpha\SearchResponse;
 use Google\Cloud\Retail\V2alpha\SearchResponse\SearchResult;
+use Google\Cloud\Retail\V2alpha\SearchServiceClient;
 use Google\Rpc\Code;
 use stdClass;
 

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/UserEventServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/UserEventServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Retail\Tests\Unit\V2alpha;
 
-use Google\Cloud\Retail\V2alpha\UserEventServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -35,6 +34,7 @@ use Google\Cloud\Retail\V2alpha\RejoinUserEventsResponse;
 use Google\Cloud\Retail\V2alpha\UserEvent;
 use Google\Cloud\Retail\V2alpha\UserEventInlineSource;
 use Google\Cloud\Retail\V2alpha\UserEventInputConfig;
+use Google\Cloud\Retail\V2alpha\UserEventServiceClient;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Any;

--- a/tests/Integration/goldens/securitycenter/tests/Unit/V1/SecurityCenterClientTest.php
+++ b/tests/Integration/goldens/securitycenter/tests/Unit/V1/SecurityCenterClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\SecurityCenter\Tests\Unit\V1;
 
-use Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -44,6 +43,7 @@ use Google\Cloud\SecurityCenter\V1\ListSourcesResponse;
 use Google\Cloud\SecurityCenter\V1\NotificationConfig;
 use Google\Cloud\SecurityCenter\V1\OrganizationSettings;
 use Google\Cloud\SecurityCenter\V1\RunAssetDiscoveryResponse;
+use Google\Cloud\SecurityCenter\V1\SecurityCenterClient;
 use Google\Cloud\SecurityCenter\V1\SecurityMarks;
 use Google\Cloud\SecurityCenter\V1\Source;
 use Google\LongRunning\GetOperationRequest;

--- a/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
+++ b/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Speech\Tests\Unit\V1;
 
-use Google\Cloud\Speech\V1\SpeechClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\BidiStream;
 use Google\ApiCore\CredentialsWrapper;
@@ -33,6 +32,7 @@ use Google\Cloud\Speech\V1\LongRunningRecognizeResponse;
 use Google\Cloud\Speech\V1\RecognitionAudio;
 use Google\Cloud\Speech\V1\RecognitionConfig;
 use Google\Cloud\Speech\V1\RecognizeResponse;
+use Google\Cloud\Speech\V1\SpeechClient;
 use Google\Cloud\Speech\V1\StreamingRecognizeRequest;
 use Google\Cloud\Speech\V1\StreamingRecognizeResponse;
 use Google\LongRunning\GetOperationRequest;

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/ApplicationServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/ApplicationServiceClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\ApplicationServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\Application;
+use Google\Cloud\Talent\V4beta1\ApplicationServiceClient;
 use Google\Cloud\Talent\V4beta1\Application\ApplicationStage;
 use Google\Cloud\Talent\V4beta1\ListApplicationsResponse;
 use Google\Protobuf\GPBEmpty;

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompanyServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompanyServiceClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\CompanyServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\Company;
+use Google\Cloud\Talent\V4beta1\CompanyServiceClient;
 use Google\Cloud\Talent\V4beta1\ListCompaniesResponse;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompletionClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompletionClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\CompletionClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\CompleteQueryResponse;
+use Google\Cloud\Talent\V4beta1\CompletionClient;
 use Google\Rpc\Code;
 use stdClass;
 

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/EventServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/EventServiceClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\EventServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\ClientEvent;
+use Google\Cloud\Talent\V4beta1\EventServiceClient;
 use Google\Protobuf\Timestamp;
 use Google\Rpc\Code;
 use stdClass;

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/JobServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/JobServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\JobServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -30,6 +29,7 @@ use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\Job;
 use Google\Cloud\Talent\V4beta1\JobOperationResult;
+use Google\Cloud\Talent\V4beta1\JobServiceClient;
 use Google\Cloud\Talent\V4beta1\ListJobsResponse;
 use Google\Cloud\Talent\V4beta1\RequestMetadata;
 use Google\Cloud\Talent\V4beta1\SearchJobsResponse;

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/ProfileServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/ProfileServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\ProfileServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
@@ -30,6 +29,7 @@ use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\HistogramQueryResult;
 use Google\Cloud\Talent\V4beta1\ListProfilesResponse;
 use Google\Cloud\Talent\V4beta1\Profile;
+use Google\Cloud\Talent\V4beta1\ProfileServiceClient;
 use Google\Cloud\Talent\V4beta1\RequestMetadata;
 use Google\Cloud\Talent\V4beta1\SearchProfilesResponse;
 use Google\Protobuf\GPBEmpty;

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/TenantServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/TenantServiceClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Google\Cloud\Talent\Tests\Unit\V4beta1;
 
-use Google\Cloud\Talent\V4beta1\TenantServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Talent\V4beta1\ListTenantsResponse;
 use Google\Cloud\Talent\V4beta1\Tenant;
+use Google\Cloud\Talent\V4beta1\TenantServiceClient;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;
 use stdClass;

--- a/tests/Integration/goldens/videointelligence/tests/Unit/V1/VideoIntelligenceServiceClientTest.php
+++ b/tests/Integration/goldens/videointelligence/tests/Unit/V1/VideoIntelligenceServiceClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Google\Cloud\VideoIntelligence\Tests\Unit\V1;
 
-use Google\Cloud\VideoIntelligence\V1\VideoIntelligenceServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\VideoIntelligence\V1\AnnotateVideoResponse;
+use Google\Cloud\VideoIntelligence\V1\VideoIntelligenceServiceClient;
 use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Any;

--- a/tests/Unit/ProtoTests/Basic/out/tests/Unit/BasicClientTest.php
+++ b/tests/Unit/ProtoTests/Basic/out/tests/Unit/BasicClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Testing\Basic\Tests\Unit;
 
-use Testing\Basic\BasicClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\Basic\BasicClient;
 use Testing\Basic\Request;
 use Testing\Basic\Response;
 use stdClass;

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/tests/Unit/BasicBidiStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/tests/Unit/BasicBidiStreamingClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Testing\BasicBidiStreaming\Tests\Unit;
 
-use Testing\BasicBidiStreaming\BasicBidiStreamingClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\BidiStream;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\BasicBidiStreaming\BasicBidiStreamingClient;
 use Testing\BasicBidiStreaming\EmptyRequest;
 use Testing\BasicBidiStreaming\Request;
 use Testing\BasicBidiStreaming\Response;

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/LibraryServiceClientTest.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/LibraryServiceClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Testing\BasicDiregapic\Tests\Unit;
 
-use Testing\BasicDiregapic\LibraryServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -40,6 +39,7 @@ use Testing\BasicDiregapic\BookFromArchiveResponse;
 use Testing\BasicDiregapic\BookResponse;
 use Testing\BasicDiregapic\FindRelatedBooksResponse;
 use Testing\BasicDiregapic\InventoryResponse;
+use Testing\BasicDiregapic\LibraryServiceClient;
 use Testing\BasicDiregapic\ListAggregatedShelvesResponse;
 use Testing\BasicDiregapic\ListBooksResponse;
 use Testing\BasicDiregapic\ListShelvesResponse;

--- a/tests/Unit/ProtoTests/BasicLro/out/tests/Unit/BasicLroClientTest.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/tests/Unit/BasicLroClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Testing\BasicLro\Tests\Unit;
 
-use Testing\BasicLro\BasicLroClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -32,6 +31,7 @@ use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Any;
 use Google\Rpc\Code;
+use Testing\BasicLro\BasicLroClient;
 use Testing\BasicLro\LroResponse;
 use Testing\BasicLro\Request;
 use stdClass;

--- a/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/BasicOneofClientTest.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/BasicOneofClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Testing\BasicOneof\Tests\Unit;
 
-use Testing\BasicOneof\BasicOneofClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\BasicOneof\BasicOneofClient;
 use Testing\BasicOneof\Request;
 use Testing\BasicOneof\Request\Other;
 use Testing\BasicOneof\Request\SupplementaryDataOneof;

--- a/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/BasicPaginatedClientTest.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/BasicPaginatedClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Testing\BasicPaginated\Tests\Unit;
 
-use Testing\BasicPaginated\BasicPaginatedClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\BasicPaginated\BasicPaginatedClient;
 use Testing\BasicPaginated\Request;
 use Testing\BasicPaginated\Response;
 use stdClass;

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/tests/Unit/BasicServerStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/tests/Unit/BasicServerStreamingClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Testing\BasicServerStreaming\Tests\Unit;
 
-use Testing\BasicServerStreaming\BasicServerStreamingClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\ServerStream;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\BasicServerStreaming\BasicServerStreamingClient;
 use Testing\BasicServerStreaming\Request;
 use Testing\BasicServerStreaming\Response;
 use stdClass;

--- a/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/CustomLroClientTest.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/CustomLroClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Testing\CustomLro\Tests\Unit;
 
-use Testing\CustomLro\CustomLroClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\CustomLro\CustomLroClient;
 use Testing\CustomLro\CustomLroOperationsClient;
 use Testing\CustomLro\CustomOperationResponse;
 use Testing\CustomLro\CustomOperationResponse\Status;

--- a/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/CustomLroOperationsClientTest.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/CustomLroOperationsClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Testing\CustomLro\Tests\Unit;
 
-use Testing\CustomLro\CustomLroOperationsClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;
+use Testing\CustomLro\CustomLroOperationsClient;
 use Testing\CustomLro\CustomOperationResponse;
 use stdClass;
 

--- a/tests/Unit/ProtoTests/DeprecatedService/out/tests/Unit/DeprecatedServiceClientTest.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/tests/Unit/DeprecatedServiceClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Testing\Deprecated\Tests\Unit;
 
-use Testing\Deprecated\DeprecatedServiceClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Protobuf\GPBEmpty;
 use Google\Rpc\Code;
+use Testing\Deprecated\DeprecatedServiceClient;
 use stdClass;
 
 /**

--- a/tests/Unit/ProtoTests/DisableSnippets/out/tests/Unit/DisableSnippetsClientTest.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/tests/Unit/DisableSnippetsClientTest.php
@@ -22,12 +22,12 @@
 
 namespace Testing\DisableSnippets\Tests\Unit;
 
-use Testing\DisableSnippets\DisableSnippetsClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
+use Testing\DisableSnippets\DisableSnippetsClient;
 use Testing\DisableSnippets\Request;
 use Testing\DisableSnippets\Response;
 use stdClass;

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/tests/Unit/GrpcServiceConfigWithRetry1ClientTest.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/tests/Unit/GrpcServiceConfigWithRetry1ClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Testing\GrpcServiceConfig\Tests\Unit;
 
-use Testing\GrpcServiceConfig\GrpcServiceConfigWithRetry1Client;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\BidiStream;
 use Google\ApiCore\CredentialsWrapper;
@@ -34,6 +33,7 @@ use Google\LongRunning\GetOperationRequest;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Any;
 use Google\Rpc\Code;
+use Testing\GrpcServiceConfig\GrpcServiceConfigWithRetry1Client;
 use Testing\GrpcServiceConfig\LroResponse;
 use Testing\GrpcServiceConfig\Request1;
 use Testing\GrpcServiceConfig\Response1;

--- a/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/ResourceNamesClientTest.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/ResourceNamesClientTest.php
@@ -22,13 +22,13 @@
 
 namespace Testing\ResourceNames\Tests\Unit;
 
-use Testing\ResourceNames\ResourceNamesClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Rpc\Code;
 use Testing\ResourceNames\PlaceholderResponse;
+use Testing\ResourceNames\ResourceNamesClient;
 use stdClass;
 
 /**

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/tests/Unit/RoutingHeadersClientTest.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/tests/Unit/RoutingHeadersClientTest.php
@@ -22,7 +22,6 @@
 
 namespace Testing\RoutingHeaders\Tests\Unit;
 
-use Testing\RoutingHeaders\RoutingHeadersClient;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
@@ -31,6 +30,7 @@ use Google\Rpc\Code;
 use Testing\RoutingHeaders\NestedRequest\Inner1;
 use Testing\RoutingHeaders\NestedRequest\Inner1\Inner2;
 use Testing\RoutingHeaders\Response;
+use Testing\RoutingHeaders\RoutingHeadersClient;
 use stdClass;
 
 /**


### PR DESCRIPTION
It looks like some of the formatting changes made in #483 obviate the need for these lines.