### PR TITLE
fix: miscellaneous snippet gen fixes

### DIFF
--- a/src/Generation/SnippetDetails.php
+++ b/src/Generation/SnippetDetails.php
@@ -96,7 +96,7 @@ class SnippetDetails
     {
         // resource based format fields
         if ($field->useResourceTestValue) {
-            $this->handleFormattedResource($field);
+            $this->handleFormattedResource($field, $parentFieldName);
             return;
         }
 
@@ -135,9 +135,16 @@ class SnippetDetails
             }
 
             $this->handleField($field, '');
+            $prefix = $field->useResourceTestValue
+                ? 'formatted_'
+                : '';
             $setter = $field->setter->getName();
             $value = $value->$setter(
-                AST::var(Helpers::toCamelCase($field->camelName))
+                AST::var(
+                    Helpers::toCamelCase(
+                        $prefix . $field->camelName
+                    )
+                )
             );
         }
 
@@ -192,8 +199,15 @@ class SnippetDetails
 
             $this->handleField($subField, $fieldVar->name);
             $setter = $subField->setter->getName();
+            $prefix = $subField->useResourceTestValue
+                ? 'formatted_'
+                : '';
             $value = $value->$setter(
-                AST::var(Helpers::toCamelCase($fieldVar->name . '_' . $subField->camelName))
+                AST::var(
+                    Helpers::toCamelCase(
+                        $prefix . $fieldVar->name . '_' . $subField->camelName
+                    )
+                )
             );
         }
 
@@ -285,10 +299,13 @@ class SnippetDetails
 
     /**
      * @param FieldDetails $field
+     * @param string|null $parentFieldName
      */
-    private function handleFormattedResource(FieldDetails $field): void
-    {
-        $fieldName = Helpers::toCamelCase("formatted_{$field->name}");
+    private function handleFormattedResource(
+        FieldDetails $field,
+        string $parentFieldName = null
+    ): void {
+        $fieldName = Helpers::toCamelCase("formatted_{$parentFieldName}_{$field->name}");
         $var = AST::var($fieldName);
         $arrayElementVar = null;
         $formatMethodArgs = $field->resourceDetails
@@ -341,6 +358,12 @@ class SnippetDetails
                 $this->filterDocLines($field->docLines)
             )
         );
+
+        // Don't append to rpcArguments if a parent exists.
+        if ($parentFieldName !== null) {
+            return;
+        }
+
         $this->rpcArguments = $this->rpcArguments->append($var);
     }
 

--- a/src/Generation/SnippetGenerator.php
+++ b/src/Generation/SnippetGenerator.php
@@ -175,7 +175,7 @@ class SnippetGenerator
                             : Vector::new([
                                 AST::inlineVarDoc(
                                     $context->type($snippetDetails->methodDetails->lroResponseType),
-                                    $responseVar
+                                    $resultVar
                                 ),
                                 AST::assign($resultVar, $responseVar->getResult()),
                                 $this->buildPrintFCall(

--- a/src/Generation/SnippetGenerator.php
+++ b/src/Generation/SnippetGenerator.php
@@ -160,6 +160,7 @@ class SnippetGenerator
         $errorVar = AST::var('error');
         $isCustomOp = $snippetDetails->methodDetails->methodType === MethodDetails::CUSTOM_OP;
         $context = $snippetDetails->context;
+        $lroResponseType = $snippetDetails->methodDetails->lroResponseType;
 
         return $this->buildSnippetFunctions(
             $snippetDetails,
@@ -174,13 +175,15 @@ class SnippetGenerator
                             ? $this->buildPrintFCall('Operation completed successfully.')
                             : Vector::new([
                                 AST::inlineVarDoc(
-                                    $context->type($snippetDetails->methodDetails->lroResponseType),
+                                    $context->type($lroResponseType),
                                     $resultVar
                                 ),
                                 AST::assign($resultVar, $responseVar->getResult()),
                                 $this->buildPrintFCall(
                                     'Operation successful with response data: %s',
-                                    "{$resultVar->toCode()}->serializeToJsonString()"
+                                    $lroResponseType->isClass()
+                                        ? "{$resultVar->toCode()}->serializeToJsonString()"
+                                        : $resultVar->toCode()
                                 )
                             ])
                     )->else(
@@ -207,6 +210,7 @@ class SnippetGenerator
         $responseVar = AST::var('response');
         $elementVar = AST::var('element');
         $context = $snippetDetails->context;
+        $resourceType = $snippetDetails->methodDetails->resourceType;
 
         return $this->buildSnippetFunctions(
             $snippetDetails,
@@ -214,13 +218,15 @@ class SnippetGenerator
                 $this->buildClientMethodCall($snippetDetails, $responseVar),
                 PHP_EOL,
                 AST::inlineVarDoc(
-                    $context->type($snippetDetails->methodDetails->resourceType),
+                    $context->type($resourceType),
                     $elementVar
                 ),
                 AST::foreach($responseVar, $elementVar)(
                     $this->buildPrintFCall(
                         'Element data: %s',
-                        "{$elementVar->toCode()}->serializeToJsonString()"
+                        $resourceType->isClass()
+                            ? "{$elementVar->toCode()}->serializeToJsonString()"
+                            : $elementVar->toCode()
                     )
                 )
             ]
@@ -236,6 +242,7 @@ class SnippetGenerator
         $streamVar = AST::var('stream');
         $elementVar = AST::var('element');
         $context = $snippetDetails->context;
+        $responseType = $snippetDetails->methodDetails->responseType;
 
         return $this->buildSnippetFunctions(
             $snippetDetails,
@@ -244,13 +251,15 @@ class SnippetGenerator
                 $streamVar->writeAll($snippetDetails->rpcArguments),
                 PHP_EOL,
                 AST::inlineVarDoc(
-                    $context->type($snippetDetails->methodDetails->responseType),
+                    $context->type($responseType),
                     $elementVar
                 ),
                 AST::foreach($streamVar->closeWriteAndReadAll(), $elementVar)(
                     $this->buildPrintFCall(
                         'Element data: %s',
-                        "{$elementVar->toCode()}->serializeToJsonString()"
+                        $responseType->isClass()
+                            ? "{$elementVar->toCode()}->serializeToJsonString()"
+                            : $elementVar->toCode()
                     )
                 )
             ]
@@ -266,6 +275,7 @@ class SnippetGenerator
         $streamVar = AST::var('stream');
         $elementVar = AST::var('element');
         $context = $snippetDetails->context;
+        $responseType = $snippetDetails->methodDetails->responseType;
 
         return $this->buildSnippetFunctions(
             $snippetDetails,
@@ -273,13 +283,15 @@ class SnippetGenerator
                 $this->buildClientMethodCall($snippetDetails, $streamVar),
                 PHP_EOL,
                 AST::inlineVarDoc(
-                    $context->type($snippetDetails->methodDetails->responseType),
+                    $context->type($responseType),
                     $elementVar
                 ),
                 AST::foreach($streamVar->readAll(), $elementVar)(
                     $this->buildPrintFCall(
                         'Element data: %s',
-                        "{$elementVar->toCode()}->serializeToJsonString()"
+                        $responseType->isClass()
+                            ? "{$elementVar->toCode()}->serializeToJsonString()"
+                            : $elementVar->toCode()
                     )
                 )
             ]
@@ -295,6 +307,7 @@ class SnippetGenerator
         $streamVar = AST::var('stream');
         $responseVar = AST::var('response');
         $context = $snippetDetails->context;
+        $responseType = $snippetDetails->methodDetails->responseType;
 
         return $this->buildSnippetFunctions(
             $snippetDetails,
@@ -302,7 +315,7 @@ class SnippetGenerator
                 $this->buildClientMethodCall($snippetDetails, $streamVar),
                 PHP_EOL,
                 AST::inlineVarDoc(
-                    $context->type($snippetDetails->methodDetails->responseType),
+                    $context->type($responseType),
                     $responseVar
                 ),
                 AST::assign(
@@ -311,7 +324,9 @@ class SnippetGenerator
                 ),
                 $this->buildPrintFCall(
                     'Response data: %s',
-                    "{$responseVar->toCode()}->serializeToJsonString()"
+                    $responseType->isClass()
+                        ? "{$responseVar->toCode()}->serializeToJsonString()"
+                        : $responseVar->toCode()
                 )
             ]
         );

--- a/src/Main.php
+++ b/src/Main.php
@@ -150,6 +150,7 @@ if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
         $gapicYaml,
         $serviceYaml,
         $numericEnums,
+        -1,
         $generateSnippets
     );
 

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
@@ -72,7 +72,7 @@ function analyze_iam_policy_longrunning_sample(string $analysisQueryScope): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var AnalyzeIamPolicyLongrunningResponse $response */
+            /** @var AnalyzeIamPolicyLongrunningResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/export_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/export_assets.php
@@ -62,7 +62,7 @@ function export_assets_sample(string $parent): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var ExportAssetsResponse $response */
+            /** @var ExportAssetsResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/aggregated_list.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/aggregated_list.php
@@ -25,7 +25,6 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 // [START compute_v1_generated_Addresses_AggregatedList_sync]
 use Google\ApiCore\ApiException;
 use Google\ApiCore\PagedListResponse;
-use Google\Cloud\Compute\V1\AddressAggregatedList\ItemsEntry;
 use Google\Cloud\Compute\V1\AddressesClient;
 
 /**
@@ -43,7 +42,6 @@ function aggregated_list_sample(string $project): void
         /** @var PagedListResponse $response */
         $response = $addressesClient->aggregatedList($project);
 
-        /** @var ItemsEntry $element */
         foreach ($response as $element) {
             printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
         }

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/list.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/list.php
@@ -25,7 +25,6 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 // [START compute_v1_generated_Addresses_List_sync]
 use Google\ApiCore\ApiException;
 use Google\ApiCore\PagedListResponse;
-use Google\Cloud\Compute\V1\Address;
 use Google\Cloud\Compute\V1\AddressesClient;
 
 /**
@@ -49,7 +48,6 @@ function list_sample(string $orderBy, string $project, string $region): void
         /** @var PagedListResponse $response */
         $response = $addressesClient->list($orderBy, $project, $region);
 
-        /** @var Address $element */
         foreach ($response as $element) {
             printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
         }

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/create_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/create_cluster.php
@@ -65,7 +65,7 @@ function create_cluster_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Cluster $response */
+            /** @var Cluster $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/diagnose_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/diagnose_cluster.php
@@ -55,7 +55,7 @@ function diagnose_cluster_sample(string $projectId, string $region, string $clus
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var DiagnoseClusterResults $response */
+            /** @var DiagnoseClusterResults $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/start_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/start_cluster.php
@@ -49,7 +49,7 @@ function start_cluster_sample(string $projectId, string $region, string $cluster
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Cluster $response */
+            /** @var Cluster $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/stop_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/stop_cluster.php
@@ -49,7 +49,7 @@ function stop_cluster_sample(string $projectId, string $region, string $clusterN
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Cluster $response */
+            /** @var Cluster $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/update_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/update_cluster.php
@@ -77,7 +77,7 @@ function update_cluster_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Cluster $response */
+            /** @var Cluster $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job_as_operation.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job_as_operation.php
@@ -59,7 +59,7 @@ function submit_job_as_operation_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Job $response */
+            /** @var Job $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/create_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/create_function.php
@@ -53,7 +53,7 @@ function create_function_sample(string $formattedLocation): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var CloudFunction $response */
+            /** @var CloudFunction $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/update_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/update_function.php
@@ -53,7 +53,7 @@ function update_function_sample(): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var CloudFunction $response */
+            /** @var CloudFunction $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_logs.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_logs.php
@@ -51,7 +51,7 @@ function list_logs_sample(string $formattedParent): void
 
         /** @var string $element */
         foreach ($response as $element) {
-            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+            printf('Element data: %s' . PHP_EOL, $element);
         }
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/create_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/create_instance.php
@@ -91,7 +91,7 @@ function create_instance_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Instance $response */
+            /** @var Instance $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/export_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/export_instance.php
@@ -57,7 +57,7 @@ function export_instance_sample(string $name): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Instance $response */
+            /** @var Instance $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/failover_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/failover_instance.php
@@ -50,7 +50,7 @@ function failover_instance_sample(string $formattedName): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Instance $response */
+            /** @var Instance $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/import_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/import_instance.php
@@ -59,7 +59,7 @@ function import_instance_sample(string $name): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Instance $response */
+            /** @var Instance $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/update_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/update_instance.php
@@ -72,7 +72,7 @@ function update_instance_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Instance $response */
+            /** @var Instance $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/upgrade_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/upgrade_instance.php
@@ -51,7 +51,7 @@ function upgrade_instance_sample(string $formattedName, string $redisVersion): v
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var Instance $response */
+            /** @var Instance $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/import_completion_data.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/import_completion_data.php
@@ -71,7 +71,7 @@ function import_completion_data_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var ImportCompletionDataResponse $response */
+            /** @var ImportCompletionDataResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_fulfillment_places.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_fulfillment_places.php
@@ -107,7 +107,7 @@ function add_fulfillment_places_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var AddFulfillmentPlacesResponse $response */
+            /** @var AddFulfillmentPlacesResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/import_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/import_products.php
@@ -61,7 +61,7 @@ function import_products_sample(string $formattedParent): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var ImportProductsResponse $response */
+            /** @var ImportProductsResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_fulfillment_places.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_fulfillment_places.php
@@ -102,7 +102,7 @@ function remove_fulfillment_places_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var RemoveFulfillmentPlacesResponse $response */
+            /** @var RemoveFulfillmentPlacesResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/set_inventory.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/set_inventory.php
@@ -99,7 +99,7 @@ function set_inventory_sample(string $inventoryTitle): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var SetInventoryResponse $response */
+            /** @var SetInventoryResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/import_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/import_user_events.php
@@ -95,7 +95,7 @@ function import_user_events_sample(
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var ImportUserEventsResponse $response */
+            /** @var ImportUserEventsResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/purge_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/purge_user_events.php
@@ -75,7 +75,7 @@ function purge_user_events_sample(string $parent, string $filter): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var PurgeUserEventsResponse $response */
+            /** @var PurgeUserEventsResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/rejoin_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/rejoin_user_events.php
@@ -53,7 +53,7 @@ function rejoin_user_events_sample(string $parent): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var RejoinUserEventsResponse $response */
+            /** @var RejoinUserEventsResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
@@ -53,7 +53,7 @@ function run_asset_discovery_sample(string $formattedParent): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var RunAssetDiscoveryResponse $response */
+            /** @var RunAssetDiscoveryResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/long_running_recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/long_running_recognize.php
@@ -63,7 +63,7 @@ function long_running_recognize_sample(string $configLanguageCode): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var LongRunningRecognizeResponse $response */
+            /** @var LongRunningRecognizeResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/create_application.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/create_application.php
@@ -32,31 +32,31 @@ use Google\Protobuf\Timestamp;
 /**
  * Creates a new application entity.
  *
- * @param string $formattedParent       Resource name of the profile under which the application is created.
+ * @param string $formattedParent         Resource name of the profile under which the application is created.
  *
- *                                      The format is
- *                                      "projects/{project_id}/tenants/{tenant_id}/profiles/{profile_id}".
- *                                      For example, "projects/foo/tenants/bar/profiles/baz". Please see
- *                                      {@see ApplicationServiceClient::profileName()} for help formatting this field.
- * @param string $applicationExternalId Client side application identifier, used to uniquely identify the
- *                                      application.
+ *                                        The format is
+ *                                        "projects/{project_id}/tenants/{tenant_id}/profiles/{profile_id}".
+ *                                        For example, "projects/foo/tenants/bar/profiles/baz". Please see
+ *                                        {@see ApplicationServiceClient::profileName()} for help formatting this field.
+ * @param string $applicationExternalId   Client side application identifier, used to uniquely identify the
+ *                                        application.
  *
- *                                      The maximum number of allowed characters is 255.
- * @param string $formattedJob          Resource name of the job which the candidate applied for.
+ *                                        The maximum number of allowed characters is 255.
+ * @param string $formattedApplicationJob Resource name of the job which the candidate applied for.
  *
- *                                      The format is
- *                                      "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For example,
- *                                      "projects/foo/tenants/bar/jobs/baz". Please see
- *                                      {@see ApplicationServiceClient::jobName()} for help formatting this field.
- * @param int    $applicationStage      What is the most recent stage of the application (that is, new,
- *                                      screen, send cv, hired, finished work)?  This field is intentionally not
- *                                      comprehensive of every possible status, but instead, represents statuses
- *                                      that would be used to indicate to the ML models good / bad matches.
+ *                                        The format is
+ *                                        "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For example,
+ *                                        "projects/foo/tenants/bar/jobs/baz". Please see
+ *                                        {@see ApplicationServiceClient::jobName()} for help formatting this field.
+ * @param int    $applicationStage        What is the most recent stage of the application (that is, new,
+ *                                        screen, send cv, hired, finished work)?  This field is intentionally not
+ *                                        comprehensive of every possible status, but instead, represents statuses
+ *                                        that would be used to indicate to the ML models good / bad matches.
  */
 function create_application_sample(
     string $formattedParent,
     string $applicationExternalId,
-    string $formattedJob,
+    string $formattedApplicationJob,
     int $applicationStage
 ): void {
     // Create a client.
@@ -66,18 +66,14 @@ function create_application_sample(
     $applicationCreateTime = new Timestamp();
     $application = (new Application())
         ->setExternalId($applicationExternalId)
-        ->setJob($applicationJob)
+        ->setJob($formattedApplicationJob)
         ->setStage($applicationStage)
         ->setCreateTime($applicationCreateTime);
 
     // Call the API and handle any network failures.
     try {
         /** @var Application $response */
-        $response = $applicationServiceClient->createApplication(
-            $formattedParent,
-            $application,
-            $formattedJob
-        );
+        $response = $applicationServiceClient->createApplication($formattedParent, $application);
         printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
@@ -97,13 +93,13 @@ function callSample(): void
 {
     $formattedParent = ApplicationServiceClient::profileName('[PROJECT]', '[TENANT]', '[PROFILE]');
     $applicationExternalId = '[EXTERNAL_ID]';
-    $formattedJob = ApplicationServiceClient::jobName('[PROJECT]', '[TENANT]', '[JOB]');
+    $formattedApplicationJob = ApplicationServiceClient::jobName('[PROJECT]', '[TENANT]', '[JOB]');
     $applicationStage = ApplicationStage::APPLICATION_STAGE_UNSPECIFIED;
 
     create_application_sample(
         $formattedParent,
         $applicationExternalId,
-        $formattedJob,
+        $formattedApplicationJob,
         $applicationStage
     );
 }

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/update_application.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/update_application.php
@@ -32,24 +32,24 @@ use Google\Protobuf\Timestamp;
 /**
  * Updates specified application.
  *
- * @param string $applicationExternalId Client side application identifier, used to uniquely identify the
- *                                      application.
+ * @param string $applicationExternalId   Client side application identifier, used to uniquely identify the
+ *                                        application.
  *
- *                                      The maximum number of allowed characters is 255.
- * @param string $formattedJob          Resource name of the job which the candidate applied for.
+ *                                        The maximum number of allowed characters is 255.
+ * @param string $formattedApplicationJob Resource name of the job which the candidate applied for.
  *
- *                                      The format is
- *                                      "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For example,
- *                                      "projects/foo/tenants/bar/jobs/baz". Please see
- *                                      {@see ApplicationServiceClient::jobName()} for help formatting this field.
- * @param int    $applicationStage      What is the most recent stage of the application (that is, new,
- *                                      screen, send cv, hired, finished work)?  This field is intentionally not
- *                                      comprehensive of every possible status, but instead, represents statuses
- *                                      that would be used to indicate to the ML models good / bad matches.
+ *                                        The format is
+ *                                        "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For example,
+ *                                        "projects/foo/tenants/bar/jobs/baz". Please see
+ *                                        {@see ApplicationServiceClient::jobName()} for help formatting this field.
+ * @param int    $applicationStage        What is the most recent stage of the application (that is, new,
+ *                                        screen, send cv, hired, finished work)?  This field is intentionally not
+ *                                        comprehensive of every possible status, but instead, represents statuses
+ *                                        that would be used to indicate to the ML models good / bad matches.
  */
 function update_application_sample(
     string $applicationExternalId,
-    string $formattedJob,
+    string $formattedApplicationJob,
     int $applicationStage
 ): void {
     // Create a client.
@@ -59,14 +59,14 @@ function update_application_sample(
     $applicationCreateTime = new Timestamp();
     $application = (new Application())
         ->setExternalId($applicationExternalId)
-        ->setJob($applicationJob)
+        ->setJob($formattedApplicationJob)
         ->setStage($applicationStage)
         ->setCreateTime($applicationCreateTime);
 
     // Call the API and handle any network failures.
     try {
         /** @var Application $response */
-        $response = $applicationServiceClient->updateApplication($application, $formattedJob);
+        $response = $applicationServiceClient->updateApplication($application);
         printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
@@ -85,9 +85,9 @@ function update_application_sample(
 function callSample(): void
 {
     $applicationExternalId = '[EXTERNAL_ID]';
-    $formattedJob = ApplicationServiceClient::jobName('[PROJECT]', '[TENANT]', '[JOB]');
+    $formattedApplicationJob = ApplicationServiceClient::jobName('[PROJECT]', '[TENANT]', '[JOB]');
     $applicationStage = ApplicationStage::APPLICATION_STAGE_UNSPECIFIED;
 
-    update_application_sample($applicationExternalId, $formattedJob, $applicationStage);
+    update_application_sample($applicationExternalId, $formattedApplicationJob, $applicationStage);
 }
 // [END jobs_v4beta1_generated_ApplicationService_UpdateApplication_sync]

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_create_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_create_jobs.php
@@ -33,45 +33,45 @@ use Google\Rpc\Status;
 /**
  * Begins executing a batch create jobs operation.
  *
- * @param string $formattedParent   The resource name of the tenant under which the job is created.
+ * @param string $formattedParent      The resource name of the tenant under which the job is created.
  *
- *                                  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
- *                                  "projects/foo/tenant/bar". If tenant id is unspecified, a default tenant
- *                                  is created. For example, "projects/foo". Please see
- *                                  {@see JobServiceClient::projectName()} for help formatting this field.
- * @param string $formattedCompany  The resource name of the company listing the job.
+ *                                     The format is "projects/{project_id}/tenants/{tenant_id}". For example,
+ *                                     "projects/foo/tenant/bar". If tenant id is unspecified, a default tenant
+ *                                     is created. For example, "projects/foo". Please see
+ *                                     {@see JobServiceClient::projectName()} for help formatting this field.
+ * @param string $formattedJobsCompany The resource name of the company listing the job.
  *
- *                                  The format is
- *                                  "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
- *                                  example, "projects/foo/tenants/bar/companies/baz".
+ *                                     The format is
+ *                                     "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
+ *                                     example, "projects/foo/tenants/bar/companies/baz".
  *
- *                                  If tenant id is unspecified, the default tenant is used. For
- *                                  example, "projects/foo/companies/bar". Please see
- *                                  {@see JobServiceClient::companyName()} for help formatting this field.
- * @param string $jobsRequisitionId The requisition ID, also referred to as the posting ID, is assigned by the
- *                                  client to identify a job. This field is intended to be used by clients
- *                                  for client identification and tracking of postings. A job isn't allowed
- *                                  to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
- *                                  [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
+ *                                     If tenant id is unspecified, the default tenant is used. For
+ *                                     example, "projects/foo/companies/bar". Please see
+ *                                     {@see JobServiceClient::companyName()} for help formatting this field.
+ * @param string $jobsRequisitionId    The requisition ID, also referred to as the posting ID, is assigned by the
+ *                                     client to identify a job. This field is intended to be used by clients
+ *                                     for client identification and tracking of postings. A job isn't allowed
+ *                                     to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
+ *                                     [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
  *
- *                                  The maximum number of allowed characters is 255.
- * @param string $jobsTitle         The title of the job, such as "Software Engineer"
+ *                                     The maximum number of allowed characters is 255.
+ * @param string $jobsTitle            The title of the job, such as "Software Engineer"
  *
- *                                  The maximum number of allowed characters is 500.
- * @param string $jobsDescription   The description of the job, which typically includes a multi-paragraph
- *                                  description of the company and related information. Separate fields are
- *                                  provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
- *                                  [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
- *                                  these separate job fields is recommended.
+ *                                     The maximum number of allowed characters is 500.
+ * @param string $jobsDescription      The description of the job, which typically includes a multi-paragraph
+ *                                     description of the company and related information. Separate fields are
+ *                                     provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
+ *                                     [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
+ *                                     these separate job fields is recommended.
  *
- *                                  This field accepts and sanitizes HTML input, and also accepts
- *                                  bold, italic, ordered list, and unordered list markup tags.
+ *                                     This field accepts and sanitizes HTML input, and also accepts
+ *                                     bold, italic, ordered list, and unordered list markup tags.
  *
- *                                  The maximum number of allowed characters is 100,000.
+ *                                     The maximum number of allowed characters is 100,000.
  */
 function batch_create_jobs_sample(
     string $formattedParent,
-    string $formattedCompany,
+    string $formattedJobsCompany,
     string $jobsRequisitionId,
     string $jobsTitle,
     string $jobsDescription
@@ -81,7 +81,7 @@ function batch_create_jobs_sample(
 
     // Prepare any non-scalar elements to be passed along with the request.
     $job = (new Job())
-        ->setCompany($jobsCompany)
+        ->setCompany($formattedJobsCompany)
         ->setRequisitionId($jobsRequisitionId)
         ->setTitle($jobsTitle)
         ->setDescription($jobsDescription);
@@ -90,11 +90,11 @@ function batch_create_jobs_sample(
     // Call the API and handle any network failures.
     try {
         /** @var OperationResponse $response */
-        $response = $jobServiceClient->batchCreateJobs($formattedParent, $jobs, $formattedCompany);
+        $response = $jobServiceClient->batchCreateJobs($formattedParent, $jobs);
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var JobOperationResult $response */
+            /** @var JobOperationResult $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {
@@ -119,14 +119,14 @@ function batch_create_jobs_sample(
 function callSample(): void
 {
     $formattedParent = JobServiceClient::projectName('[PROJECT]');
-    $formattedCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+    $formattedJobsCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
     $jobsRequisitionId = '[REQUISITION_ID]';
     $jobsTitle = '[TITLE]';
     $jobsDescription = '[DESCRIPTION]';
 
     batch_create_jobs_sample(
         $formattedParent,
-        $formattedCompany,
+        $formattedJobsCompany,
         $jobsRequisitionId,
         $jobsTitle,
         $jobsDescription

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_update_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_update_jobs.php
@@ -33,45 +33,45 @@ use Google\Rpc\Status;
 /**
  * Begins executing a batch update jobs operation.
  *
- * @param string $formattedParent   The resource name of the tenant under which the job is created.
+ * @param string $formattedParent      The resource name of the tenant under which the job is created.
  *
- *                                  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
- *                                  "projects/foo/tenant/bar". If tenant id is unspecified, a default tenant
- *                                  is created. For example, "projects/foo". Please see
- *                                  {@see JobServiceClient::projectName()} for help formatting this field.
- * @param string $formattedCompany  The resource name of the company listing the job.
+ *                                     The format is "projects/{project_id}/tenants/{tenant_id}". For example,
+ *                                     "projects/foo/tenant/bar". If tenant id is unspecified, a default tenant
+ *                                     is created. For example, "projects/foo". Please see
+ *                                     {@see JobServiceClient::projectName()} for help formatting this field.
+ * @param string $formattedJobsCompany The resource name of the company listing the job.
  *
- *                                  The format is
- *                                  "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
- *                                  example, "projects/foo/tenants/bar/companies/baz".
+ *                                     The format is
+ *                                     "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
+ *                                     example, "projects/foo/tenants/bar/companies/baz".
  *
- *                                  If tenant id is unspecified, the default tenant is used. For
- *                                  example, "projects/foo/companies/bar". Please see
- *                                  {@see JobServiceClient::companyName()} for help formatting this field.
- * @param string $jobsRequisitionId The requisition ID, also referred to as the posting ID, is assigned by the
- *                                  client to identify a job. This field is intended to be used by clients
- *                                  for client identification and tracking of postings. A job isn't allowed
- *                                  to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
- *                                  [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
+ *                                     If tenant id is unspecified, the default tenant is used. For
+ *                                     example, "projects/foo/companies/bar". Please see
+ *                                     {@see JobServiceClient::companyName()} for help formatting this field.
+ * @param string $jobsRequisitionId    The requisition ID, also referred to as the posting ID, is assigned by the
+ *                                     client to identify a job. This field is intended to be used by clients
+ *                                     for client identification and tracking of postings. A job isn't allowed
+ *                                     to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
+ *                                     [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
  *
- *                                  The maximum number of allowed characters is 255.
- * @param string $jobsTitle         The title of the job, such as "Software Engineer"
+ *                                     The maximum number of allowed characters is 255.
+ * @param string $jobsTitle            The title of the job, such as "Software Engineer"
  *
- *                                  The maximum number of allowed characters is 500.
- * @param string $jobsDescription   The description of the job, which typically includes a multi-paragraph
- *                                  description of the company and related information. Separate fields are
- *                                  provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
- *                                  [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
- *                                  these separate job fields is recommended.
+ *                                     The maximum number of allowed characters is 500.
+ * @param string $jobsDescription      The description of the job, which typically includes a multi-paragraph
+ *                                     description of the company and related information. Separate fields are
+ *                                     provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
+ *                                     [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
+ *                                     these separate job fields is recommended.
  *
- *                                  This field accepts and sanitizes HTML input, and also accepts
- *                                  bold, italic, ordered list, and unordered list markup tags.
+ *                                     This field accepts and sanitizes HTML input, and also accepts
+ *                                     bold, italic, ordered list, and unordered list markup tags.
  *
- *                                  The maximum number of allowed characters is 100,000.
+ *                                     The maximum number of allowed characters is 100,000.
  */
 function batch_update_jobs_sample(
     string $formattedParent,
-    string $formattedCompany,
+    string $formattedJobsCompany,
     string $jobsRequisitionId,
     string $jobsTitle,
     string $jobsDescription
@@ -81,7 +81,7 @@ function batch_update_jobs_sample(
 
     // Prepare any non-scalar elements to be passed along with the request.
     $job = (new Job())
-        ->setCompany($jobsCompany)
+        ->setCompany($formattedJobsCompany)
         ->setRequisitionId($jobsRequisitionId)
         ->setTitle($jobsTitle)
         ->setDescription($jobsDescription);
@@ -90,11 +90,11 @@ function batch_update_jobs_sample(
     // Call the API and handle any network failures.
     try {
         /** @var OperationResponse $response */
-        $response = $jobServiceClient->batchUpdateJobs($formattedParent, $jobs, $formattedCompany);
+        $response = $jobServiceClient->batchUpdateJobs($formattedParent, $jobs);
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var JobOperationResult $response */
+            /** @var JobOperationResult $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {
@@ -119,14 +119,14 @@ function batch_update_jobs_sample(
 function callSample(): void
 {
     $formattedParent = JobServiceClient::projectName('[PROJECT]');
-    $formattedCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+    $formattedJobsCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
     $jobsRequisitionId = '[REQUISITION_ID]';
     $jobsTitle = '[TITLE]';
     $jobsDescription = '[DESCRIPTION]';
 
     batch_update_jobs_sample(
         $formattedParent,
-        $formattedCompany,
+        $formattedJobsCompany,
         $jobsRequisitionId,
         $jobsTitle,
         $jobsDescription

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/create_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/create_job.php
@@ -33,45 +33,45 @@ use Google\Cloud\Talent\V4beta1\JobServiceClient;
  * Typically, the job becomes searchable within 10 seconds, but it may take
  * up to 5 minutes.
  *
- * @param string $formattedParent  The resource name of the tenant under which the job is created.
+ * @param string $formattedParent     The resource name of the tenant under which the job is created.
  *
- *                                 The format is "projects/{project_id}/tenants/{tenant_id}". For example,
- *                                 "projects/foo/tenant/bar". If tenant id is unspecified a default tenant
- *                                 is created. For example, "projects/foo". Please see
- *                                 {@see JobServiceClient::projectName()} for help formatting this field.
- * @param string $formattedCompany The resource name of the company listing the job.
+ *                                    The format is "projects/{project_id}/tenants/{tenant_id}". For example,
+ *                                    "projects/foo/tenant/bar". If tenant id is unspecified a default tenant
+ *                                    is created. For example, "projects/foo". Please see
+ *                                    {@see JobServiceClient::projectName()} for help formatting this field.
+ * @param string $formattedJobCompany The resource name of the company listing the job.
  *
- *                                 The format is
- *                                 "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
- *                                 example, "projects/foo/tenants/bar/companies/baz".
+ *                                    The format is
+ *                                    "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
+ *                                    example, "projects/foo/tenants/bar/companies/baz".
  *
- *                                 If tenant id is unspecified, the default tenant is used. For
- *                                 example, "projects/foo/companies/bar". Please see
- *                                 {@see JobServiceClient::companyName()} for help formatting this field.
- * @param string $jobRequisitionId The requisition ID, also referred to as the posting ID, is assigned by the
- *                                 client to identify a job. This field is intended to be used by clients
- *                                 for client identification and tracking of postings. A job isn't allowed
- *                                 to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
- *                                 [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
+ *                                    If tenant id is unspecified, the default tenant is used. For
+ *                                    example, "projects/foo/companies/bar". Please see
+ *                                    {@see JobServiceClient::companyName()} for help formatting this field.
+ * @param string $jobRequisitionId    The requisition ID, also referred to as the posting ID, is assigned by the
+ *                                    client to identify a job. This field is intended to be used by clients
+ *                                    for client identification and tracking of postings. A job isn't allowed
+ *                                    to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
+ *                                    [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
  *
- *                                 The maximum number of allowed characters is 255.
- * @param string $jobTitle         The title of the job, such as "Software Engineer"
+ *                                    The maximum number of allowed characters is 255.
+ * @param string $jobTitle            The title of the job, such as "Software Engineer"
  *
- *                                 The maximum number of allowed characters is 500.
- * @param string $jobDescription   The description of the job, which typically includes a multi-paragraph
- *                                 description of the company and related information. Separate fields are
- *                                 provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
- *                                 [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
- *                                 these separate job fields is recommended.
+ *                                    The maximum number of allowed characters is 500.
+ * @param string $jobDescription      The description of the job, which typically includes a multi-paragraph
+ *                                    description of the company and related information. Separate fields are
+ *                                    provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
+ *                                    [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
+ *                                    these separate job fields is recommended.
  *
- *                                 This field accepts and sanitizes HTML input, and also accepts
- *                                 bold, italic, ordered list, and unordered list markup tags.
+ *                                    This field accepts and sanitizes HTML input, and also accepts
+ *                                    bold, italic, ordered list, and unordered list markup tags.
  *
- *                                 The maximum number of allowed characters is 100,000.
+ *                                    The maximum number of allowed characters is 100,000.
  */
 function create_job_sample(
     string $formattedParent,
-    string $formattedCompany,
+    string $formattedJobCompany,
     string $jobRequisitionId,
     string $jobTitle,
     string $jobDescription
@@ -81,7 +81,7 @@ function create_job_sample(
 
     // Prepare any non-scalar elements to be passed along with the request.
     $job = (new Job())
-        ->setCompany($jobCompany)
+        ->setCompany($formattedJobCompany)
         ->setRequisitionId($jobRequisitionId)
         ->setTitle($jobTitle)
         ->setDescription($jobDescription);
@@ -89,7 +89,7 @@ function create_job_sample(
     // Call the API and handle any network failures.
     try {
         /** @var Job $response */
-        $response = $jobServiceClient->createJob($formattedParent, $job, $formattedCompany);
+        $response = $jobServiceClient->createJob($formattedParent, $job);
         printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
@@ -108,14 +108,14 @@ function create_job_sample(
 function callSample(): void
 {
     $formattedParent = JobServiceClient::projectName('[PROJECT]');
-    $formattedCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+    $formattedJobCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
     $jobRequisitionId = '[REQUISITION_ID]';
     $jobTitle = '[TITLE]';
     $jobDescription = '[DESCRIPTION]';
 
     create_job_sample(
         $formattedParent,
-        $formattedCompany,
+        $formattedJobCompany,
         $jobRequisitionId,
         $jobTitle,
         $jobDescription

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/update_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/update_job.php
@@ -33,38 +33,38 @@ use Google\Cloud\Talent\V4beta1\JobServiceClient;
  * Typically, updated contents become visible in search results within 10
  * seconds, but it may take up to 5 minutes.
  *
- * @param string $formattedCompany The resource name of the company listing the job.
+ * @param string $formattedJobCompany The resource name of the company listing the job.
  *
- *                                 The format is
- *                                 "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
- *                                 example, "projects/foo/tenants/bar/companies/baz".
+ *                                    The format is
+ *                                    "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}". For
+ *                                    example, "projects/foo/tenants/bar/companies/baz".
  *
- *                                 If tenant id is unspecified, the default tenant is used. For
- *                                 example, "projects/foo/companies/bar". Please see
- *                                 {@see JobServiceClient::companyName()} for help formatting this field.
- * @param string $jobRequisitionId The requisition ID, also referred to as the posting ID, is assigned by the
- *                                 client to identify a job. This field is intended to be used by clients
- *                                 for client identification and tracking of postings. A job isn't allowed
- *                                 to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
- *                                 [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
+ *                                    If tenant id is unspecified, the default tenant is used. For
+ *                                    example, "projects/foo/companies/bar". Please see
+ *                                    {@see JobServiceClient::companyName()} for help formatting this field.
+ * @param string $jobRequisitionId    The requisition ID, also referred to as the posting ID, is assigned by the
+ *                                    client to identify a job. This field is intended to be used by clients
+ *                                    for client identification and tracking of postings. A job isn't allowed
+ *                                    to be created if there is another job with the same [company][google.cloud.talent.v4beta1.Job.name],
+ *                                    [language_code][google.cloud.talent.v4beta1.Job.language_code] and [requisition_id][google.cloud.talent.v4beta1.Job.requisition_id].
  *
- *                                 The maximum number of allowed characters is 255.
- * @param string $jobTitle         The title of the job, such as "Software Engineer"
+ *                                    The maximum number of allowed characters is 255.
+ * @param string $jobTitle            The title of the job, such as "Software Engineer"
  *
- *                                 The maximum number of allowed characters is 500.
- * @param string $jobDescription   The description of the job, which typically includes a multi-paragraph
- *                                 description of the company and related information. Separate fields are
- *                                 provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
- *                                 [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
- *                                 these separate job fields is recommended.
+ *                                    The maximum number of allowed characters is 500.
+ * @param string $jobDescription      The description of the job, which typically includes a multi-paragraph
+ *                                    description of the company and related information. Separate fields are
+ *                                    provided on the job object for [responsibilities][google.cloud.talent.v4beta1.Job.responsibilities],
+ *                                    [qualifications][google.cloud.talent.v4beta1.Job.qualifications], and other job characteristics. Use of
+ *                                    these separate job fields is recommended.
  *
- *                                 This field accepts and sanitizes HTML input, and also accepts
- *                                 bold, italic, ordered list, and unordered list markup tags.
+ *                                    This field accepts and sanitizes HTML input, and also accepts
+ *                                    bold, italic, ordered list, and unordered list markup tags.
  *
- *                                 The maximum number of allowed characters is 100,000.
+ *                                    The maximum number of allowed characters is 100,000.
  */
 function update_job_sample(
-    string $formattedCompany,
+    string $formattedJobCompany,
     string $jobRequisitionId,
     string $jobTitle,
     string $jobDescription
@@ -74,7 +74,7 @@ function update_job_sample(
 
     // Prepare any non-scalar elements to be passed along with the request.
     $job = (new Job())
-        ->setCompany($jobCompany)
+        ->setCompany($formattedJobCompany)
         ->setRequisitionId($jobRequisitionId)
         ->setTitle($jobTitle)
         ->setDescription($jobDescription);
@@ -82,7 +82,7 @@ function update_job_sample(
     // Call the API and handle any network failures.
     try {
         /** @var Job $response */
-        $response = $jobServiceClient->updateJob($job, $formattedCompany);
+        $response = $jobServiceClient->updateJob($job);
         printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
@@ -100,11 +100,11 @@ function update_job_sample(
  */
 function callSample(): void
 {
-    $formattedCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
+    $formattedJobCompany = JobServiceClient::companyName('[PROJECT]', '[TENANT]', '[COMPANY]');
     $jobRequisitionId = '[REQUISITION_ID]';
     $jobTitle = '[TITLE]';
     $jobDescription = '[DESCRIPTION]';
 
-    update_job_sample($formattedCompany, $jobRequisitionId, $jobTitle, $jobDescription);
+    update_job_sample($formattedJobCompany, $jobRequisitionId, $jobTitle, $jobDescription);
 }
 // [END jobs_v4beta1_generated_JobService_UpdateJob_sync]

--- a/tests/Integration/goldens/videointelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
+++ b/tests/Integration/goldens/videointelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
@@ -53,7 +53,7 @@ function annotate_video_sample(): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var AnnotateVideoResponse $response */
+            /** @var AnnotateVideoResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Unit/ProtoTests/BasicDiregapic/library_rest.proto
+++ b/tests/Unit/ProtoTests/BasicDiregapic/library_rest.proto
@@ -889,7 +889,12 @@ message BookResponse {
   // The resource name of the book.
   // BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
   // Message field comment may include special characters: <>&"`'@.
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {
+      type: "library.googleapis.com/Book"
+    }
+  ];
 
   // The name of the book author.
   string author = 2;

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/create_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/create_book.php
@@ -30,20 +30,21 @@ use Testing\BasicDiregapic\LibraryServiceClient;
 /**
  * Creates a book.
  *
- * @param string $formattedName The name of the shelf in which the book is created. Please see
- *                              {@see LibraryServiceClient::shelfName()} for help formatting this field.
- * @param string $bookName      The resource name of the book.
- *                              BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
- *                              Message field comment may include special characters: <>&"`'&#64;.
+ * @param string $formattedName     The name of the shelf in which the book is created. Please see
+ *                                  {@see LibraryServiceClient::shelfName()} for help formatting this field.
+ * @param string $formattedBookName The resource name of the book.
+ *                                  BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+ *                                  Message field comment may include special characters: <>&"`'&#64;. Please see
+ *                                  {@see LibraryServiceClient::bookName()} for help formatting this field.
  */
-function create_book_sample(string $formattedName, string $bookName): void
+function create_book_sample(string $formattedName, string $formattedBookName): void
 {
     // Create a client.
     $libraryServiceClient = new LibraryServiceClient();
 
     // Prepare any non-scalar elements to be passed along with the request.
     $book = (new BookResponse())
-        ->setName($bookName);
+        ->setName($formattedBookName);
 
     // Call the API and handle any network failures.
     try {
@@ -67,8 +68,8 @@ function create_book_sample(string $formattedName, string $bookName): void
 function callSample(): void
 {
     $formattedName = LibraryServiceClient::shelfName('[SHELF]');
-    $bookName = '[NAME]';
+    $formattedBookName = LibraryServiceClient::bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
 
-    create_book_sample($formattedName, $bookName);
+    create_book_sample($formattedName, $formattedBookName);
 }
 // [END example_generated_LibraryService_CreateBook_sync]

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/find_related_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/find_related_books.php
@@ -47,9 +47,8 @@ function find_related_books_sample(
         /** @var PagedListResponse $response */
         $response = $libraryServiceClient->findRelatedBooks($formattedNames, $formattedShelves);
 
-        /** @var string $element */
         foreach ($response as $element) {
-            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+            printf('Element data: %s' . PHP_EOL, $element);
         }
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/get_big_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/get_big_book.php
@@ -47,7 +47,7 @@ function get_big_book_sample(string $formattedName): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var BookResponse $response */
+            /** @var BookResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/list_aggregated_shelves.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/list_aggregated_shelves.php
@@ -26,7 +26,6 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 use Google\ApiCore\ApiException;
 use Google\ApiCore\PagedListResponse;
 use Testing\BasicDiregapic\LibraryServiceClient;
-use Testing\BasicDiregapic\ShelfResponse;
 
 /**
  * Lists shelves.
@@ -47,7 +46,6 @@ function list_aggregated_shelves_sample(): void
         /** @var PagedListResponse $response */
         $response = $libraryServiceClient->listAggregatedShelves();
 
-        /** @var ShelfResponse $element */
         foreach ($response as $element) {
             printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
         }

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/list_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/list_books.php
@@ -25,7 +25,6 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 // [START example_generated_LibraryService_ListBooks_sync]
 use Google\ApiCore\ApiException;
 use Google\ApiCore\PagedListResponse;
-use Testing\BasicDiregapic\BookResponse;
 use Testing\BasicDiregapic\LibraryServiceClient;
 
 /**
@@ -44,7 +43,6 @@ function list_books_sample(string $formattedName): void
         /** @var PagedListResponse $response */
         $response = $libraryServiceClient->listBooks($formattedName);
 
-        /** @var BookResponse $element */
         foreach ($response as $element) {
             printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
         }

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/list_strings.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/list_strings.php
@@ -46,9 +46,8 @@ function list_strings_sample(): void
         /** @var PagedListResponse $response */
         $response = $libraryServiceClient->listStrings();
 
-        /** @var string $element */
         foreach ($response as $element) {
-            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+            printf('Element data: %s' . PHP_EOL, $element);
         }
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/long_running_archive_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/long_running_archive_books.php
@@ -48,7 +48,7 @@ function long_running_archive_books_sample(): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var ArchiveBooksResponse $response */
+            /** @var ArchiveBooksResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/publish_series.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/publish_series.php
@@ -35,15 +35,19 @@ use Testing\BasicDiregapic\ShelfResponse;
  * Creates a series of books.
  * Tests PHP required nested fields.
  *
- * @param string $shelfName     The resource name of the shelf.
- *                              ShelfResponse names have the form `shelves/{shelf}`.
- * @param string $booksName     The resource name of the book.
- *                              BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
- *                              Message field comment may include special characters: <>&"`'&#64;.
- * @param int    $genresElement A set of enums containing genres the series falls into.
+ * @param string $shelfName          The resource name of the shelf.
+ *                                   ShelfResponse names have the form `shelves/{shelf}`.
+ * @param string $formattedBooksName The resource name of the book.
+ *                                   BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+ *                                   Message field comment may include special characters: <>&"`'&#64;. Please see
+ *                                   {@see LibraryServiceClient::bookName()} for help formatting this field.
+ * @param int    $genresElement      A set of enums containing genres the series falls into.
  */
-function publish_series_sample(string $shelfName, string $booksName, int $genresElement): void
-{
+function publish_series_sample(
+    string $shelfName,
+    string $formattedBooksName,
+    int $genresElement
+): void {
     // Create a client.
     $libraryServiceClient = new LibraryServiceClient();
 
@@ -51,7 +55,7 @@ function publish_series_sample(string $shelfName, string $booksName, int $genres
     $shelf = (new ShelfResponse())
         ->setName($shelfName);
     $bookResponse = (new BookResponse())
-        ->setName($booksName);
+        ->setName($formattedBooksName);
     $books = [$bookResponse,];
     $seriesUuid = new SeriesUuidResponse();
     $genres = [$genresElement,];
@@ -78,9 +82,9 @@ function publish_series_sample(string $shelfName, string $booksName, int $genres
 function callSample(): void
 {
     $shelfName = '[NAME]';
-    $booksName = '[NAME]';
+    $formattedBooksName = LibraryServiceClient::bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
     $genresElement = Genre::UNSET;
 
-    publish_series_sample($shelfName, $booksName, $genresElement);
+    publish_series_sample($shelfName, $formattedBooksName, $genresElement);
 }
 // [END example_generated_LibraryService_PublishSeries_sync]

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/save_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/save_book.php
@@ -31,18 +31,19 @@ use Testing\BasicDiregapic\LibraryServiceClient;
  * (CreateSubscription) for historical reasons. New APIs should always create
  * a separate message for a request.
  *
- * @param string $name The resource name of the book.
- *                     BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
- *                     Message field comment may include special characters: <>&"`'&#64;.
+ * @param string $formattedName The resource name of the book.
+ *                              BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+ *                              Message field comment may include special characters: <>&"`'&#64;. Please see
+ *                              {@see LibraryServiceClient::bookName()} for help formatting this field.
  */
-function save_book_sample(string $name): void
+function save_book_sample(string $formattedName): void
 {
     // Create a client.
     $libraryServiceClient = new LibraryServiceClient();
 
     // Call the API and handle any network failures.
     try {
-        $libraryServiceClient->saveBook($name);
+        $libraryServiceClient->saveBook($formattedName);
         printf('Call completed successfully.' . PHP_EOL);
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
@@ -60,8 +61,8 @@ function save_book_sample(string $name): void
  */
 function callSample(): void
 {
-    $name = '[NAME]';
+    $formattedName = LibraryServiceClient::bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
 
-    save_book_sample($name);
+    save_book_sample($formattedName);
 }
 // [END example_generated_LibraryService_SaveBook_sync]

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/update_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryServiceClient/update_book.php
@@ -30,20 +30,21 @@ use Testing\BasicDiregapic\LibraryServiceClient;
 /**
  * Updates a book.
  *
- * @param string $formattedName The name of the book to update. Please see
- *                              {@see LibraryServiceClient::bookName()} for help formatting this field.
- * @param string $bookName      The resource name of the book.
- *                              BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
- *                              Message field comment may include special characters: <>&"`'&#64;.
+ * @param string $formattedName     The name of the book to update. Please see
+ *                                  {@see LibraryServiceClient::bookName()} for help formatting this field.
+ * @param string $formattedBookName The resource name of the book.
+ *                                  BookResponse names have the form `bookShelves/{shelf_id}/books/{book_id}`.
+ *                                  Message field comment may include special characters: <>&"`'&#64;. Please see
+ *                                  {@see LibraryServiceClient::bookName()} for help formatting this field.
  */
-function update_book_sample(string $formattedName, string $bookName): void
+function update_book_sample(string $formattedName, string $formattedBookName): void
 {
     // Create a client.
     $libraryServiceClient = new LibraryServiceClient();
 
     // Prepare any non-scalar elements to be passed along with the request.
     $book = (new BookResponse())
-        ->setName($bookName);
+        ->setName($formattedBookName);
 
     // Call the API and handle any network failures.
     try {
@@ -67,8 +68,8 @@ function update_book_sample(string $formattedName, string $bookName): void
 function callSample(): void
 {
     $formattedName = LibraryServiceClient::bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
-    $bookName = '[NAME]';
+    $formattedBookName = LibraryServiceClient::bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
 
-    update_book_sample($formattedName, $bookName);
+    update_book_sample($formattedName, $formattedBookName);
 }
 // [END example_generated_LibraryService_UpdateBook_sync]

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryServiceGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryServiceGapicClient.php
@@ -2175,8 +2175,8 @@ class LibraryServiceGapicClient
      * ```
      * $libraryServiceClient = new LibraryServiceClient();
      * try {
-     *     $name = 'name';
-     *     $libraryServiceClient->saveBook($name);
+     *     $formattedName = $libraryServiceClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
+     *     $libraryServiceClient->saveBook($formattedName);
      * } finally {
      *     $libraryServiceClient->close();
      * }

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/LibraryServiceClientTest.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/LibraryServiceClientTest.php
@@ -279,7 +279,7 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->shelfName('[SHELF]');
         $book = new BookResponse();
-        $bookName = 'bookName2004454676';
+        $bookName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book->setName($bookName);
         $response = $gapicClient->createBook($formattedName, $book);
         $this->assertEquals($expectedResponse, $response);
@@ -316,7 +316,7 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->shelfName('[SHELF]');
         $book = new BookResponse();
-        $bookName = 'bookName2004454676';
+        $bookName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book->setName($bookName);
         try {
             $gapicClient->createBook($formattedName, $book);
@@ -1960,15 +1960,15 @@ class LibraryServiceClientTest extends GeneratedTest
         $expectedResponse = new GPBEmpty();
         $transport->addResponse($expectedResponse);
         // Mock request
-        $name = 'name3373707';
-        $gapicClient->saveBook($name);
+        $formattedName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
+        $gapicClient->saveBook($formattedName);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
         $this->assertSame('/google.example.library.v1.LibraryService/SaveBook', $actualFuncCall);
         $actualValue = $actualRequestObject->getName();
-        $this->assertProtobufEquals($name, $actualValue);
+        $this->assertProtobufEquals($formattedName, $actualValue);
         $this->assertTrue($transport->isExhausted());
     }
 
@@ -1991,9 +1991,9 @@ class LibraryServiceClientTest extends GeneratedTest
         ], JSON_PRETTY_PRINT);
         $transport->addResponse(null, $status);
         // Mock request
-        $name = 'name3373707';
+        $formattedName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         try {
-            $gapicClient->saveBook($name);
+            $gapicClient->saveBook($formattedName);
             // If the $gapicClient method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {
@@ -2029,7 +2029,7 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book = new BookResponse();
-        $bookName = 'bookName2004454676';
+        $bookName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book->setName($bookName);
         $response = $gapicClient->updateBook($formattedName, $book);
         $this->assertEquals($expectedResponse, $response);
@@ -2066,7 +2066,7 @@ class LibraryServiceClientTest extends GeneratedTest
         // Mock request
         $formattedName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book = new BookResponse();
-        $bookName = 'bookName2004454676';
+        $bookName = $gapicClient->bookName('[SHELF]', '[BOOK_ONE]', '[BOOK_TWO]');
         $book->setName($bookName);
         try {
             $gapicClient->updateBook($formattedName, $book);

--- a/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method1.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method1.php
@@ -52,7 +52,7 @@ function method1_sample(): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var LroResponse $response */
+            /** @var LroResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {

--- a/tests/Unit/ProtoTests/BasicPaginated/out/samples/BasicPaginatedClient/method_paginated.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/samples/BasicPaginatedClient/method_paginated.php
@@ -50,7 +50,7 @@ function method_paginated_sample(string $aField, string $pageToken): void
 
         /** @var string $element */
         foreach ($response as $element) {
-            printf('Element data: %s' . PHP_EOL, $element->serializeToJsonString());
+            printf('Element data: %s' . PHP_EOL, $element);
         }
     } catch (ApiException $ex) {
         printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_b_lro.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_b_lro.php
@@ -48,7 +48,7 @@ function method1_b_lro_sample(): void
         $response->pollUntilComplete();
 
         if ($response->operationSucceeded()) {
-            /** @var LroResponse $response */
+            /** @var LroResponse $result */
             $result = $response->getResult();
             printf('Operation successful with response data: %s' . PHP_EOL, $result->serializeToJsonString());
         } else {


### PR DESCRIPTION
While going through the influx of new PRs generated by snippet gen I discovered a handful of issues which this PR addresses.

Each commit address a separate issue, if preferred I can open multiple PRs - but I thought it would be nice to have the test updates all in one place.

Here are the learnings/fixes:

1. Format methods aren't only applied at the base request level, they can be found in nested messages as well. Adjusted for this.
2. Updated inline var block on `getResults`calls in LRO samples to annotate the correct item.
3. Prevent calling `serializeToJsonString` on primitives.

I also temporarily disabled the inline var block for paginated samples on REST only clients. When the resource type is a map the `MethodDetails`class is having trouble determining the correct type to display. Seems like a wider issue that I plan to address separately.