### PR TITLE
chore: revert startApiCall in gapic generator

### DIFF
--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -494,6 +494,12 @@ abstract class MethodDetails
     /** @var ?string *Readonly* REST method, if specified in a 'google.api.http' proto option. */
     public ?string $restMethod;
 
+    /** @var ?Map *Readonly* Map of string to Vector of strings; placeholder name -> list of property getters. */
+    public ?Map $restRoutingHeaders;
+
+    /** @var Map *Readonly* Vector of RoutingParameters; parsed from the google.api.routing annotation. */
+    public ?Map $routingParameters = null;
+
     public ?array $headerParams;
 
     /** @var bool *Readonly* Whether the service is deprecated. */
@@ -523,10 +529,17 @@ abstract class MethodDetails
         $this->docLines = $desc->leadingComments;
         $this->httpRule = ProtoHelpers::getCustomOption($desc, CustomOptions::GOOGLE_API_HTTP, HttpRule::class);
         $this->restMethod = is_null($this->httpRule) ? null : $this->httpRule->getPattern();
+        // DO NOT SORT - currently in reverse order of the first-seen variables.
+        $this->restRoutingHeaders = is_null($this->httpRule) ? null : ProtoHelpers::restPlaceholders($this->catalog, $this->httpRule, $this->inputMsg);
         $this->headerParams = ProtoHelpers::headerParams($this->catalog, $desc);
 
         if ($desc->hasOptions() && $desc->getOptions()->hasDeprecated()) {
             $this->isDeprecated = $desc->getOptions()->getDeprecated();
+        }
+
+        $routingRule = ProtoHelpers::routingRule($desc);
+        if (!is_null($routingRule)) {
+            $this->routingParameters = ProtoHelpers::routingParameters($this->catalog, $this->inputMsg, $routingRule);
         }
     }
 

--- a/tests/Unit/ProtoTests/Basic/out/src/Gapic/BasicGapicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Gapic/BasicGapicClient.php
@@ -36,6 +36,7 @@ use Testing\Basic\PartOfRequestB;
 use Testing\Basic\PartOfRequestC;
 use Testing\Basic\Request;
 use Testing\Basic\RequestWithArgs;
+use Testing\Basic\Response;
 
 /**
  * Service Description: This is a basic service.
@@ -182,7 +183,7 @@ class BasicGapicClient
     public function aMethod(array $optionalArgs = [])
     {
         $request = new Request();
-        return $this->startApiCall('AMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('AMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -237,6 +238,6 @@ class BasicGapicClient
             $request->setPartOfRequestC($optionalArgs['partOfRequestC']);
         }
 
-        return $this->startApiCall('MethodWithArgs', $request, $optionalArgs)->wait();
+        return $this->startCall('MethodWithArgs', Response::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Gapic/BasicBidiStreamingGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Gapic/BasicBidiStreamingGapicClient.php
@@ -25,6 +25,7 @@
 namespace Testing\BasicBidiStreaming\Gapic;
 
 use Google\ApiCore\ApiException;
+use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\Transport\TransportInterface;
@@ -32,6 +33,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\BasicBidiStreaming\EmptyRequest;
 use Testing\BasicBidiStreaming\Request;
+use Testing\BasicBidiStreaming\Response;
 
 /**
  * Service Description:
@@ -235,7 +237,7 @@ class BasicBidiStreamingGapicClient
      */
     public function methodBidi(array $optionalArgs = [])
     {
-        return $this->startApiCall('MethodBidi', null, $optionalArgs);
+        return $this->startCall('MethodBidi', Response::class, $optionalArgs, null, Call::BIDI_STREAMING_CALL);
     }
 
     /**
@@ -293,6 +295,6 @@ class BasicBidiStreamingGapicClient
      */
     public function methodEmpty(array $optionalArgs = [])
     {
-        return $this->startApiCall('MethodEmpty', null, $optionalArgs);
+        return $this->startCall('MethodEmpty', Response::class, $optionalArgs, null, Call::BIDI_STREAMING_CALL);
     }
 }

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Gapic/BasicClientStreamingGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Gapic/BasicClientStreamingGapicClient.php
@@ -25,6 +25,7 @@
 namespace Testing\BasicClientStreaming\Gapic;
 
 use Google\ApiCore\ApiException;
+use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\Transport\TransportInterface;
@@ -32,6 +33,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\BasicClientStreaming\EmptyRequest;
 use Testing\BasicClientStreaming\Request;
+use Testing\BasicClientStreaming\Response;
 
 /**
  * Service Description:
@@ -211,7 +213,7 @@ class BasicClientStreamingGapicClient
      */
     public function methodClient(array $optionalArgs = [])
     {
-        return $this->startApiCall('MethodClient', null, $optionalArgs);
+        return $this->startCall('MethodClient', Response::class, $optionalArgs, null, Call::CLIENT_STREAMING_CALL);
     }
 
     /**
@@ -257,6 +259,6 @@ class BasicClientStreamingGapicClient
      */
     public function methodEmpty(array $optionalArgs = [])
     {
-        return $this->startApiCall('MethodEmpty', null, $optionalArgs);
+        return $this->startCall('MethodEmpty', Response::class, $optionalArgs, null, Call::CLIENT_STREAMING_CALL);
     }
 }

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryServiceGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryServiceGapicClient.php
@@ -30,6 +30,7 @@ use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\OperationResponse;
 use Google\ApiCore\PathTemplate;
+use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
@@ -42,6 +43,7 @@ use Google\Protobuf\DoubleValue;
 use Google\Protobuf\Duration;
 use Google\Protobuf\FieldMask;
 use Google\Protobuf\FloatValue;
+use Google\Protobuf\GPBEmpty;
 use Google\Protobuf\Int32Value;
 use Google\Protobuf\Int64Value;
 use Google\Protobuf\ListValue;
@@ -53,7 +55,11 @@ use Google\Protobuf\UInt64Value;
 use Google\Protobuf\Value;
 use Testing\BasicDiregapic\AddCommentsRequest;
 use Testing\BasicDiregapic\AddTagRequest;
+use Testing\BasicDiregapic\AddTagResponse;
 use Testing\BasicDiregapic\ArchiveBooksRequest;
+use Testing\BasicDiregapic\ArchiveBooksResponse;
+use Testing\BasicDiregapic\BookFromAnywhereResponse;
+use Testing\BasicDiregapic\BookFromArchiveResponse;
 use Testing\BasicDiregapic\BookResponse;
 use Testing\BasicDiregapic\Comment;
 use Testing\BasicDiregapic\CreateBookRequest;
@@ -62,6 +68,7 @@ use Testing\BasicDiregapic\CreateShelfRequest;
 use Testing\BasicDiregapic\DeleteBookRequest;
 use Testing\BasicDiregapic\DeleteShelfRequest;
 use Testing\BasicDiregapic\FindRelatedBooksRequest;
+use Testing\BasicDiregapic\FindRelatedBooksResponse;
 use Testing\BasicDiregapic\GetBookFromAbsolutelyAnywhereRequest;
 use Testing\BasicDiregapic\GetBookFromAnywhereRequest;
 use Testing\BasicDiregapic\GetBookFromArchiveRequest;
@@ -69,13 +76,19 @@ use Testing\BasicDiregapic\GetBookRequest;
 use Testing\BasicDiregapic\GetShelfRequest;
 use Testing\BasicDiregapic\InventoryResponse;
 use Testing\BasicDiregapic\ListAggregatedShelvesRequest;
+use Testing\BasicDiregapic\ListAggregatedShelvesResponse;
 use Testing\BasicDiregapic\ListBooksRequest;
+use Testing\BasicDiregapic\ListBooksResponse;
 use Testing\BasicDiregapic\ListShelvesRequest;
+use Testing\BasicDiregapic\ListShelvesResponse;
 use Testing\BasicDiregapic\ListStringsRequest;
+use Testing\BasicDiregapic\ListStringsResponse;
 use Testing\BasicDiregapic\MergeShelvesRequest;
 use Testing\BasicDiregapic\MoveBookRequest;
 use Testing\BasicDiregapic\MoveBooksRequest;
+use Testing\BasicDiregapic\MoveBooksResponse;
 use Testing\BasicDiregapic\PublishSeriesRequest;
+use Testing\BasicDiregapic\PublishSeriesResponse;
 use Testing\BasicDiregapic\SeriesUuidResponse;
 use Testing\BasicDiregapic\ShelfResponse;
 use Testing\BasicDiregapic\SomeMessage;
@@ -865,9 +878,13 @@ class LibraryServiceGapicClient
     public function addComments($name, $comments, array $optionalArgs = [])
     {
         $request = new AddCommentsRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setComments($comments);
-        return $this->startApiCall('AddComments', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('AddComments', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -904,9 +921,13 @@ class LibraryServiceGapicClient
     public function addTag($resource, $tag, array $optionalArgs = [])
     {
         $request = new AddTagRequest();
+        $requestParamHeaders = [];
         $request->setResource($resource);
         $request->setTag($tag);
-        return $this->startApiCall('AddTag', $request, $optionalArgs)->wait();
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('AddTag', AddTagResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -939,15 +960,19 @@ class LibraryServiceGapicClient
     public function archiveBooks(array $optionalArgs = [])
     {
         $request = new ArchiveBooksRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['source'])) {
             $request->setSource($optionalArgs['source']);
+            $requestParamHeaders['source'] = $optionalArgs['source'];
         }
 
         if (isset($optionalArgs['archive'])) {
             $request->setArchive($optionalArgs['archive']);
         }
 
-        return $this->startApiCall('ArchiveBooks', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('ArchiveBooks', ArchiveBooksResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -983,9 +1008,13 @@ class LibraryServiceGapicClient
     public function createBook($name, $book, array $optionalArgs = [])
     {
         $request = new CreateBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setBook($book);
-        return $this->startApiCall('CreateBook', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('CreateBook', BookResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1026,15 +1055,19 @@ class LibraryServiceGapicClient
     public function createInventory($parent, $asset, $parentAsset, $assets, array $optionalArgs = [])
     {
         $request = new CreateInventoryRequest();
+        $requestParamHeaders = [];
         $request->setParent($parent);
         $request->setAsset($asset);
         $request->setParentAsset($parentAsset);
         $request->setAssets($assets);
+        $requestParamHeaders['parent'] = $parent;
         if (isset($optionalArgs['inventory'])) {
             $request->setInventory($optionalArgs['inventory']);
         }
 
-        return $this->startApiCall('CreateInventory', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('CreateInventory', InventoryResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1070,7 +1103,7 @@ class LibraryServiceGapicClient
     {
         $request = new CreateShelfRequest();
         $request->setShelf($shelf);
-        return $this->startApiCall('CreateShelf', $request, $optionalArgs)->wait();
+        return $this->startCall('CreateShelf', ShelfResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1102,8 +1135,12 @@ class LibraryServiceGapicClient
     public function deleteBook($name, array $optionalArgs = [])
     {
         $request = new DeleteBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        return $this->startApiCall('DeleteBook', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('DeleteBook', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1135,8 +1172,12 @@ class LibraryServiceGapicClient
     public function deleteShelf($name, array $optionalArgs = [])
     {
         $request = new DeleteShelfRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        return $this->startApiCall('DeleteShelf', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('DeleteShelf', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1206,7 +1247,7 @@ class LibraryServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        return $this->startApiCall('FindRelatedBooks', $request, $optionalArgs);
+        return $this->getPagedListResponse('FindRelatedBooks', $optionalArgs, FindRelatedBooksResponse::class, $request);
     }
 
     /**
@@ -1265,8 +1306,12 @@ class LibraryServiceGapicClient
     public function getBigBook($name, array $optionalArgs = [])
     {
         $request = new GetBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        return $this->startApiCall('GetBigBook', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startOperationsCall('GetBigBook', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
 
     /**
@@ -1323,8 +1368,12 @@ class LibraryServiceGapicClient
     public function getBigNothing($name, array $optionalArgs = [])
     {
         $request = new GetBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        return $this->startApiCall('GetBigNothing', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startOperationsCall('GetBigNothing', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
 
     /**
@@ -1358,8 +1407,12 @@ class LibraryServiceGapicClient
     public function getBook($name, array $optionalArgs = [])
     {
         $request = new GetBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
-        return $this->startApiCall('GetBook', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetBook', BookResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1396,12 +1449,17 @@ class LibraryServiceGapicClient
     public function getBookFromAbsolutelyAnywhere($name, array $optionalArgs = [])
     {
         $request = new GetBookFromAbsolutelyAnywhereRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['altBookName'])) {
             $request->setAltBookName($optionalArgs['altBookName']);
+            $requestParamHeaders['alt_book_name'] = $optionalArgs['altBookName'];
         }
 
-        return $this->startApiCall('GetBookFromAbsolutelyAnywhere', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetBookFromAbsolutelyAnywhere', BookFromAnywhereResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1442,11 +1500,15 @@ class LibraryServiceGapicClient
     public function getBookFromAnywhere($name, $altBookName, $place, $folder, array $optionalArgs = [])
     {
         $request = new GetBookFromAnywhereRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setAltBookName($altBookName);
         $request->setPlace($place);
         $request->setFolder($folder);
-        return $this->startApiCall('GetBookFromAnywhere', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetBookFromAnywhere', BookFromAnywhereResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1482,9 +1544,13 @@ class LibraryServiceGapicClient
     public function getBookFromArchive($name, $parent, array $optionalArgs = [])
     {
         $request = new GetBookFromArchiveRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setParent($parent);
-        return $this->startApiCall('GetBookFromArchive', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetBookFromArchive', BookFromArchiveResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1523,8 +1589,10 @@ class LibraryServiceGapicClient
     public function getShelf($name, $options, array $optionalArgs = [])
     {
         $request = new GetShelfRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setOptions($options);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['message'])) {
             $request->setMessage($optionalArgs['message']);
         }
@@ -1533,7 +1601,9 @@ class LibraryServiceGapicClient
             $request->setStringBuilder($optionalArgs['stringBuilder']);
         }
 
-        return $this->startApiCall('GetShelf', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetShelf', ShelfResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1592,7 +1662,7 @@ class LibraryServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        return $this->startApiCall('ListAggregatedShelves', $request, $optionalArgs);
+        return $this->getPagedListResponse('ListAggregatedShelves', $optionalArgs, ListAggregatedShelvesResponse::class, $request);
     }
 
     /**
@@ -1649,7 +1719,9 @@ class LibraryServiceGapicClient
     public function listBooks($name, array $optionalArgs = [])
     {
         $request = new ListBooksRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
@@ -1662,7 +1734,9 @@ class LibraryServiceGapicClient
             $request->setFilter($optionalArgs['filter']);
         }
 
-        return $this->startApiCall('ListBooks', $request, $optionalArgs);
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->getPagedListResponse('ListBooks', $optionalArgs, ListBooksResponse::class, $request);
     }
 
     /**
@@ -1703,7 +1777,7 @@ class LibraryServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        return $this->startApiCall('ListShelves', $request, $optionalArgs)->wait();
+        return $this->startCall('ListShelves', ListShelvesResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1769,7 +1843,7 @@ class LibraryServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        return $this->startApiCall('ListStrings', $request, $optionalArgs);
+        return $this->getPagedListResponse('ListStrings', $optionalArgs, ListStringsResponse::class, $request);
     }
 
     /**
@@ -1827,15 +1901,19 @@ class LibraryServiceGapicClient
     public function longRunningArchiveBooks(array $optionalArgs = [])
     {
         $request = new ArchiveBooksRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['source'])) {
             $request->setSource($optionalArgs['source']);
+            $requestParamHeaders['source'] = $optionalArgs['source'];
         }
 
         if (isset($optionalArgs['archive'])) {
             $request->setArchive($optionalArgs['archive']);
         }
 
-        return $this->startApiCall('LongRunningArchiveBooks', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startOperationsCall('LongRunningArchiveBooks', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
 
     /**
@@ -1873,9 +1951,13 @@ class LibraryServiceGapicClient
     public function mergeShelves($name, $otherShelfName, array $optionalArgs = [])
     {
         $request = new MergeShelvesRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setOtherShelfName($otherShelfName);
-        return $this->startApiCall('MergeShelves', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('MergeShelves', ShelfResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1911,9 +1993,13 @@ class LibraryServiceGapicClient
     public function moveBook($name, $otherShelfName, array $optionalArgs = [])
     {
         $request = new MoveBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setOtherShelfName($otherShelfName);
-        return $this->startApiCall('MoveBook', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('MoveBook', BookResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -1948,8 +2034,10 @@ class LibraryServiceGapicClient
     public function moveBooks(array $optionalArgs = [])
     {
         $request = new MoveBooksRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['source'])) {
             $request->setSource($optionalArgs['source']);
+            $requestParamHeaders['source'] = $optionalArgs['source'];
         }
 
         if (isset($optionalArgs['destination'])) {
@@ -1964,7 +2052,9 @@ class LibraryServiceGapicClient
             $request->setProject($optionalArgs['project']);
         }
 
-        return $this->startApiCall('MoveBooks', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('MoveBooks', MoveBooksResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -2005,7 +2095,7 @@ class LibraryServiceGapicClient
             $request->setPageToken($optionalArgs['pageToken']);
         }
 
-        return $this->startApiCall('PrivateListShelves', $request, $optionalArgs)->wait();
+        return $this->startCall('PrivateListShelves', BookResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -2053,10 +2143,12 @@ class LibraryServiceGapicClient
     public function publishSeries($shelf, $books, $seriesUuid, $genres, array $optionalArgs = [])
     {
         $request = new PublishSeriesRequest();
+        $requestParamHeaders = [];
         $request->setShelf($shelf);
         $request->setBooks($books);
         $request->setSeriesUuid($seriesUuid);
         $request->setGenres($genres);
+        $requestParamHeaders['shelf.name'] = $shelf->getName();
         if (isset($optionalArgs['edition'])) {
             $request->setEdition($optionalArgs['edition']);
         }
@@ -2069,7 +2161,9 @@ class LibraryServiceGapicClient
             $request->setPublisher($optionalArgs['publisher']);
         }
 
-        return $this->startApiCall('PublishSeries', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('PublishSeries', PublishSeriesResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -2255,7 +2349,7 @@ class LibraryServiceGapicClient
             $request->setMapBoolKey($optionalArgs['mapBoolKey']);
         }
 
-        return $this->startApiCall('SaveBook', $request, $optionalArgs)->wait();
+        return $this->startCall('SaveBook', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -2295,8 +2389,10 @@ class LibraryServiceGapicClient
     public function updateBook($name, $book, array $optionalArgs = [])
     {
         $request = new UpdateBookRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setBook($book);
+        $requestParamHeaders['name'] = $name;
         if (isset($optionalArgs['optionalFoo'])) {
             $request->setOptionalFoo($optionalArgs['optionalFoo']);
         }
@@ -2305,7 +2401,9 @@ class LibraryServiceGapicClient
             $request->setUpdateMask($optionalArgs['updateMask']);
         }
 
-        return $this->startApiCall('UpdateBook', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('UpdateBook', BookResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -2341,9 +2439,13 @@ class LibraryServiceGapicClient
     public function updateBookIndex($name, $indexName, $indexMap, array $optionalArgs = [])
     {
         $request = new UpdateBookIndexRequest();
+        $requestParamHeaders = [];
         $request->setName($name);
         $request->setIndexName($indexName);
         $request->setIndexMap($indexMap);
-        return $this->startApiCall('UpdateBookIndex', $request, $optionalArgs)->wait();
+        $requestParamHeaders['name'] = $name;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('UpdateBookIndex', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Gapic/BasicLroGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Gapic/BasicLroGapicClient.php
@@ -265,7 +265,7 @@ class BasicLroGapicClient
     public function method1(array $optionalArgs = [])
     {
         $request = new Request();
-        return $this->startApiCall('Method1', $request, $optionalArgs)->wait();
+        return $this->startOperationsCall('Method1', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
 
     /**
@@ -296,7 +296,7 @@ class BasicLroGapicClient
     public function methodNonLro1(array $optionalArgs = [])
     {
         $request = new Request();
-        return $this->startApiCall('MethodNonLro1', $request, $optionalArgs)->wait();
+        return $this->startCall('MethodNonLro1', Request::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -327,6 +327,6 @@ class BasicLroGapicClient
     public function methodNonLro2(array $optionalArgs = [])
     {
         $request = new Request();
-        return $this->startApiCall('MethodNonLro2', $request, $optionalArgs)->wait();
+        return $this->startCall('MethodNonLro2', Request::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
@@ -34,6 +34,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Testing\BasicOneof\Request;
 use Testing\BasicOneof\Request\Other;
 use Testing\BasicOneof\Request\SupplementaryDataOneof;
+use Testing\BasicOneof\Response;
 
 /**
  * Service Description: This is a basic service.
@@ -228,6 +229,6 @@ class BasicOneofGapicClient
             $request->setOptionalCount($optionalArgs['optionalCount']);
         }
 
-        return $this->startApiCall('AMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('AMethod', Response::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Gapic/BasicPaginatedGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Gapic/BasicPaginatedGapicClient.php
@@ -35,6 +35,7 @@ use Testing\BasicPaginated\PartOfRequestA;
 use Testing\BasicPaginated\PartOfRequestB;
 use Testing\BasicPaginated\PartOfRequestC;
 use Testing\BasicPaginated\Request;
+use Testing\BasicPaginated\Response;
 
 /**
  * Service Description:
@@ -237,6 +238,6 @@ class BasicPaginatedGapicClient
             $request->setPartOfRequestC($optionalArgs['partOfRequestC']);
         }
 
-        return $this->startApiCall('MethodPaginated', $request, $optionalArgs);
+        return $this->getPagedListResponse('MethodPaginated', $optionalArgs, Response::class, $request);
     }
 }

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Gapic/BasicServerStreamingGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Gapic/BasicServerStreamingGapicClient.php
@@ -25,6 +25,7 @@
 namespace Testing\BasicServerStreaming\Gapic;
 
 use Google\ApiCore\ApiException;
+use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\Transport\TransportInterface;
@@ -32,6 +33,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\BasicServerStreaming\EmptyRequest;
 use Testing\BasicServerStreaming\Request;
+use Testing\BasicServerStreaming\Response;
 
 /**
  * Service Description:
@@ -180,7 +182,7 @@ class BasicServerStreamingGapicClient
     public function methodEmpty(array $optionalArgs = [])
     {
         $request = new EmptyRequest();
-        return $this->startApiCall('MethodEmpty', $request, $optionalArgs);
+        return $this->startCall('MethodEmpty', Response::class, $optionalArgs, $request, Call::SERVER_STREAMING_CALL);
     }
 
     /**
@@ -221,6 +223,6 @@ class BasicServerStreamingGapicClient
             $request->setAString($optionalArgs['aString']);
         }
 
-        return $this->startApiCall('MethodServer', $request, $optionalArgs);
+        return $this->startCall('MethodServer', Response::class, $optionalArgs, $request, Call::SERVER_STREAMING_CALL);
     }
 }

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
@@ -34,6 +34,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\CustomLro\CreateFooRequest;
 use Testing\CustomLro\CustomLroOperationsClient;
+use Testing\CustomLro\CustomOperationResponse;
 
 /**
  * Service Description:
@@ -302,6 +303,6 @@ class CustomLroGapicClient
             $request->setFoo($optionalArgs['foo']);
         }
 
-        return $this->startApiCall('CreateFoo', $request, $optionalArgs)->wait();
+        return $this->startOperationsCall('CreateFoo', $optionalArgs, $request, $this->getOperationsClient(), null, CustomOperationResponse::class)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
@@ -31,7 +31,9 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\GPBEmpty;
 use Testing\CustomLro\CancelOperationRequest;
+use Testing\CustomLro\CustomOperationResponse;
 use Testing\CustomLro\DeleteOperationRequest;
 use Testing\CustomLro\GetOperationRequest;
 
@@ -192,7 +194,7 @@ class CustomLroOperationsGapicClient
     {
         $request = new CancelOperationRequest();
         $request->setOperation($operation);
-        return $this->startApiCall('Cancel', $request, $optionalArgs)->wait();
+        return $this->startCall('Cancel', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -224,7 +226,7 @@ class CustomLroOperationsGapicClient
     {
         $request = new DeleteOperationRequest();
         $request->setOperation($operation);
-        return $this->startApiCall('Delete', $request, $optionalArgs)->wait();
+        return $this->startCall('Delete', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -267,6 +269,6 @@ class CustomLroOperationsGapicClient
         $request->setProject($project);
         $request->setRegion($region);
         $request->setFoo($foo);
-        return $this->startApiCall('Get', $request, $optionalArgs)->wait();
+        return $this->startCall('Get', CustomOperationResponse::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Gapic/DeprecatedServiceGapicClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Gapic/DeprecatedServiceGapicClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\GPBEmpty;
 use Testing\Deprecated\FibonacciRequest;
 
 /**
@@ -184,7 +185,7 @@ class DeprecatedServiceGapicClient
             $request->setValue($optionalArgs['value']);
         }
 
-        return $this->startApiCall('FastFibonacci', $request, $optionalArgs)->wait();
+        return $this->startCall('FastFibonacci', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -222,6 +223,6 @@ class DeprecatedServiceGapicClient
             $request->setValue($optionalArgs['value']);
         }
 
-        return $this->startApiCall('SlowFibonacci', $request, $optionalArgs)->wait();
+        return $this->startCall('SlowFibonacci', GPBEmpty::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Gapic/DisableSnippetsGapicClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Gapic/DisableSnippetsGapicClient.php
@@ -32,6 +32,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Testing\DisableSnippets\Request;
+use Testing\DisableSnippets\Response;
 
 /**
  * Service Description:
@@ -178,6 +179,6 @@ class DisableSnippetsGapicClient
     {
         $request = new Request();
         $request->setTestField($testField);
-        return $this->startApiCall('Method1', $request, $optionalArgs)->wait();
+        return $this->startCall('Method1', Response::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Gapic/GrpcServiceConfigWithRetry1GapicClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Gapic/GrpcServiceConfigWithRetry1GapicClient.php
@@ -25,6 +25,7 @@
 namespace Testing\GrpcServiceConfig\Gapic;
 
 use Google\ApiCore\ApiException;
+use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -35,6 +36,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\LongRunning\Operation;
 use Testing\GrpcServiceConfig\Request1;
+use Testing\GrpcServiceConfig\Response1;
 
 /**
  * Service Description:
@@ -209,7 +211,7 @@ class GrpcServiceConfigWithRetry1GapicClient
     public function method1A(array $optionalArgs = [])
     {
         $request = new Request1();
-        return $this->startApiCall('Method1A', $request, $optionalArgs)->wait();
+        return $this->startCall('Method1A', Response1::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -265,7 +267,7 @@ class GrpcServiceConfigWithRetry1GapicClient
     public function method1BLro(array $optionalArgs = [])
     {
         $request = new Request1();
-        return $this->startApiCall('Method1BLro', $request, $optionalArgs)->wait();
+        return $this->startOperationsCall('Method1BLro', $optionalArgs, $request, $this->getOperationsClient())->wait();
     }
 
     /**
@@ -323,7 +325,7 @@ class GrpcServiceConfigWithRetry1GapicClient
      */
     public function method1BidiStreaming(array $optionalArgs = [])
     {
-        return $this->startApiCall('Method1BidiStreaming', null, $optionalArgs);
+        return $this->startCall('Method1BidiStreaming', Response1::class, $optionalArgs, null, Call::BIDI_STREAMING_CALL);
     }
 
     /**
@@ -354,7 +356,7 @@ class GrpcServiceConfigWithRetry1GapicClient
     public function method1CServiceLevelRetry(array $optionalArgs = [])
     {
         $request = new Request1();
-        return $this->startApiCall('Method1CServiceLevelRetry', $request, $optionalArgs)->wait();
+        return $this->startCall('Method1CServiceLevelRetry', Response1::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -385,7 +387,7 @@ class GrpcServiceConfigWithRetry1GapicClient
     public function method1DTimeoutOnlyRetry(array $optionalArgs = [])
     {
         $request = new Request1();
-        return $this->startApiCall('Method1DTimeoutOnlyRetry', $request, $optionalArgs)->wait();
+        return $this->startCall('Method1DTimeoutOnlyRetry', Response1::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -418,6 +420,6 @@ class GrpcServiceConfigWithRetry1GapicClient
     public function method1ServerStreaming(array $optionalArgs = [])
     {
         $request = new Request1();
-        return $this->startApiCall('Method1ServerStreaming', $request, $optionalArgs);
+        return $this->startCall('Method1ServerStreaming', Response1::class, $optionalArgs, $request, Call::SERVER_STREAMING_CALL);
     }
 }

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Gapic/ResourceNamesGapicClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Gapic/ResourceNamesGapicClient.php
@@ -35,6 +35,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Testing\ResourceNames\FileLevelChildTypeRefRequest;
 use Testing\ResourceNames\FileLevelTypeRefRequest;
 use Testing\ResourceNames\MultiPatternRequest;
+use Testing\ResourceNames\PlaceholderResponse;
 use Testing\ResourceNames\SinglePatternRequest;
 use Testing\ResourceNames\WildcardChildReferenceRequest;
 use Testing\ResourceNames\WildcardMultiPatternRequest;
@@ -712,7 +713,7 @@ class ResourceNamesGapicClient
             $request->setFolderMultiWildcardName($optionalArgs['folderMultiWildcardName']);
         }
 
-        return $this->startApiCall('FileLevelChildTypeRefMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('FileLevelChildTypeRefMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -748,7 +749,7 @@ class ResourceNamesGapicClient
             $request->setFileName($optionalArgs['fileName']);
         }
 
-        return $this->startApiCall('FileLevelTypeRefMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('FileLevelTypeRefMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -784,7 +785,7 @@ class ResourceNamesGapicClient
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('MultiPatternMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('MultiPatternMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -821,7 +822,7 @@ class ResourceNamesGapicClient
             $request->setRealName($optionalArgs['realName']);
         }
 
-        return $this->startApiCall('SinglePatternMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('SinglePatternMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -857,7 +858,7 @@ class ResourceNamesGapicClient
             $request->setParent($optionalArgs['parent']);
         }
 
-        return $this->startApiCall('WildcardChildReferenceMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('WildcardChildReferenceMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -893,7 +894,7 @@ class ResourceNamesGapicClient
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('WildcardMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('WildcardMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -929,7 +930,7 @@ class ResourceNamesGapicClient
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('WildcardMultiMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('WildcardMultiMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -965,6 +966,6 @@ class ResourceNamesGapicClient
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('WildcardReferenceMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('WildcardReferenceMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 }

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Gapic/RoutingHeadersGapicClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Gapic/RoutingHeadersGapicClient.php
@@ -27,6 +27,7 @@ namespace Testing\RoutingHeaders\Gapic;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\GapicClientTrait;
+use Google\ApiCore\RequestParamsHeaderDescriptor;
 use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
@@ -34,6 +35,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Testing\RoutingHeaders\NestedRequest;
 use Testing\RoutingHeaders\NestedRequest\Inner1;
 use Testing\RoutingHeaders\OrderRequest;
+use Testing\RoutingHeaders\Response;
 use Testing\RoutingHeaders\SimpleRequest;
 
 /**
@@ -178,11 +180,15 @@ class RoutingHeadersGapicClient
     public function deleteMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('DeleteMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('DeleteMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -214,11 +220,15 @@ class RoutingHeadersGapicClient
     public function getMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('GetMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -254,7 +264,7 @@ class RoutingHeadersGapicClient
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('GetNoPlaceholdersMethod', $request, $optionalArgs)->wait();
+        return $this->startCall('GetNoPlaceholdersMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -286,11 +296,15 @@ class RoutingHeadersGapicClient
     public function getNoTemplateMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('GetNoTemplateMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('GetNoTemplateMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -326,13 +340,17 @@ class RoutingHeadersGapicClient
     public function nestedMethod($nest1, $anotherName, array $optionalArgs = [])
     {
         $request = new NestedRequest();
+        $requestParamHeaders = [];
         $request->setNest1($nest1);
         $request->setAnotherName($anotherName);
+        $requestParamHeaders['nest1.nest2.name'] = $nest1->getNest2()->getName();
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('NestedMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('NestedMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -368,13 +386,19 @@ class RoutingHeadersGapicClient
     public function nestedMultiMethod($nest1, $anotherName, array $optionalArgs = [])
     {
         $request = new NestedRequest();
+        $requestParamHeaders = [];
         $request->setNest1($nest1);
         $request->setAnotherName($anotherName);
+        $requestParamHeaders['nest1.nest2.name'] = $nest1->getNest2()->getName();
+        $requestParamHeaders['another_name'] = $anotherName;
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('NestedMultiMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('NestedMultiMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -418,24 +442,35 @@ class RoutingHeadersGapicClient
     public function orderingMethod($a, $b, $d, $c, $e, array $optionalArgs = [])
     {
         $request = new OrderRequest();
+        $requestParamHeaders = [];
         $request->setA($a);
         $request->setB($b);
         $request->setD($d);
         $request->setC($c);
         $request->setE($e);
+        $requestParamHeaders['a'] = $a;
+        $requestParamHeaders['b'] = $b;
+        $requestParamHeaders['d'] = $d;
+        $requestParamHeaders['c'] = $c;
+        $requestParamHeaders['e'] = $e;
         if (isset($optionalArgs['aId'])) {
             $request->setAId($optionalArgs['aId']);
+            $requestParamHeaders['a_id'] = $optionalArgs['aId'];
         }
 
         if (isset($optionalArgs['bId'])) {
             $request->setBId($optionalArgs['bId']);
+            $requestParamHeaders['b_id'] = $optionalArgs['bId'];
         }
 
         if (isset($optionalArgs['aa'])) {
             $request->setAa($optionalArgs['aa']);
+            $requestParamHeaders['aa'] = $optionalArgs['aa'];
         }
 
-        return $this->startApiCall('OrderingMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('OrderingMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -467,11 +502,15 @@ class RoutingHeadersGapicClient
     public function patchMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('PatchMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('PatchMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -503,11 +542,15 @@ class RoutingHeadersGapicClient
     public function postMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('PostMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('PostMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -539,11 +582,15 @@ class RoutingHeadersGapicClient
     public function putMethod(array $optionalArgs = [])
     {
         $request = new SimpleRequest();
+        $requestParamHeaders = [];
         if (isset($optionalArgs['name'])) {
             $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
         }
 
-        return $this->startApiCall('PutMethod', $request, $optionalArgs)->wait();
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('PutMethod', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -585,7 +632,7 @@ class RoutingHeadersGapicClient
             $request->setName($optionalArgs['name']);
         }
 
-        return $this->startApiCall('RoutingRuleWithOutParameters', $request, $optionalArgs)->wait();
+        return $this->startCall('RoutingRuleWithOutParameters', Response::class, $optionalArgs, $request)->wait();
     }
 
     /**
@@ -621,12 +668,38 @@ class RoutingHeadersGapicClient
     public function routingRuleWithParameters($nest1, $anotherName, array $optionalArgs = [])
     {
         $request = new NestedRequest();
+        $requestParamHeaders = [];
         $request->setNest1($nest1);
         $request->setAnotherName($anotherName);
-        if (isset($optionalArgs['name'])) {
-            $request->setName($optionalArgs['name']);
+        $fooNameMatches = [];
+        if (preg_match('/^(?<foo_name>projects\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/', $anotherName, $fooNameMatches)) {
+            $requestParamHeaders['foo_name'] = $fooNameMatches['foo_name'];
+        } elseif (preg_match('/^(?<foo_name>projects\/[^\/]+\/foos\/[^\/]+)\/bars\/[^\/]+(?:\/.*)?$/', $anotherName, $fooNameMatches)) {
+            $requestParamHeaders['foo_name'] = $fooNameMatches['foo_name'];
         }
 
-        return $this->startApiCall('RoutingRuleWithParameters', $request, $optionalArgs)->wait();
+        $barNameMatches = [];
+        if (preg_match('/^projects\/[^\/]+\/foos\/[^\/]+\/(?<bar_name>bars\/[^\/]+)(?:\/.*)?$/', $anotherName, $barNameMatches)) {
+            $requestParamHeaders['bar_name'] = $barNameMatches['bar_name'];
+        }
+
+        $requestParamHeaders['nested_name'] = $nest1->getNest2()->getName();
+        $partOfNestedMatches = [];
+        if (preg_match('/^(?<part_of_nested>projects\/[^\/]+)\/bars$/', $nest1->getNest2()->getName(), $partOfNestedMatches)) {
+            $requestParamHeaders['part_of_nested'] = $partOfNestedMatches['part_of_nested'];
+        }
+
+        if (isset($optionalArgs['name'])) {
+            $request->setName($optionalArgs['name']);
+            $requestParamHeaders['name'] = $optionalArgs['name'];
+            $nameMatches = [];
+            if (preg_match('/^(?<name>projects\/[^\/]+)\/foos$/', $optionalArgs['name'], $nameMatches)) {
+                $requestParamHeaders['name'] = $nameMatches['name'];
+            }
+        }
+
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('RoutingRuleWithParameters', Response::class, $optionalArgs, $request)->wait();
     }
 }


### PR DESCRIPTION
As discussed, this reverts startApiCall in the existing gapic generator. The functionality will be ported over to the "v2" generator. This doesn't update the integration goldens, I am planning to include those in the followup PR to introduce the v2 generator. Please let me know if you'd prefer I add them here, instead (just seemed like it would save a few steps to include them in the other PR).