### PR TITLE
feat(v2): add sendAsync generation support

### DIFF
--- a/src/Generation/GapicClientExamplesGenerator.php
+++ b/src/Generation/GapicClientExamplesGenerator.php
@@ -133,6 +133,34 @@ class GapicClientExamplesGenerator
         ];
     }
 
+    private static function initRequestMessage(MethodDetails $method, SourceFileContext $ctx): AST
+    {
+        // TODO: Switch this to request builder when possible.
+        return AST::new($ctx->type($method->requestType))();
+    }
+
+    public static function sendAsyncExample(ServiceDetails $service, SourceFileContext $ctx): AST
+    {
+        $serviceClient = AST::var($service->clientVarName);
+        $method = $service->methods->firstOrNull(fn($m) => !$m->isStreaming());
+        if (!$method) {
+            return null;
+        }
+        $request = AST::var('request');
+        $response = AST::var('response');
+        $requestInit = static::initRequestMessage($method, $ctx);
+        return AST::block(
+            AST::assign($serviceClient, AST::new($ctx->type($service->emptyClientType, false, true))()),
+            AST::assign($request, $requestInit),
+            AST::try(
+                AST::assign($response,
+                    AST::call($serviceClient, AST::method('sendAsync'))($method->methodName, $request)->wait())
+            )->finally(
+                AST::call($serviceClient, AST::method('close'))()
+            )
+        );
+    }
+
     private function rpcMethodExampleNormal(MethodDetails $method): AST
     {
         $serviceClient = AST::var($this->serviceDetails->clientVarName);

--- a/src/Utils/ResolvedType.php
+++ b/src/Utils/ResolvedType.php
@@ -25,6 +25,16 @@ namespace Google\Generator\Utils;
 class ResolvedType
 {
     /**
+     * The 'array' built-in type.
+     *
+     * @return ResolvedType
+     */
+    public static function array(): ResolvedType
+    {
+        return new ResolvedType(Type::array(), fn () => 'array');
+    }
+
+    /**
      * The 'mixed' built-in type.
      *
      * @return ResolvedType
@@ -32,6 +42,16 @@ class ResolvedType
     public static function mixed(): ResolvedType
     {
         return new ResolvedType(Type::mixed(), fn () => 'mixed');
+    }
+
+    /**
+     * The 'string' built-in type.
+     *
+     * @return ResolvedType
+     */
+    public static function string(): ResolvedType
+    {
+        return new ResolvedType(Type::string(), fn () => 'string');
     }
 
     /**

--- a/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
@@ -54,6 +54,7 @@ use Google\Cloud\Asset\V1\SearchAllIamPoliciesRequest;
 use Google\Cloud\Asset\V1\SearchAllResourcesRequest;
 use Google\Cloud\Asset\V1\UpdateFeedRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Asset service definition.
@@ -297,6 +298,33 @@ class AssetServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $assetServiceClient = new AssetServiceClient();
+     * $request = new AnalyzeIamPolicyRequest();
+     * try {
+     *     $response = $assetServiceClient->sendAsync('analyzeIamPolicy', $request)->wait();
+     * } finally {
+     *     $assetServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
@@ -38,6 +38,7 @@ use Google\Cloud\Compute\V1\DeleteAddressRequest;
 use Google\Cloud\Compute\V1\InsertAddressRequest;
 use Google\Cloud\Compute\V1\ListAddressesRequest;
 use Google\Cloud\Compute\V1\RegionOperationsClient;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description:
@@ -210,6 +211,33 @@ class AddressesBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $addressesClient = new AddressesClient();
+     * $request = new AggregatedListAddressesRequest();
+     * try {
+     *     $response = $addressesClient->sendAsync('aggregatedList', $request)->wait();
+     * } finally {
+     *     $addressesClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
@@ -33,6 +33,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Compute\V1\GetRegionOperationRequest;
 use Google\Cloud\Compute\V1\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: The RegionOperations API.
@@ -151,6 +152,33 @@ class RegionOperationsBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $regionOperationsClient = new RegionOperationsClient();
+     * $request = new GetRegionOperationRequest();
+     * try {
+     *     $response = $regionOperationsClient->sendAsync('get', $request)->wait();
+     * } finally {
+     *     $regionOperationsClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
@@ -72,6 +72,7 @@ use Google\Cloud\Container\V1\StartIPRotationRequest;
 use Google\Cloud\Container\V1\UpdateClusterRequest;
 use Google\Cloud\Container\V1\UpdateMasterRequest;
 use Google\Cloud\Container\V1\UpdateNodePoolRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Google Kubernetes Engine Cluster Manager v1
@@ -177,6 +178,33 @@ class ClusterManagerBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $clusterManagerClient = new ClusterManagerClient();
+     * $request = new CancelOperationRequest();
+     * try {
+     *     $response = $clusterManagerClient->sendAsync('cancelOperation', $request)->wait();
+     * } finally {
+     *     $clusterManagerClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
@@ -39,6 +39,7 @@ use Google\Cloud\Dataproc\V1\DeleteAutoscalingPolicyRequest;
 use Google\Cloud\Dataproc\V1\GetAutoscalingPolicyRequest;
 use Google\Cloud\Dataproc\V1\ListAutoscalingPoliciesRequest;
 use Google\Cloud\Dataproc\V1\UpdateAutoscalingPolicyRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: The API interface for managing autoscaling policies in the
@@ -275,6 +276,33 @@ class AutoscalingPolicyServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $autoscalingPolicyServiceClient = new AutoscalingPolicyServiceClient();
+     * $request = new CreateAutoscalingPolicyRequest();
+     * try {
+     *     $response = $autoscalingPolicyServiceClient->sendAsync('createAutoscalingPolicy', $request)->wait();
+     * } finally {
+     *     $autoscalingPolicyServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
@@ -47,6 +47,7 @@ use Google\Cloud\Dataproc\V1\StartClusterRequest;
 use Google\Cloud\Dataproc\V1\StopClusterRequest;
 use Google\Cloud\Dataproc\V1\UpdateClusterRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: The ClusterControllerService provides methods to manage clusters
@@ -259,6 +260,33 @@ class ClusterControllerBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $clusterControllerClient = new ClusterControllerClient();
+     * $request = new CreateClusterRequest();
+     * try {
+     *     $response = $clusterControllerClient->sendAsync('createCluster', $request)->wait();
+     * } finally {
+     *     $clusterControllerClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
@@ -42,6 +42,7 @@ use Google\Cloud\Dataproc\V1\ListJobsRequest;
 use Google\Cloud\Dataproc\V1\SubmitJobRequest;
 use Google\Cloud\Dataproc\V1\UpdateJobRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: The JobController provides methods to manage jobs.
@@ -179,6 +180,33 @@ class JobControllerBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $jobControllerClient = new JobControllerClient();
+     * $request = new CancelJobRequest();
+     * try {
+     *     $response = $jobControllerClient->sendAsync('cancelJob', $request)->wait();
+     * } finally {
+     *     $jobControllerClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
@@ -45,6 +45,7 @@ use Google\Cloud\Dataproc\V1\UpdateWorkflowTemplateRequest;
 use Google\Cloud\Dataproc\V1\WorkflowMetadata;
 use Google\Cloud\Dataproc\V1\WorkflowTemplate;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: The API interface for managing Workflow Templates in the
@@ -353,6 +354,33 @@ class WorkflowTemplateServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $workflowTemplateServiceClient = new WorkflowTemplateServiceClient();
+     * $request = new CreateWorkflowTemplateRequest();
+     * try {
+     *     $response = $workflowTemplateServiceClient->sendAsync('createWorkflowTemplate', $request)->wait();
+     * } finally {
+     *     $workflowTemplateServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
@@ -53,6 +53,7 @@ use Google\Cloud\Iam\V1\SetIamPolicyRequest;
 use Google\Cloud\Iam\V1\TestIamPermissionsRequest;
 use Google\Cloud\Iam\V1\TestIamPermissionsResponse;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service that application uses to manipulate triggers and functions.
@@ -262,6 +263,33 @@ class CloudFunctionsServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $cloudFunctionsServiceClient = new CloudFunctionsServiceClient();
+     * $request = new CallFunctionRequest();
+     * try {
+     *     $response = $cloudFunctionsServiceClient->sendAsync('callFunction', $request)->wait();
+     * } finally {
+     *     $cloudFunctionsServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
@@ -36,6 +36,7 @@ use Google\Cloud\Iam\V1\Policy;
 use Google\Cloud\Iam\V1\SetIamPolicyRequest;
 use Google\Cloud\Iam\V1\TestIamPermissionsRequest;
 use Google\Cloud\Iam\V1\TestIamPermissionsResponse;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: ## API Overview
@@ -163,6 +164,33 @@ class IAMPolicyBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $iAMPolicyClient = new IAMPolicyClient();
+     * $request = new GetIamPolicyRequest();
+     * try {
+     *     $response = $iAMPolicyClient->sendAsync('getIamPolicy', $request)->wait();
+     * } finally {
+     *     $iAMPolicyClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
@@ -70,6 +70,7 @@ use Google\Cloud\Kms\V1\UpdateCryptoKeyVersionRequest;
 use Google\Cloud\Location\GetLocationRequest;
 use Google\Cloud\Location\ListLocationsRequest;
 use Google\Cloud\Location\Location;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Google Cloud Key Management Service
@@ -327,6 +328,33 @@ class KeyManagementServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $keyManagementServiceClient = new KeyManagementServiceClient();
+     * $request = new AsymmetricDecryptRequest();
+     * try {
+     *     $response = $keyManagementServiceClient->sendAsync('asymmetricDecrypt', $request)->wait();
+     * } finally {
+     *     $keyManagementServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
@@ -61,6 +61,7 @@ use Google\Cloud\Logging\V2\UpdateCmekSettingsRequest;
 use Google\Cloud\Logging\V2\UpdateExclusionRequest;
 use Google\Cloud\Logging\V2\UpdateSinkRequest;
 use Google\Cloud\Logging\V2\UpdateViewRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for configuring sinks used to route log entries.
@@ -809,6 +810,33 @@ class ConfigServiceV2BaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $configServiceV2Client = new ConfigServiceV2Client();
+     * $request = new CreateBucketRequest();
+     * try {
+     *     $response = $configServiceV2Client->sendAsync('createBucket', $request)->wait();
+     * } finally {
+     *     $configServiceV2Client->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
@@ -40,6 +40,7 @@ use Google\Cloud\Logging\V2\ListLogsRequest;
 use Google\Cloud\Logging\V2\ListMonitoredResourceDescriptorsRequest;
 use Google\Cloud\Logging\V2\WriteLogEntriesRequest;
 use Google\Cloud\Logging\V2\WriteLogEntriesResponse;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for ingesting and querying logs.
@@ -337,6 +338,33 @@ class LoggingServiceV2BaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $loggingServiceV2Client = new LoggingServiceV2Client();
+     * $request = new DeleteLogRequest();
+     * try {
+     *     $response = $loggingServiceV2Client->sendAsync('deleteLog', $request)->wait();
+     * } finally {
+     *     $loggingServiceV2Client->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
@@ -39,6 +39,7 @@ use Google\Cloud\Logging\V2\GetLogMetricRequest;
 use Google\Cloud\Logging\V2\ListLogMetricsRequest;
 use Google\Cloud\Logging\V2\LogMetric;
 use Google\Cloud\Logging\V2\UpdateLogMetricRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for configuring logs-based metrics.
@@ -216,6 +217,33 @@ class MetricsServiceV2BaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $metricsServiceV2Client = new MetricsServiceV2Client();
+     * $request = new CreateLogMetricRequest();
+     * try {
+     *     $response = $metricsServiceV2Client->sendAsync('createLogMetric', $request)->wait();
+     * } finally {
+     *     $metricsServiceV2Client->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
@@ -46,6 +46,7 @@ use Google\Cloud\Redis\V1\ListInstancesRequest;
 use Google\Cloud\Redis\V1\UpdateInstanceRequest;
 use Google\Cloud\Redis\V1\UpgradeInstanceRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Configures and manages Cloud Memorystore for Redis instances
@@ -269,6 +270,33 @@ class CloudRedisBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $cloudRedisClient = new CloudRedisClient();
+     * $request = new CreateInstanceRequest();
+     * try {
+     *     $response = $cloudRedisClient->sendAsync('createInstance', $request)->wait();
+     * } finally {
+     *     $cloudRedisClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
@@ -41,6 +41,7 @@ use Google\Cloud\Retail\V2alpha\GetDefaultBranchResponse;
 use Google\Cloud\Retail\V2alpha\ListCatalogsRequest;
 use Google\Cloud\Retail\V2alpha\SetDefaultBranchRequest;
 use Google\Cloud\Retail\V2alpha\UpdateCatalogRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for managing catalog configuration.
@@ -252,6 +253,33 @@ class CatalogServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $catalogServiceClient = new CatalogServiceClient();
+     * $request = new GetDefaultBranchRequest();
+     * try {
+     *     $response = $catalogServiceClient->sendAsync('getDefaultBranch', $request)->wait();
+     * } finally {
+     *     $catalogServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
@@ -40,6 +40,7 @@ use Google\Cloud\Retail\V2alpha\CompleteQueryRequest;
 use Google\Cloud\Retail\V2alpha\CompleteQueryResponse;
 use Google\Cloud\Retail\V2alpha\ImportCompletionDataRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Auto-completion service for retail.
@@ -247,6 +248,33 @@ class CompletionServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $completionServiceClient = new CompletionServiceClient();
+     * $request = new CompleteQueryRequest();
+     * try {
+     *     $response = $completionServiceClient->sendAsync('completeQuery', $request)->wait();
+     * } finally {
+     *     $completionServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
@@ -36,6 +36,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Retail\V2alpha\PredictRequest;
 use Google\Cloud\Retail\V2alpha\PredictResponse;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for making recommendation prediction.
@@ -207,6 +208,33 @@ class PredictionServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $predictionServiceClient = new PredictionServiceClient();
+     * $request = new PredictRequest();
+     * try {
+     *     $response = $predictionServiceClient->sendAsync('predict', $request)->wait();
+     * } finally {
+     *     $predictionServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
@@ -48,6 +48,7 @@ use Google\Cloud\Retail\V2alpha\RemoveFulfillmentPlacesRequest;
 use Google\Cloud\Retail\V2alpha\SetInventoryRequest;
 use Google\Cloud\Retail\V2alpha\UpdateProductRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for ingesting [Product][google.cloud.retail.v2alpha.Product]
@@ -280,6 +281,33 @@ class ProductServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $productServiceClient = new ProductServiceClient();
+     * $request = new AddFulfillmentPlacesRequest();
+     * try {
+     *     $response = $productServiceClient->sendAsync('addFulfillmentPlaces', $request)->wait();
+     * } finally {
+     *     $productServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
@@ -36,6 +36,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Retail\V2alpha\SearchRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for search.
@@ -209,6 +210,33 @@ class SearchServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $searchServiceClient = new SearchServiceClient();
+     * $request = new SearchRequest();
+     * try {
+     *     $response = $searchServiceClient->sendAsync('search', $request)->wait();
+     * } finally {
+     *     $searchServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
@@ -45,6 +45,7 @@ use Google\Cloud\Retail\V2alpha\RejoinUserEventsRequest;
 use Google\Cloud\Retail\V2alpha\UserEvent;
 use Google\Cloud\Retail\V2alpha\WriteUserEventRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service for ingesting end user actions on the customer website.
@@ -274,6 +275,33 @@ class UserEventServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $userEventServiceClient = new UserEventServiceClient();
+     * $request = new CollectUserEventRequest();
+     * try {
+     *     $response = $userEventServiceClient->sendAsync('collectUserEvent', $request)->wait();
+     * } finally {
+     *     $userEventServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
@@ -66,6 +66,7 @@ use Google\Cloud\SecurityCenter\V1\UpdateOrganizationSettingsRequest;
 use Google\Cloud\SecurityCenter\V1\UpdateSecurityMarksRequest;
 use Google\Cloud\SecurityCenter\V1\UpdateSourceRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: V1 APIs for Security Center service.
@@ -621,6 +622,33 @@ class SecurityCenterBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $securityCenterClient = new SecurityCenterClient();
+     * $request = new CreateFindingRequest();
+     * try {
+     *     $response = $securityCenterClient->sendAsync('createFinding', $request)->wait();
+     * } finally {
+     *     $securityCenterClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
@@ -39,6 +39,7 @@ use Google\Cloud\Speech\V1\LongRunningRecognizeResponse;
 use Google\Cloud\Speech\V1\RecognizeRequest;
 use Google\Cloud\Speech\V1\RecognizeResponse;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service that implements Google Cloud Speech API.
@@ -176,6 +177,33 @@ class SpeechBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $speechClient = new SpeechClient();
+     * $request = new LongRunningRecognizeRequest();
+     * try {
+     *     $response = $speechClient->sendAsync('longRunningRecognize', $request)->wait();
+     * } finally {
+     *     $speechClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
@@ -41,6 +41,7 @@ use Google\Cloud\Talent\V4beta1\DeleteApplicationRequest;
 use Google\Cloud\Talent\V4beta1\GetApplicationRequest;
 use Google\Cloud\Talent\V4beta1\ListApplicationsRequest;
 use Google\Cloud\Talent\V4beta1\UpdateApplicationRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service that handles application management, including CRUD and
@@ -362,6 +363,33 @@ class ApplicationServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $applicationServiceClient = new ApplicationServiceClient();
+     * $request = new CreateApplicationRequest();
+     * try {
+     *     $response = $applicationServiceClient->sendAsync('createApplication', $request)->wait();
+     * } finally {
+     *     $applicationServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
@@ -41,6 +41,7 @@ use Google\Cloud\Talent\V4beta1\DeleteCompanyRequest;
 use Google\Cloud\Talent\V4beta1\GetCompanyRequest;
 use Google\Cloud\Talent\V4beta1\ListCompaniesRequest;
 use Google\Cloud\Talent\V4beta1\UpdateCompanyRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service that handles company management, including CRUD and enumeration.
@@ -289,6 +290,33 @@ class CompanyServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $companyServiceClient = new CompanyServiceClient();
+     * $request = new CreateCompanyRequest();
+     * try {
+     *     $response = $companyServiceClient->sendAsync('createCompany', $request)->wait();
+     * } finally {
+     *     $companyServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
@@ -36,6 +36,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Talent\V4beta1\CompleteQueryRequest;
 use Google\Cloud\Talent\V4beta1\CompleteQueryResponse;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service handles auto completion.
@@ -284,6 +285,33 @@ class CompletionBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $completionClient = new CompletionClient();
+     * $request = new CompleteQueryRequest();
+     * try {
+     *     $response = $completionClient->sendAsync('completeQuery', $request)->wait();
+     * } finally {
+     *     $completionClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
@@ -36,6 +36,7 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Talent\V4beta1\ClientEvent;
 use Google\Cloud\Talent\V4beta1\CreateClientEventRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service handles client event report.
@@ -220,6 +221,33 @@ class EventServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $eventServiceClient = new EventServiceClient();
+     * $request = new CreateClientEventRequest();
+     * try {
+     *     $response = $eventServiceClient->sendAsync('createClientEvent', $request)->wait();
+     * } finally {
+     *     $eventServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
@@ -48,6 +48,7 @@ use Google\Cloud\Talent\V4beta1\ListJobsRequest;
 use Google\Cloud\Talent\V4beta1\SearchJobsRequest;
 use Google\Cloud\Talent\V4beta1\UpdateJobRequest;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service handles job management, including job CRUD, enumeration and search.
@@ -396,6 +397,33 @@ class JobServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $jobServiceClient = new JobServiceClient();
+     * $request = new BatchCreateJobsRequest();
+     * try {
+     *     $response = $jobServiceClient->sendAsync('batchCreateJobs', $request)->wait();
+     * } finally {
+     *     $jobServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
@@ -42,6 +42,7 @@ use Google\Cloud\Talent\V4beta1\ListProfilesRequest;
 use Google\Cloud\Talent\V4beta1\Profile;
 use Google\Cloud\Talent\V4beta1\SearchProfilesRequest;
 use Google\Cloud\Talent\V4beta1\UpdateProfileRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service that handles profile management, including profile CRUD,
@@ -231,6 +232,33 @@ class ProfileServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $profileServiceClient = new ProfileServiceClient();
+     * $request = new CreateProfileRequest();
+     * try {
+     *     $response = $profileServiceClient->sendAsync('createProfile', $request)->wait();
+     * } finally {
+     *     $profileServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
@@ -41,6 +41,7 @@ use Google\Cloud\Talent\V4beta1\GetTenantRequest;
 use Google\Cloud\Talent\V4beta1\ListTenantsRequest;
 use Google\Cloud\Talent\V4beta1\Tenant;
 use Google\Cloud\Talent\V4beta1\UpdateTenantRequest;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: A service that handles tenant management, including CRUD and enumeration.
@@ -225,6 +226,33 @@ class TenantServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $tenantServiceClient = new TenantServiceClient();
+     * $request = new CreateTenantRequest();
+     * try {
+     *     $response = $tenantServiceClient->sendAsync('createTenant', $request)->wait();
+     * } finally {
+     *     $tenantServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
@@ -37,6 +37,7 @@ use Google\Cloud\VideoIntelligence\V1\AnnotateVideoProgress;
 use Google\Cloud\VideoIntelligence\V1\AnnotateVideoRequest;
 use Google\Cloud\VideoIntelligence\V1\AnnotateVideoResponse;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 
 /**
  * Service Description: Service that implements the Video Intelligence API.
@@ -174,6 +175,33 @@ class VideoIntelligenceServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $videoIntelligenceServiceClient = new VideoIntelligenceServiceClient();
+     * $request = new AnnotateVideoRequest();
+     * try {
+     *     $response = $videoIntelligenceServiceClient->sendAsync('annotateVideo', $request)->wait();
+     * } finally {
+     *     $videoIntelligenceServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\Basic\Request;
 use Testing\Basic\RequestWithArgs;
 use Testing\Basic\Response;
@@ -140,6 +141,33 @@ class BasicBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $basicClient = new BasicClient();
+     * $request = new Request();
+     * try {
+     *     $response = $basicClient->sendAsync('aMethod', $request)->wait();
+     * } finally {
+     *     $basicClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryServiceBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryServiceBaseClient.php
@@ -36,6 +36,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 use Testing\BasicDiregapic\AddCommentsRequest;
 use Testing\BasicDiregapic\AddTagRequest;
 use Testing\BasicDiregapic\AddTagResponse;
@@ -582,6 +583,33 @@ class LibraryServiceBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $libraryServiceClient = new LibraryServiceClient();
+     * $request = new AddCommentsRequest();
+     * try {
+     *     $response = $libraryServiceClient->sendAsync('addComments', $request)->wait();
+     * } finally {
+     *     $libraryServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
@@ -34,6 +34,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 use Testing\BasicLro\Request;
 
 /**
@@ -173,6 +174,33 @@ class BasicLroBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $basicLroClient = new BasicLroClient();
+     * $request = new Request();
+     * try {
+     *     $response = $basicLroClient->sendAsync('method1', $request)->wait();
+     * } finally {
+     *     $basicLroClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\BasicOneof\Request;
 use Testing\BasicOneof\Response;
 
@@ -139,6 +140,33 @@ class BasicOneofBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $basicOneofClient = new BasicOneofClient();
+     * $request = new Request();
+     * try {
+     *     $response = $basicOneofClient->sendAsync('aMethod', $request)->wait();
+     * } finally {
+     *     $basicOneofClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
@@ -32,6 +32,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\BasicPaginated\Request;
 
 /**
@@ -139,6 +140,33 @@ class BasicPaginatedBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $basicPaginatedClient = new BasicPaginatedClient();
+     * $request = new Request();
+     * try {
+     *     $response = $basicPaginatedClient->sendAsync('methodPaginated', $request)->wait();
+     * } finally {
+     *     $basicPaginatedClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
@@ -32,6 +32,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\CustomLro\CreateFooRequest;
 use Testing\CustomLro\CustomLroOperationsClient;
 
@@ -204,6 +205,33 @@ class CustomLroBaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $customLroClient = new CustomLroClient();
+     * $request = new CreateFooRequest();
+     * try {
+     *     $response = $customLroClient->sendAsync('createFoo', $request)->wait();
+     * } finally {
+     *     $customLroClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\CustomLro\CancelOperationRequest;
 use Testing\CustomLro\CustomOperationResponse;
 use Testing\CustomLro\DeleteOperationRequest;
@@ -152,6 +153,33 @@ class CustomLroOperationsBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $customLroOperationsClient = new CustomLroOperationsClient();
+     * $request = new CancelOperationRequest();
+     * try {
+     *     $response = $customLroOperationsClient->sendAsync('cancel', $request)->wait();
+     * } finally {
+     *     $customLroOperationsClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\Deprecated\FibonacciRequest;
 
 /**
@@ -140,6 +141,33 @@ class DeprecatedServiceBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $deprecatedServiceClient = new DeprecatedServiceClient();
+     * $request = new FibonacciRequest();
+     * try {
+     *     $response = $deprecatedServiceClient->sendAsync('fastFibonacci', $request)->wait();
+     * } finally {
+     *     $deprecatedServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\DisableSnippets\Request;
 use Testing\DisableSnippets\Response;
 
@@ -136,6 +137,33 @@ class DisableSnippetsBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $disableSnippetsClient = new DisableSnippetsClient();
+     * $request = new Request();
+     * try {
+     *     $response = $disableSnippetsClient->sendAsync('method1', $request)->wait();
+     * } finally {
+     *     $disableSnippetsClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
@@ -36,6 +36,7 @@ use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\LongRunning\Operation;
+use Google\Protobuf\Internal\Message;
 use Testing\GrpcServiceConfig\Request1;
 use Testing\GrpcServiceConfig\Response1;
 
@@ -173,6 +174,33 @@ class GrpcServiceConfigWithRetry1BaseClient
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
         $this->operationsClient = $this->createOperationsClient($clientOptions);
+    }
+
+    /**
+     * ```
+     * $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
+     * $request = new Request1();
+     * try {
+     *     $response = $grpcServiceConfigWithRetry1Client->sendAsync('method1A', $request)->wait();
+     * } finally {
+     *     $grpcServiceConfigWithRetry1Client->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
@@ -32,6 +32,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\ResourceNames\FileLevelChildTypeRefRequest;
 use Testing\ResourceNames\FileLevelTypeRefRequest;
 use Testing\ResourceNames\MultiPatternRequest;
@@ -452,6 +453,33 @@ class ResourceNamesBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $resourceNamesClient = new ResourceNamesClient();
+     * $request = new FileLevelChildTypeRefRequest();
+     * try {
+     *     $response = $resourceNamesClient->sendAsync('fileLevelChildTypeRefMethod', $request)->wait();
+     * } finally {
+     *     $resourceNamesClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
@@ -31,6 +31,7 @@ use Google\ApiCore\RetrySettings;
 use Google\ApiCore\Transport\TransportInterface;
 use Google\ApiCore\ValidationException;
 use Google\Auth\FetchAuthTokenInterface;
+use Google\Protobuf\Internal\Message;
 use Testing\RoutingHeaders\NestedRequest;
 use Testing\RoutingHeaders\OrderRequest;
 use Testing\RoutingHeaders\Response;
@@ -138,6 +139,33 @@ class RoutingHeadersBaseClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
+    }
+
+    /**
+     * ```
+     * $routingHeadersClient = new RoutingHeadersClient();
+     * $request = new SimpleRequest();
+     * try {
+     *     $response = $routingHeadersClient->sendAsync('deleteMethod', $request)->wait();
+     * } finally {
+     *     $routingHeadersClient->close();
+     * }
+     * ```
+     *
+     * @param string  $methodName   Name of the client method to be executed.
+     * @param Message $request      Request message payload.
+     * @param array   $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     */
+    public function sendAsync(string $methodName, Message $request, array $optionalArgs = [])
+    {
+        return $this->startAsyncCall($methodName, $request, $optionalArgs);
     }
 
     /**


### PR DESCRIPTION
Adds generation of the GAPIC v2 method `sendAsync`. This method invokes the `GapicClientTrait.startAsyncCall` to start the API call, then returning the `Promise` directly for the caller to manage. This only works for non-streaming calls. This method will only be generated for GAPICs with at least one non-streaming RPC. 

Also add to convenience methods to `ResolvedType` for the PHP types `string` and `array`.