### PR TITLE
fix: properly parse recently added flags in bazel

### DIFF
--- a/src/Main.php
+++ b/src/Main.php
@@ -56,6 +56,7 @@ function showUsageAndExit()
 // file loading.
 $opts = getopt('', ['side_loaded_root_dir:']);
 $sideLoadedRootDir = isset($opts['side_loaded_root_dir']) ? rtrim($opts['side_loaded_root_dir'], '/') : null;
+$defaultLicenseYear = -1;
 
 // argc <= 3 to allow both "--side_loaded_root_dir=path" and "--side_loaded_root_dir path"
 if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
@@ -104,8 +105,14 @@ if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
         if (array_key_exists('metadata', $opts)) {
             $opts['metadata'] = false;
         }
+        if (array_key_exists('rest-numeric-enums', $opts)) {
+            $opts['rest-numeric-enums'] = false;
+        }
+        if (array_key_exists('generate-snippets', $opts)) {
+            $opts['generate-snippets'] = false;
+        }
 
-        [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata] =
+        [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata, $numericEnums, $generateSnippets] =
             readOptions($opts, $sideLoadedRootDir);
 
         $files = CodeGenerator::generate(
@@ -115,7 +122,10 @@ if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
             $generateGapicMetadata,
             $grpcServiceConfig,
             $gapicYaml,
-            $serviceYaml
+            $serviceYaml,
+            $numericEnums,
+            $defaultLicenseYear,
+            $generateSnippets
         );
         $files = Vector::new($files)->map(function ($fileData) {
             [$relativeFilename, $fileContent] = $fileData;
@@ -138,7 +148,6 @@ if ($argc === 1 || (!is_null($sideLoadedRootDir) && $argc <= 3)) {
     $descBytes = file_get_contents($opts['descriptor']);
     $package = $opts['package'];
     $outputDir = $opts['output'];
-    $defaultLicenseYear = -1;
     [$grpcServiceConfig, $gapicYaml, $serviceYaml, $transport, $generateGapicMetadata, $numericEnums, $generateSnippets] = readOptions($opts);
 
     // Generate PHP code.

--- a/tests/Integration/BUILD.bazel
+++ b/tests/Integration/BUILD.bazel
@@ -66,6 +66,7 @@ php_gapic_library(
     name = "asset_php_gapic",
     srcs = ["@com_google_googleapis//google/cloud/asset/v1:asset_proto_with_info"],
     grpc_service_config = "@com_google_googleapis//google/cloud/asset/v1:cloudasset_grpc_service_config.json",
+    rest_numeric_enums = True,
     deps = [
         ":asset_php_grpc",
         ":asset_php_proto",

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_move.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_move.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/batch_get_assets_history.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/batch_get_assets_history.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/create_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/create_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/delete_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/delete_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/export_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/export_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/get_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/get_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_feeds.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_feeds.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_iam_policies.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_iam_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_resources.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_resources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/update_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/update_feed.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/src/V1/AssetServiceClient.php
+++ b/tests/Integration/goldens/asset/src/V1/AssetServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/asset/src/V1/resources/asset_service_rest_client_config.php
+++ b/tests/Integration/goldens/asset/src/V1/resources/asset_service_rest_client_config.php
@@ -155,4 +155,5 @@ return [
             ],
         ],
     ],
+    'numericEnums' => true,
 ];

--- a/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
+++ b/tests/Integration/goldens/asset/tests/Unit/V1/AssetServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/aggregated_list.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/aggregated_list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/delete.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/delete.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/insert.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/insert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/list.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/list.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/samples/V1/RegionOperationsClient/get.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/RegionOperationsClient/get.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/AddressesClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/AddressesClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Address/AddressType.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Address/AddressType.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Address/IpVersion.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Address/IpVersion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Address/NetworkTier.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Address/NetworkTier.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Address/Purpose.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Address/Purpose.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Address/Status.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Address/Status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Operation/Status.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Operation/Status.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Warning/Code.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Warning/Code.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Enums/Warnings/Code.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Enums/Warnings/Code.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/RegionOperationsGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/RegionOperationsGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/src/V1/RegionOperationsClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/RegionOperationsClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/AddressesClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/RegionOperationsClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/RegionOperationsClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/cancel_operation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/cancel_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/complete_ip_rotation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/complete_ip_rotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_json_web_keys.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_json_web_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_operation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_server_config.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_server_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_clusters.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_node_pools.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_node_pools.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_operations.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_operations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_usable_subnetworks.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_usable_subnetworks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/rollback_node_pool_upgrade.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/rollback_node_pool_upgrade.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_addons_config.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_addons_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_labels.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_labels.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_legacy_abac.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_legacy_abac.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_locations.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_logging_service.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_logging_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_maintenance_policy.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_maintenance_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_master_auth.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_master_auth.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_monitoring_service.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_monitoring_service.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_network_policy.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_network_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_autoscaling.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_autoscaling.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_management.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_management.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_size.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_size.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/start_ip_rotation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/start_ip_rotation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_master.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_master.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_node_pool.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/src/V1/ClusterManagerClient.php
+++ b/tests/Integration/goldens/container/src/V1/ClusterManagerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
+++ b/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
+++ b/tests/Integration/goldens/container/tests/Unit/V1/ClusterManagerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/create_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/create_autoscaling_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/delete_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/delete_autoscaling_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/get_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/get_autoscaling_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/list_autoscaling_policies.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/list_autoscaling_policies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/update_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/update_autoscaling_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/create_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/create_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/delete_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/delete_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/diagnose_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/diagnose_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/get_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/get_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/list_clusters.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/list_clusters.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/start_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/start_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/stop_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/stop_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/update_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/update_cluster.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/cancel_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/cancel_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/delete_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/get_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/list_jobs.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job_as_operation.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job_as_operation.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/update_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/update_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/create_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/create_workflow_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/delete_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/delete_workflow_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/get_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/get_workflow_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_inline_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_inline_workflow_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_workflow_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/list_workflow_templates.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/list_workflow_templates.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/update_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/update_workflow_template.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/AutoscalingPolicyServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/AutoscalingPolicyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/ClusterControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/ClusterControllerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/AutoscalingPolicyServiceGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/AutoscalingPolicyServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/ClusterControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/ClusterControllerGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/JobControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/JobControllerGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/WorkflowTemplateServiceGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/WorkflowTemplateServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/JobControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/JobControllerClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/src/V1/WorkflowTemplateServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/WorkflowTemplateServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/AutoscalingPolicyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/ClusterControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/ClusterControllerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/JobControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/JobControllerClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/WorkflowTemplateServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/WorkflowTemplateServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/call_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/call_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/create_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/create_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/delete_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/delete_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_download_url.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_download_url.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_upload_url.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_upload_url.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_iam_policy.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/list_functions.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/list_functions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/set_iam_policy.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/update_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/update_function.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/src/V1/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/CloudFunctionsServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/src/V1/Gapic/CloudFunctionsServiceGapicClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Gapic/CloudFunctionsServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/functions/tests/Unit/V1/CloudFunctionsServiceClientTest.php
+++ b/tests/Integration/goldens/functions/tests/Unit/V1/CloudFunctionsServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/get_iam_policy.php
+++ b/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/set_iam_policy.php
+++ b/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/iam/src/V1/Gapic/IAMPolicyGapicClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Gapic/IAMPolicyGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/iam/src/V1/IAMPolicyClient.php
+++ b/tests/Integration/goldens/iam/src/V1/IAMPolicyClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/iam/tests/Unit/V1/IAMPolicyClientTest.php
+++ b/tests/Integration/goldens/iam/tests/Unit/V1/IAMPolicyClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_decrypt.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_decrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_sign.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_sign.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_import_job.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_key_ring.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_key_ring.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/decrypt.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/decrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/destroy_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/destroy_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/encrypt.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/encrypt.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_iam_policy.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_import_job.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_import_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_key_ring.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_key_ring.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_location.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_location.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_public_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_public_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/import_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/import_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_key_versions.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_key_versions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_keys.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_keys.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_import_jobs.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_import_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_key_rings.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_key_rings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_locations.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_locations.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/restore_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/restore_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_primary_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_primary_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_version.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/src/V1/KeyManagementServiceClient.php
+++ b/tests/Integration/goldens/kms/src/V1/KeyManagementServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
+++ b/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_cmek_settings.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_cmek_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_buckets.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_buckets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_exclusions.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_exclusions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_sinks.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_sinks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_views.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_views.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/undelete_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/undelete_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_bucket.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_cmek_settings.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_cmek_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_exclusion.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_sink.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_view.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/delete_log.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/delete_log.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_logs.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_logs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_monitored_resource_descriptors.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_monitored_resource_descriptors.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/tail_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/tail_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/write_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/write_log_entries.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/create_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/create_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/delete_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/delete_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/get_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/get_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/list_log_metrics.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/list_log_metrics.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/update_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/update_log_metric.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/src/V2/ConfigServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/ConfigServiceV2Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/src/V2/Gapic/ConfigServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/ConfigServiceV2GapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/src/V2/Gapic/LoggingServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/LoggingServiceV2GapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/src/V2/Gapic/MetricsServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/MetricsServiceV2GapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/src/V2/LoggingServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/LoggingServiceV2Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/src/V2/MetricsServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/MetricsServiceV2Client.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/tests/Unit/V2/ConfigServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/ConfigServiceV2ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/tests/Unit/V2/LoggingServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/LoggingServiceV2ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/logging/tests/Unit/V2/MetricsServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/MetricsServiceV2ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/create_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/create_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/delete_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/delete_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/export_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/export_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/failover_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/failover_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/import_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/import_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/list_instances.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/list_instances.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/update_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/update_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/upgrade_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/upgrade_instance.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/src/V1/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/CloudRedisClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/src/V1/Gapic/CloudRedisGapicClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Gapic/CloudRedisGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
+++ b/tests/Integration/goldens/redis/tests/Unit/V1/CloudRedisClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_default_branch.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_default_branch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/list_catalogs.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/list_catalogs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/set_default_branch.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/set_default_branch.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_catalog.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_catalog.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/complete_query.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/complete_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/import_completion_data.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/import_completion_data.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/PredictionServiceClient/predict.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/PredictionServiceClient/predict.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_fulfillment_places.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_fulfillment_places.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/create_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/create_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/delete_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/delete_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/get_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/get_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/import_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/import_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/list_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/list_products.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_fulfillment_places.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_fulfillment_places.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/set_inventory.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/set_inventory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/update_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/update_product.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/SearchServiceClient/search.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/SearchServiceClient/search.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/collect_user_event.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/collect_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/import_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/import_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/purge_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/purge_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/rejoin_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/rejoin_user_events.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/write_user_event.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/write_user_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/CatalogServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/CatalogServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/CompletionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/CompletionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/CatalogServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/CatalogServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/CompletionServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/CompletionServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/PredictionServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/PredictionServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ProductServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ProductServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/SearchServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/SearchServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/UserEventServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/UserEventServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/PredictionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/PredictionServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/ProductServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/ProductServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/SearchServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/SearchServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/src/V2alpha/UserEventServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/UserEventServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/CatalogServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/CatalogServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/CompletionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/CompletionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/PredictionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/PredictionServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/ProductServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/ProductServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/SearchServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/SearchServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/UserEventServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/UserEventServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_finding.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_source.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_iam_policy.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_organization_settings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_organization_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_source.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_assets.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_findings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_assets.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_assets.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_findings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_findings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_notification_configs.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_notification_configs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_sources.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_sources.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_finding_state.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_finding_state.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_iam_policy.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_iam_policy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/test_iam_permissions.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_finding.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_finding.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_notification_config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_organization_settings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_organization_settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_security_marks.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_security_marks.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_source.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_source.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/src/V1/Gapic/SecurityCenterGapicClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Gapic/SecurityCenterGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/src/V1/SecurityCenterClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/SecurityCenterClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/securitycenter/tests/Unit/V1/SecurityCenterClientTest.php
+++ b/tests/Integration/goldens/securitycenter/tests/Unit/V1/SecurityCenterClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/long_running_recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/long_running_recognize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/recognize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/streaming_recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/streaming_recognize.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/speech/src/V1/Gapic/SpeechGapicClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Gapic/SpeechGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/speech/src/V1/SpeechClient.php
+++ b/tests/Integration/goldens/speech/src/V1/SpeechClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
+++ b/tests/Integration/goldens/speech/tests/Unit/V1/SpeechClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/create_application.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/create_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/delete_application.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/delete_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/get_application.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/get_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/list_applications.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/list_applications.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/update_application.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ApplicationServiceClient/update_application.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/create_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/create_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/delete_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/delete_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/get_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/get_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/list_companies.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/list_companies.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/update_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/update_company.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompletionClient/complete_query.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompletionClient/complete_query.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/EventServiceClient/create_client_event.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/EventServiceClient/create_client_event.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_create_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_create_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_delete_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_delete_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_update_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_update_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/create_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/create_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/delete_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/delete_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/get_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/get_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/list_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/list_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs_for_alert.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs_for_alert.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/update_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/update_job.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/create_profile.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/create_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/delete_profile.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/delete_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/get_profile.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/get_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/list_profiles.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/list_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/search_profiles.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/search_profiles.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/update_profile.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/ProfileServiceClient/update_profile.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/create_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/create_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/delete_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/delete_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/get_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/get_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/list_tenants.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/list_tenants.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/update_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/update_tenant.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/ApplicationServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/ApplicationServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/CompanyServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/CompanyServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/CompletionClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/CompletionClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/EventServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/EventServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/ApplicationServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/ApplicationServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompanyServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompanyServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompletionGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompletionGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/EventServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/EventServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/JobServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/JobServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/ProfileServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/ProfileServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/TenantServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/TenantServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/JobServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/JobServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/ProfileServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/ProfileServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/src/V4beta1/TenantServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/TenantServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/ApplicationServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/ApplicationServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompanyServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompanyServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompletionClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/CompletionClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/EventServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/EventServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/JobServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/JobServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/ProfileServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/ProfileServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/TenantServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/TenantServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/videointelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
+++ b/tests/Integration/goldens/videointelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/videointelligence/src/V1/Gapic/VideoIntelligenceServiceGapicClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Gapic/VideoIntelligenceServiceGapicClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/videointelligence/src/V1/VideoIntelligenceServiceClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/VideoIntelligenceServiceClient.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Integration/goldens/videointelligence/tests/Unit/V1/VideoIntelligenceServiceClientTest.php
+++ b/tests/Integration/goldens/videointelligence/tests/Unit/V1/VideoIntelligenceServiceClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This fixes the parsing of flags when the generator is run in bazel mode, specifically the `rest-numeric-enums` and `generate-snippets` flags. Adds `rest_numeric_enums = True` to the `asset_php_gapic` integration test.

Also (unfortunately) need to update the license year on all of the goldens :(