### PR TITLE
chore(allstar): exempt tools/protoc

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,4 @@
+# Ignore reason: These artifacts are used in tests to both run the test and
+# generate baseline files.
+ignorePaths:
+- tools/protoc


### PR DESCRIPTION
This will exempt the `tools/protoc` binary used for baseline tests from the allstar check i.e. #550 .