### PR TITLE
fix: use camelName for optionalArgs when settings requestParamHeaders

### DIFF
--- a/src/Generation/GapicClientGenerator.php
+++ b/src/Generation/GapicClientGenerator.php
@@ -1060,7 +1060,7 @@ class GapicClientGenerator
                 $field = $fieldDetailsByRootField[$root];
                 $param = $field->isRequired
                     ? AST::param(null, AST::var($field->camelName))
-                    : AST::index(AST::var('optionalArgs'), $root);
+                    : AST::index(AST::var('optionalArgs'), $field->camelName);
                 $assignValue = $param;
 
                 // Construct the getter chain if the routing header uses a nested field.


### PR DESCRIPTION
addresses #573