### PR TITLE
fix: required-to-optional for Scheduler.UpdateJob

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -115,6 +115,7 @@ class FieldDetails
         'google.bigtable.admin.v2.Instance' => ['name', 'type', 'labels'],
         'google.cloud.asset.v1.BatchGetAssetsHistoryRequest' => ['content_type', 'read_time_window'],
         'google.cloud.datacatalog.v1.SearchCatalogRequest' => ['query'],
+        'google.cloud.scheduler.v1.UpdateJobRequest' => ['update_mask'],
         'google.datastore.v1.CommitRequest' => ['mode', 'mutations'],
         'google.datastore.v1.RunQueryRequest' => ['partition_id'],
         'google.firestore.v1.CommitRequest' => ['writes'],


### PR DESCRIPTION
Prevent breaking change in V1 Scheduler

https://github.com/googleapis/google-cloud-php/pull/5919#pullrequestreview-1323861537