### PR TITLE
fix: dupe method names from mixins

### DIFF
--- a/src/Generation/ServiceDetails.php
+++ b/src/Generation/ServiceDetails.php
@@ -174,11 +174,11 @@ class ServiceDetails
             // Technically there could be multiple different named operation services,
             // but for simplicity we will assume they are all the same and use the first.
             $this->customOperationService = $customOperations[0]->operationService;
-            
+
             // Determine if the operation service implements the Cancel and/or the Delete RPCs.
             $this->hasCustomOpCancel = Vector::new($this->customOperationService->getMethod())->any(fn ($x) => $x->getName() === 'Cancel');
             $this->hasCustomOpDelete = Vector::new($this->customOperationService->getMethod())->any(fn ($x) => $x->getName() === 'Delete');
-            
+
             // Assuming the custom operations service client is in the same namespace as the client to generate.
             $cname = $this->customOperationService->getName() . 'Client';
             $this->customOperationServiceClientType = Type::fromName("{$this->namespace}\\{$cname}");
@@ -286,6 +286,7 @@ class ServiceDetails
         // Less elegant because  PHP 7.2 doesn't support multiline lambdas.
         $mixinMethods = $mixinService->methods
           ->filter(fn ($m) => !in_array($m->name, $rpcNameBlocklist))
+          ->filter(fn ($m) => !in_array($m->name, $this->methods->map(fn ($m) => $m->name)->toArray()))
           ->orderBy(fn ($m) => $m->name);
         foreach ($mixinMethods as $method) {
             $method->mixinServiceFullname = $mixinService->serviceName;

--- a/src/Generation/ServiceDetails.php
+++ b/src/Generation/ServiceDetails.php
@@ -285,7 +285,9 @@ class ServiceDetails
     {
         // Less elegant because  PHP 7.2 doesn't support multiline lambdas.
         $mixinMethods = $mixinService->methods
+          // remove methods specified by the blocklist
           ->filter(fn ($m) => !in_array($m->name, $rpcNameBlocklist))
+          // remove methods that are already defined in this service.
           ->filter(fn ($m) => !in_array($m->name, $this->methods->map(fn ($m) => $m->name)->toArray()))
           ->orderBy(fn ($m) => $m->name);
         foreach ($mixinMethods as $method) {

--- a/tests/Integration/apis/kms/v1/cloudkms_test_mixins_v1.yaml
+++ b/tests/Integration/apis/kms/v1/cloudkms_test_mixins_v1.yaml
@@ -6,8 +6,7 @@ title: Cloud Key Management Service (KMS) API
 apis:
 - name: google.cloud.kms.v1.KeyManagementService
 - name: google.cloud.location.Locations
-# - name: google.iam.v1.IAMPolicy
-# Commented-out to ensure unlisted mixin methods with Bazel deps aren't generated.
+- name: google.iam.v1.IAMPolicy
 
 types:
 - name: google.cloud.kms.v1.LocationMetadata

--- a/tests/Integration/apis/kms/v1/service.proto
+++ b/tests/Integration/apis/kms/v1/service.proto
@@ -350,23 +350,6 @@ service KeyManagementService {
       body: "*"
     };
   }
-
-  // Gets the access control policy for a contentitem resource. A `NOT_FOUND`
-  // error is returned if the resource does not exist. An empty policy is
-  // returned if the resource exists but does not have a policy set on it.
-  //
-  // Caller must have Google IAM `dataplex.content.getIamPolicy` permission
-  // on the resource.
-  rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest)
-      returns (google.iam.v1.Policy) {
-    option (google.api.http) = {
-      get: "/v1/{resource=projects/*/locations/*/lakes/*/contentitems/**}:getIamPolicy"
-      additional_bindings {
-        get: "/v1/{resource=projects/*/locations/*/lakes/*/content/**}:getIamPolicy"
-      }
-    };
-    option (google.api.method_signature) = "resource";
-  }
 }
 
 // Request message for

--- a/tests/Integration/apis/kms/v1/service.proto
+++ b/tests/Integration/apis/kms/v1/service.proto
@@ -350,6 +350,23 @@ service KeyManagementService {
       body: "*"
     };
   }
+
+  // Gets the access control policy for a contentitem resource. A `NOT_FOUND`
+  // error is returned if the resource does not exist. An empty policy is
+  // returned if the resource exists but does not have a policy set on it.
+  //
+  // Caller must have Google IAM `dataplex.content.getIamPolicy` permission
+  // on the resource.
+  rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest)
+      returns (google.iam.v1.Policy) {
+    option (google.api.http) = {
+      get: "/v1/{resource=projects/*/locations/*/lakes/*/contentitems/**}:getIamPolicy"
+      additional_bindings {
+        get: "/v1/{resource=projects/*/locations/*/lakes/*/content/**}:getIamPolicy"
+      }
+    };
+    option (google.api.method_signature) = "resource";
+  }
 }
 
 // Request message for

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/set_iam_policy.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/set_iam_policy.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START cloudkms_v1_generated_KeyManagementService_SetIamPolicy_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Iam\V1\Policy;
+use Google\Cloud\Kms\V1\KeyManagementServiceClient;
+
+/**
+ * Sets the access control policy on the specified resource. Replaces
+any existing policy.
+Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
+errors.
+ *
+ * @param string $resource REQUIRED: The resource for which the policy is being specified.
+ *                         See the operation documentation for the appropriate value for this field.
+ */
+function set_iam_policy_sample(string $resource): void
+{
+    // Create a client.
+    $keyManagementServiceClient = new KeyManagementServiceClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $policy = new Policy();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var Policy $response */
+        $response = $keyManagementServiceClient->setIamPolicy($resource, $policy);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $resource = '[RESOURCE]';
+
+    set_iam_policy_sample($resource);
+}
+// [END cloudkms_v1_generated_KeyManagementService_SetIamPolicy_sync]

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/test_iam_permissions.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START cloudkms_v1_generated_KeyManagementService_TestIamPermissions_sync]
+use Google\ApiCore\ApiException;
+use Google\Cloud\Iam\V1\TestIamPermissionsResponse;
+use Google\Cloud\Kms\V1\KeyManagementServiceClient;
+
+/**
+ * Returns permissions that a caller has on the specified resource. If the
+resource does not exist, this will return an empty set of
+permissions, not a `NOT_FOUND` error.
+Note: This operation is designed to be used for building
+permission-aware UIs and command-line tools, not for authorization
+checking. This operation may "fail open" without warning.
+ *
+ * @param string $resource           REQUIRED: The resource for which the policy detail is being requested.
+ *                                   See the operation documentation for the appropriate value for this field.
+ * @param string $permissionsElement The set of permissions to check for the `resource`. Permissions with
+ *                                   wildcards (such as '*' or 'storage.*') are not allowed. For more
+ *                                   information see
+ *                                   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+ */
+function test_iam_permissions_sample(string $resource, string $permissionsElement): void
+{
+    // Create a client.
+    $keyManagementServiceClient = new KeyManagementServiceClient();
+
+    // Prepare any non-scalar elements to be passed along with the request.
+    $permissions = [$permissionsElement,];
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var TestIamPermissionsResponse $response */
+        $response = $keyManagementServiceClient->testIamPermissions($resource, $permissions);
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+
+/**
+ * Helper to execute the sample.
+ *
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function callSample(): void
+{
+    $resource = '[RESOURCE]';
+    $permissionsElement = '[PERMISSIONS]';
+
+    test_iam_permissions_sample($resource, $permissionsElement);
+}
+// [END cloudkms_v1_generated_KeyManagementService_TestIamPermissions_sync]

--- a/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
@@ -37,6 +37,9 @@ use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Iam\V1\GetIamPolicyRequest;
 use Google\Cloud\Iam\V1\GetPolicyOptions;
 use Google\Cloud\Iam\V1\Policy;
+use Google\Cloud\Iam\V1\SetIamPolicyRequest;
+use Google\Cloud\Iam\V1\TestIamPermissionsRequest;
+use Google\Cloud\Iam\V1\TestIamPermissionsResponse;
 use Google\Cloud\Kms\V1\AsymmetricDecryptRequest;
 use Google\Cloud\Kms\V1\AsymmetricDecryptResponse;
 use Google\Cloud\Kms\V1\AsymmetricSignRequest;
@@ -1993,6 +1996,106 @@ class KeyManagementServiceGapicClient
         $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
         $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
         return $this->startCall('UpdateCryptoKeyVersion', CryptoKeyVersion::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     * Sets the access control policy on the specified resource. Replaces
+    any existing policy.
+    Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
+    errors.
+     *
+     * Sample code:
+     * ```
+     * $keyManagementServiceClient = new KeyManagementServiceClient();
+     * try {
+     *     $resource = 'resource';
+     *     $policy = new Policy();
+     *     $response = $keyManagementServiceClient->setIamPolicy($resource, $policy);
+     * } finally {
+     *     $keyManagementServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string $resource     REQUIRED: The resource for which the policy is being specified.
+     *                             See the operation documentation for the appropriate value for this field.
+     * @param Policy $policy       REQUIRED: The complete policy to be applied to the `resource`. The size of
+     *                             the policy is limited to a few 10s of KB. An empty policy is a
+     *                             valid policy but certain Cloud Platform services (such as Projects)
+     *                             might reject them.
+     * @param array  $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Iam\V1\Policy
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function setIamPolicy($resource, $policy, array $optionalArgs = [])
+    {
+        $request = new SetIamPolicyRequest();
+        $requestParamHeaders = [];
+        $request->setResource($resource);
+        $request->setPolicy($policy);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('SetIamPolicy', Policy::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
+    }
+
+    /**
+     * Returns permissions that a caller has on the specified resource. If the
+    resource does not exist, this will return an empty set of
+    permissions, not a `NOT_FOUND` error.
+    Note: This operation is designed to be used for building
+    permission-aware UIs and command-line tools, not for authorization
+    checking. This operation may "fail open" without warning.
+     *
+     * Sample code:
+     * ```
+     * $keyManagementServiceClient = new KeyManagementServiceClient();
+     * try {
+     *     $resource = 'resource';
+     *     $permissions = [];
+     *     $response = $keyManagementServiceClient->testIamPermissions($resource, $permissions);
+     * } finally {
+     *     $keyManagementServiceClient->close();
+     * }
+     * ```
+     *
+     * @param string   $resource     REQUIRED: The resource for which the policy detail is being requested.
+     *                               See the operation documentation for the appropriate value for this field.
+     * @param string[] $permissions  The set of permissions to check for the `resource`. Permissions with
+     *                               wildcards (such as '*' or 'storage.*') are not allowed. For more
+     *                               information see
+     *                               [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+     * @param array    $optionalArgs {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     *
+     * @return \Google\Cloud\Iam\V1\TestIamPermissionsResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function testIamPermissions($resource, $permissions, array $optionalArgs = [])
+    {
+        $request = new TestIamPermissionsRequest();
+        $requestParamHeaders = [];
+        $request->setResource($resource);
+        $request->setPermissions($permissions);
+        $requestParamHeaders['resource'] = $resource;
+        $requestParams = new RequestParamsHeaderDescriptor($requestParamHeaders);
+        $optionalArgs['headers'] = isset($optionalArgs['headers']) ? array_merge($requestParams->getHeader(), $optionalArgs['headers']) : $requestParams->getHeader();
+        return $this->startCall('TestIamPermissions', TestIamPermissionsResponse::class, $optionalArgs, $request, Call::UNARY_CALL, 'google.iam.v1.IAMPolicy')->wait();
     }
 
     /**

--- a/tests/Integration/goldens/kms/src/V1/gapic_metadata.json
+++ b/tests/Integration/goldens/kms/src/V1/gapic_metadata.json
@@ -130,6 +130,16 @@
                                 "updateCryptoKeyVersion"
                             ]
                         },
+                        "SetIamPolicy": {
+                            "methods": [
+                                "setIamPolicy"
+                            ]
+                        },
+                        "TestIamPermissions": {
+                            "methods": [
+                                "testIamPermissions"
+                            ]
+                        },
                         "GetLocation": {
                             "methods": [
                                 "getLocation"

--- a/tests/Integration/goldens/kms/src/V1/resources/key_management_service_client_config.json
+++ b/tests/Integration/goldens/kms/src/V1/resources/key_management_service_client_config.json
@@ -159,6 +159,16 @@
                     "retry_codes_name": "retry_policy_1_codes",
                     "retry_params_name": "retry_policy_1_params"
                 },
+                "SetIamPolicy": {
+                    "timeout_millis": 60000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
+                "TestIamPermissions": {
+                    "timeout_millis": 60000,
+                    "retry_codes_name": "retry_policy_1_codes",
+                    "retry_params_name": "retry_policy_1_params"
+                },
                 "GetLocation": {
                     "timeout_millis": 60000,
                     "retry_codes_name": "no_retry_codes",

--- a/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
+++ b/tests/Integration/goldens/kms/tests/Unit/V1/KeyManagementServiceClientTest.php
@@ -27,6 +27,7 @@ use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Testing\GeneratedTest;
 use Google\ApiCore\Testing\MockTransport;
 use Google\Cloud\Iam\V1\Policy;
+use Google\Cloud\Iam\V1\TestIamPermissionsResponse;
 use Google\Cloud\Kms\V1\AsymmetricDecryptResponse;
 use Google\Cloud\Kms\V1\AsymmetricSignResponse;
 use Google\Cloud\Kms\V1\CryptoKey;
@@ -1660,6 +1661,134 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $updateMask = new FieldMask();
         try {
             $gapicClient->updateCryptoKeyVersion($cryptoKeyVersion, $updateMask);
+            // If the $gapicClient method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function setIamPolicyTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $version = 351608024;
+        $etag = '21';
+        $expectedResponse = new Policy();
+        $expectedResponse->setVersion($version);
+        $expectedResponse->setEtag($etag);
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $resource = 'resource-341064690';
+        $policy = new Policy();
+        $response = $gapicClient->setIamPolicy($resource, $policy);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.iam.v1.IAMPolicy/SetIamPolicy', $actualFuncCall);
+        $actualValue = $actualRequestObject->getResource();
+        $this->assertProtobufEquals($resource, $actualValue);
+        $actualValue = $actualRequestObject->getPolicy();
+        $this->assertProtobufEquals($policy, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function setIamPolicyExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $resource = 'resource-341064690';
+        $policy = new Policy();
+        try {
+            $gapicClient->setIamPolicy($resource, $policy);
+            // If the $gapicClient method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function testIamPermissionsTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new TestIamPermissionsResponse();
+        $transport->addResponse($expectedResponse);
+        // Mock request
+        $resource = 'resource-341064690';
+        $permissions = [];
+        $response = $gapicClient->testIamPermissions($resource, $permissions);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/google.iam.v1.IAMPolicy/TestIamPermissions', $actualFuncCall);
+        $actualValue = $actualRequestObject->getResource();
+        $this->assertProtobufEquals($resource, $actualValue);
+        $actualValue = $actualRequestObject->getPermissions();
+        $this->assertProtobufEquals($permissions, $actualValue);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function testIamPermissionsExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        // Mock request
+        $resource = 'resource-341064690';
+        $permissions = [];
+        try {
+            $gapicClient->testIamPermissions($resource, $permissions);
             // If the $gapicClient method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {


### PR DESCRIPTION
fixes #561

This is the correct way to handle it according to https://google.aip.dev/client-libraries/4234#overriding-a-duplicate-rpc