### PR TITLE
fix: required-to-optional for Spanner.CommitRequest

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -130,6 +130,7 @@ class FieldDetails
         'google.longrunning.GetOperationRequest'    => ['name'],
         'google.longrunning.ListOperationsRequest'  => ['name', 'filter'],
         'google.pubsub.v1.DeleteSchemaRevisionRequest' => ['revision_id'],
+        'google.spanner.v1.CommitRequest' => ['mutations'],
     ];
 
     /**


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-php/pull/5930
See https://github.com/googleapis/google-cloud-php/pull/5916