### PR TITLE
fix(bazel): exclude fragment files from package

### DIFF
--- a/rules_php_gapic/php_gapic_pkg.bzl
+++ b/rules_php_gapic/php_gapic_pkg.bzl
@@ -63,7 +63,7 @@ def _php_gapic_src_pkg_impl(ctx):
     done
     {post_processor} --input {package_dir_path}
     cd {package_dir_path}/{tar_cd_suffix}
-    tar -zchpf {tar_prefix}/{package_dir}.tar.gz {tar_prefix}/*
+    tar --exclude=*.build.txt  -zchpf {tar_prefix}/{package_dir}.tar.gz {tar_prefix}/*
     cd -
     mv {package_dir_path}/{package_dir}.tar.gz {pkg}
     rm -rf {package_dir_path}


### PR DESCRIPTION
This is the easiest/dirtiest way to exclude the generated fragment `.build.txt` files. It also makes it easier to debug later on b.c the fragments aren't deleted from the archive generated by `php_gapic_library`.

The "post-processor" version of this would be to `rm` the fragment file after applying it to the protobuf-php file, but I'm not sure we want to remove it, as this will make future debugging a tad more difficult. Open to suggestions though e.g. only delete the fragment if it was successfully applied.