### PR TITLE
fix(v2): final empty classes, internal base classes

### DIFF
--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -155,9 +155,9 @@ abstract class AST
      *
      * @return PhpClass
      */
-    public static function class(Type $type, ?ResolvedType $extends = null): PhpClass
+    public static function class(Type $type, ?ResolvedType $extends = null, bool $final = false): PhpClass
     {
-        return new PhpClass($type, $extends);
+        return new PhpClass($type, $extends, $final);
     }
 
     /**

--- a/src/Ast/PhpClass.php
+++ b/src/Ast/PhpClass.php
@@ -28,12 +28,13 @@ final class PhpClass extends AST
 {
     use HasPhpDoc;
 
-    public function __construct(Type $type, ?ResolvedType $extends)
+    public function __construct(Type $type, ?ResolvedType $extends, bool $final)
     {
         $this->type = $type;
         $this->extends = $extends;
         $this->traits = Set::new();
         $this->members = Vector::new();
+        $this->final = $final;
     }
 
     /** @var Type *Readonly* The type of this class. */
@@ -44,6 +45,9 @@ final class PhpClass extends AST
 
     /** @var Vector *Readonly* Vector of PhpClassMember; all members of this class. */
     public Vector $members;
+
+    /** @var bool *Readonly* Flag indicating if the class is final or not. */
+    public bool $final;
 
     /**
      * Create a class with an additional trait.
@@ -94,9 +98,10 @@ final class PhpClass extends AST
     public function toCode(): string
     {
         $extends = is_null($this->extends) ? '' : " extends {$this->extends->toCode()}";
+        $class = $this->final ? 'final class' : 'class';
         return
             $this->phpDocToCode() .
-            "class {$this->type->name}{$extends}\n" .
+            "{$class} {$this->type->name}{$extends}\n" .
             "{\n" .
             $this->traits->toVector()->map(fn ($x) => "use {$x->toCode()};\n")->join() .
             (count($this->traits) >= 1 ? "\n" : '') .

--- a/src/Ast/PhpDoc.php
+++ b/src/Ast/PhpDoc.php
@@ -181,6 +181,21 @@ abstract class PhpDoc
     }
 
     /**
+     * Add the @internal tag to the PHP doc block.
+     *
+     * @return PhpDoc
+     */
+    public static function internal(): PhpDoc
+    {
+        return new class extends PhpDoc {
+            protected function toLines(Map $info): Vector
+            {
+                return Vector::new(['@internal']);
+            }
+        };
+    }
+
+    /**
      * Add the @experimental tag to the PHP doc block.
      *
      * @return PhpDoc

--- a/src/Generation/EmptyClientV2Generator.php
+++ b/src/Generation/EmptyClientV2Generator.php
@@ -51,7 +51,7 @@ class EmptyClientV2Generator
 
     private function generateClass(): PhpClass
     {
-        return AST::class($this->serviceDetails->emptyClientV2Type, $this->ctx->type($this->serviceDetails->gapicClientV2Type))
+        return AST::class($this->serviceDetails->emptyClientV2Type, $this->ctx->type($this->serviceDetails->gapicClientV2Type), /* final */ true)
             ->withPhpDoc(PhpDoc::block(PhpDoc::inherit()))
             ->withMember(AST::comment(PhpDoc::text(
                 'This class is intentionally empty, and is intended to hold manual additions to the generated',

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -118,6 +118,7 @@ class GapicClientV2Generator
                         'a parseName method to extract the individual identifiers contained within formatted names ' .
                         'that are returned by the API.'
                     ),
+                PhpDoc::internal(),
                 $this->serviceDetails->isGa() ? null : PhpDoc::experimental(),
                 !$this->serviceDetails->isDeprecated ? null : PhpDoc::deprecated(ServiceDetails::DEPRECATED_MSG),
                 $this->serviceDetails->streamingOnly ? null : $this->magicAsyncDocs(),

--- a/tests/Integration/goldens/asset/src/V1/Client/AssetServiceClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/AssetServiceClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Asset\V1\Client;
 use Google\Cloud\Asset\V1\Client\BaseClient\AssetServiceBaseClient;
 
 /** {@inheritdoc} */
-class AssetServiceClient extends AssetServiceBaseClient
+final class AssetServiceClient extends AssetServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see AssetServiceBaseClient} class.

--- a/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
@@ -67,6 +67,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface analyzeIamPolicyAsync(AnalyzeIamPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface analyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest $request, array $optionalArgs = [])
  * @method PromiseInterface analyzeMoveAsync(AnalyzeMoveRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/compute_small/src/V1/Client/AddressesClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/AddressesClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Compute\V1\Client;
 use Google\Cloud\Compute\V1\Client\BaseClient\AddressesBaseClient;
 
 /** {@inheritdoc} */
-class AddressesClient extends AddressesBaseClient
+final class AddressesClient extends AddressesBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see AddressesBaseClient} class.

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface aggregatedListAsync(AggregatedListAddressesRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteAsync(DeleteAddressRequest $request, array $optionalArgs = [])
  * @method PromiseInterface insertAsync(InsertAddressRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
@@ -41,6 +41,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface getAsync(GetRegionOperationRequest $request, array $optionalArgs = [])
  */
 class RegionOperationsBaseClient

--- a/tests/Integration/goldens/compute_small/src/V1/Client/RegionOperationsClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/RegionOperationsClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Compute\V1\Client;
 use Google\Cloud\Compute\V1\Client\BaseClient\RegionOperationsBaseClient;
 
 /** {@inheritdoc} */
-class RegionOperationsClient extends RegionOperationsBaseClient
+final class RegionOperationsClient extends RegionOperationsBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see RegionOperationsBaseClient} class.

--- a/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
@@ -80,6 +80,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface cancelOperationAsync(CancelOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface completeIPRotationAsync(CompleteIPRotationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createClusterAsync(CreateClusterRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/container/src/V1/Client/ClusterManagerClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/ClusterManagerClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Container\V1\Client;
 use Google\Cloud\Container\V1\Client\BaseClient\ClusterManagerBaseClient;
 
 /** {@inheritdoc} */
-class ClusterManagerClient extends ClusterManagerBaseClient
+final class ClusterManagerClient extends ClusterManagerBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ClusterManagerBaseClient} class.

--- a/tests/Integration/goldens/dataproc/src/V1/Client/AutoscalingPolicyServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/AutoscalingPolicyServiceClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Dataproc\V1\Client;
 use Google\Cloud\Dataproc\V1\Client\BaseClient\AutoscalingPolicyServiceBaseClient;
 
 /** {@inheritdoc} */
-class AutoscalingPolicyServiceClient extends AutoscalingPolicyServiceBaseClient
+final class AutoscalingPolicyServiceClient extends AutoscalingPolicyServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see AutoscalingPolicyServiceBaseClient} class.

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
@@ -53,6 +53,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createAutoscalingPolicyAsync(CreateAutoscalingPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteAutoscalingPolicyAsync(DeleteAutoscalingPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getAutoscalingPolicyAsync(GetAutoscalingPolicyRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
@@ -61,6 +61,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createClusterAsync(CreateClusterRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteClusterAsync(DeleteClusterRequest $request, array $optionalArgs = [])
  * @method PromiseInterface diagnoseClusterAsync(DiagnoseClusterRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
@@ -50,6 +50,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface cancelJobAsync(CancelJobRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteJobAsync(DeleteJobRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getJobAsync(GetJobRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
@@ -59,6 +59,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createWorkflowTemplateAsync(CreateWorkflowTemplateRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteWorkflowTemplateAsync(DeleteWorkflowTemplateRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getWorkflowTemplateAsync(GetWorkflowTemplateRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/ClusterControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/ClusterControllerClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Dataproc\V1\Client;
 use Google\Cloud\Dataproc\V1\Client\BaseClient\ClusterControllerBaseClient;
 
 /** {@inheritdoc} */
-class ClusterControllerClient extends ClusterControllerBaseClient
+final class ClusterControllerClient extends ClusterControllerBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ClusterControllerBaseClient} class.

--- a/tests/Integration/goldens/dataproc/src/V1/Client/JobControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/JobControllerClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Dataproc\V1\Client;
 use Google\Cloud\Dataproc\V1\Client\BaseClient\JobControllerBaseClient;
 
 /** {@inheritdoc} */
-class JobControllerClient extends JobControllerBaseClient
+final class JobControllerClient extends JobControllerBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see JobControllerBaseClient} class.

--- a/tests/Integration/goldens/dataproc/src/V1/Client/WorkflowTemplateServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/WorkflowTemplateServiceClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Dataproc\V1\Client;
 use Google\Cloud\Dataproc\V1\Client\BaseClient\WorkflowTemplateServiceBaseClient;
 
 /** {@inheritdoc} */
-class WorkflowTemplateServiceClient extends WorkflowTemplateServiceBaseClient
+final class WorkflowTemplateServiceClient extends WorkflowTemplateServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see WorkflowTemplateServiceBaseClient} class.

--- a/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
@@ -66,6 +66,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface callFunctionAsync(CallFunctionRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createFunctionAsync(CreateFunctionRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteFunctionAsync(DeleteFunctionRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Functions\V1\Client;
 use Google\Cloud\Functions\V1\Client\BaseClient\CloudFunctionsServiceBaseClient;
 
 /** {@inheritdoc} */
-class CloudFunctionsServiceClient extends CloudFunctionsServiceBaseClient
+final class CloudFunctionsServiceClient extends CloudFunctionsServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CloudFunctionsServiceBaseClient} class.

--- a/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
@@ -68,6 +68,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface getIamPolicyAsync(GetIamPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface setIamPolicyAsync(SetIamPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface testIamPermissionsAsync(TestIamPermissionsRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/iam/src/V1/Client/IAMPolicyClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/IAMPolicyClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Iam\V1\Client;
 use Google\Cloud\Iam\V1\Client\BaseClient\IAMPolicyBaseClient;
 
 /** {@inheritdoc} */
-class IAMPolicyClient extends IAMPolicyBaseClient
+final class IAMPolicyClient extends IAMPolicyBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see IAMPolicyBaseClient} class.

--- a/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
@@ -94,6 +94,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface asymmetricDecryptAsync(AsymmetricDecryptRequest $request, array $optionalArgs = [])
  * @method PromiseInterface asymmetricSignAsync(AsymmetricSignRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createCryptoKeyAsync(CreateCryptoKeyRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/kms/src/V1/Client/KeyManagementServiceClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/KeyManagementServiceClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Kms\V1\Client;
 use Google\Cloud\Kms\V1\Client\BaseClient\KeyManagementServiceBaseClient;
 
 /** {@inheritdoc} */
-class KeyManagementServiceClient extends KeyManagementServiceBaseClient
+final class KeyManagementServiceClient extends KeyManagementServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see KeyManagementServiceBaseClient} class.

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
@@ -74,6 +74,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createBucketAsync(CreateBucketRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createExclusionAsync(CreateExclusionRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createSinkAsync(CreateSinkRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
@@ -53,6 +53,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface deleteLogAsync(DeleteLogRequest $request, array $optionalArgs = [])
  * @method PromiseInterface listLogEntriesAsync(ListLogEntriesRequest $request, array $optionalArgs = [])
  * @method PromiseInterface listLogsAsync(ListLogsRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
@@ -52,6 +52,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createLogMetricAsync(CreateLogMetricRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteLogMetricAsync(DeleteLogMetricRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getLogMetricAsync(GetLogMetricRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/logging/src/V2/Client/ConfigServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/ConfigServiceV2Client.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Logging\V2\Client;
 use Google\Cloud\Logging\V2\Client\BaseClient\ConfigServiceV2BaseClient;
 
 /** {@inheritdoc} */
-class ConfigServiceV2Client extends ConfigServiceV2BaseClient
+final class ConfigServiceV2Client extends ConfigServiceV2BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ConfigServiceV2BaseClient} class.

--- a/tests/Integration/goldens/logging/src/V2/Client/LoggingServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/LoggingServiceV2Client.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Logging\V2\Client;
 use Google\Cloud\Logging\V2\Client\BaseClient\LoggingServiceV2BaseClient;
 
 /** {@inheritdoc} */
-class LoggingServiceV2Client extends LoggingServiceV2BaseClient
+final class LoggingServiceV2Client extends LoggingServiceV2BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see LoggingServiceV2BaseClient} class.

--- a/tests/Integration/goldens/logging/src/V2/Client/MetricsServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/MetricsServiceV2Client.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Logging\V2\Client;
 use Google\Cloud\Logging\V2\Client\BaseClient\MetricsServiceV2BaseClient;
 
 /** {@inheritdoc} */
-class MetricsServiceV2Client extends MetricsServiceV2BaseClient
+final class MetricsServiceV2Client extends MetricsServiceV2BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see MetricsServiceV2BaseClient} class.

--- a/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
@@ -73,6 +73,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createInstanceAsync(CreateInstanceRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteInstanceAsync(DeleteInstanceRequest $request, array $optionalArgs = [])
  * @method PromiseInterface exportInstanceAsync(ExportInstanceRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Redis\V1\Client;
 use Google\Cloud\Redis\V1\Client\BaseClient\CloudRedisBaseClient;
 
 /** {@inheritdoc} */
-class CloudRedisClient extends CloudRedisBaseClient
+final class CloudRedisClient extends CloudRedisBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CloudRedisBaseClient} class.

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
@@ -54,6 +54,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface getDefaultBranchAsync(GetDefaultBranchRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
@@ -57,6 +57,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface completeQueryAsync(CompleteQueryRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface predictAsync(PredictRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
@@ -62,6 +62,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface addFulfillmentPlacesAsync(AddFulfillmentPlacesRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
@@ -53,6 +53,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface searchAsync(SearchRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
@@ -58,6 +58,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface collectUserEventAsync(CollectUserEventRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/CatalogServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/CatalogServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\CatalogServiceBaseClient;
 
 /** {@inheritdoc} */
-class CatalogServiceClient extends CatalogServiceBaseClient
+final class CatalogServiceClient extends CatalogServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CatalogServiceBaseClient} class.

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/CompletionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/CompletionServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\CompletionServiceBaseClient;
 
 /** {@inheritdoc} */
-class CompletionServiceClient extends CompletionServiceBaseClient
+final class CompletionServiceClient extends CompletionServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CompletionServiceBaseClient} class.

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/PredictionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/PredictionServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\PredictionServiceBaseClient;
 
 /** {@inheritdoc} */
-class PredictionServiceClient extends PredictionServiceBaseClient
+final class PredictionServiceClient extends PredictionServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see PredictionServiceBaseClient} class.

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ProductServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ProductServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\ProductServiceBaseClient;
 
 /** {@inheritdoc} */
-class ProductServiceClient extends ProductServiceBaseClient
+final class ProductServiceClient extends ProductServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ProductServiceBaseClient} class.

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/SearchServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/SearchServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\SearchServiceBaseClient;
 
 /** {@inheritdoc} */
-class SearchServiceClient extends SearchServiceBaseClient
+final class SearchServiceClient extends SearchServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see SearchServiceBaseClient} class.

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/UserEventServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/UserEventServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\UserEventServiceBaseClient;
 
 /** {@inheritdoc} */
-class UserEventServiceClient extends UserEventServiceBaseClient
+final class UserEventServiceClient extends UserEventServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see UserEventServiceBaseClient} class.

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
@@ -79,6 +79,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface createFindingAsync(CreateFindingRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createNotificationConfigAsync(CreateNotificationConfigRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createSourceAsync(CreateSourceRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\SecurityCenter\V1\Client;
 use Google\Cloud\SecurityCenter\V1\Client\BaseClient\SecurityCenterBaseClient;
 
 /** {@inheritdoc} */
-class SecurityCenterClient extends SecurityCenterBaseClient
+final class SecurityCenterClient extends SecurityCenterBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see SecurityCenterBaseClient} class.

--- a/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
@@ -47,6 +47,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface longRunningRecognizeAsync(LongRunningRecognizeRequest $request, array $optionalArgs = [])
  * @method PromiseInterface recognizeAsync(RecognizeRequest $request, array $optionalArgs = [])
  */

--- a/tests/Integration/goldens/speech/src/V1/Client/SpeechClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/SpeechClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\Speech\V1\Client;
 use Google\Cloud\Speech\V1\Client\BaseClient\SpeechBaseClient;
 
 /** {@inheritdoc} */
-class SpeechClient extends SpeechBaseClient
+final class SpeechClient extends SpeechBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see SpeechBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/ApplicationServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/ApplicationServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\ApplicationServiceBaseClient;
 
 /** {@inheritdoc} */
-class ApplicationServiceClient extends ApplicationServiceBaseClient
+final class ApplicationServiceClient extends ApplicationServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ApplicationServiceBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
@@ -55,6 +55,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface createApplicationAsync(CreateApplicationRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
@@ -54,6 +54,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface createCompanyAsync(CreateCompanyRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface completeQueryAsync(CompleteQueryRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface createClientEventAsync(CreateClientEventRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
@@ -61,6 +61,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface batchCreateJobsAsync(BatchCreateJobsRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
@@ -56,6 +56,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface createProfileAsync(CreateProfileRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
@@ -54,6 +54,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @experimental
  *
  * @method PromiseInterface createTenantAsync(CreateTenantRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/CompanyServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/CompanyServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\CompanyServiceBaseClient;
 
 /** {@inheritdoc} */
-class CompanyServiceClient extends CompanyServiceBaseClient
+final class CompanyServiceClient extends CompanyServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CompanyServiceBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/CompletionClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/CompletionClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\CompletionBaseClient;
 
 /** {@inheritdoc} */
-class CompletionClient extends CompletionBaseClient
+final class CompletionClient extends CompletionBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CompletionBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/EventServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/EventServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\EventServiceBaseClient;
 
 /** {@inheritdoc} */
-class EventServiceClient extends EventServiceBaseClient
+final class EventServiceClient extends EventServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see EventServiceBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/JobServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/JobServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\JobServiceBaseClient;
 
 /** {@inheritdoc} */
-class JobServiceClient extends JobServiceBaseClient
+final class JobServiceClient extends JobServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see JobServiceBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/ProfileServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/ProfileServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\ProfileServiceBaseClient;
 
 /** {@inheritdoc} */
-class ProfileServiceClient extends ProfileServiceBaseClient
+final class ProfileServiceClient extends ProfileServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ProfileServiceBaseClient} class.

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/TenantServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/TenantServiceClient.php
@@ -29,7 +29,7 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\TenantServiceBaseClient;
 
 /** {@inheritdoc} */
-class TenantServiceClient extends TenantServiceBaseClient
+final class TenantServiceClient extends TenantServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see TenantServiceBaseClient} class.

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
@@ -45,6 +45,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface annotateVideoAsync(AnnotateVideoRequest $request, array $optionalArgs = [])
  */
 class VideoIntelligenceServiceBaseClient

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/VideoIntelligenceServiceClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/VideoIntelligenceServiceClient.php
@@ -27,7 +27,7 @@ namespace Google\Cloud\VideoIntelligence\V1\Client;
 use Google\Cloud\VideoIntelligence\V1\Client\BaseClient\VideoIntelligenceServiceBaseClient;
 
 /** {@inheritdoc} */
-class VideoIntelligenceServiceClient extends VideoIntelligenceServiceBaseClient
+final class VideoIntelligenceServiceClient extends VideoIntelligenceServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see VideoIntelligenceServiceBaseClient} class.

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
@@ -42,6 +42,8 @@ use Testing\Basic\Response;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface aMethodAsync(Request $request, array $optionalArgs = [])
  * @method PromiseInterface methodWithArgsAsync(RequestWithArgs $request, array $optionalArgs = [])
  */

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -27,7 +27,7 @@ namespace Testing\Basic\Client;
 use Testing\Basic\Client\BaseClient\BasicBaseClient;
 
 /** {@inheritdoc} */
-class BasicClient extends BasicBaseClient
+final class BasicClient extends BasicBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BaseClient/BasicBidiStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BaseClient/BasicBidiStreamingBaseClient.php
@@ -37,6 +37,8 @@ use Google\Auth\FetchAuthTokenInterface;
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
+ *
+ * @internal
  */
 class BasicBidiStreamingBaseClient
 {

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BasicBidiStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BasicBidiStreamingClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicBidiStreaming\Client;
 use Testing\BasicBidiStreaming\Client\BaseClient\BasicBidiStreamingBaseClient;
 
 /** {@inheritdoc} */
-class BasicBidiStreamingClient extends BasicBidiStreamingBaseClient
+final class BasicBidiStreamingClient extends BasicBidiStreamingBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicBidiStreamingBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BaseClient/BasicClientStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BaseClient/BasicClientStreamingBaseClient.php
@@ -37,6 +37,8 @@ use Google\Auth\FetchAuthTokenInterface;
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
+ *
+ * @internal
  */
 class BasicClientStreamingBaseClient
 {

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BasicClientStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BasicClientStreamingClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicClientStreaming\Client;
 use Testing\BasicClientStreaming\Client\BaseClient\BasicClientStreamingBaseClient;
 
 /** {@inheritdoc} */
-class BasicClientStreamingClient extends BasicClientStreamingBaseClient
+final class BasicClientStreamingClient extends BasicClientStreamingBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicClientStreamingBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryBaseClient.php
@@ -100,6 +100,8 @@ use Testing\BasicDiregapic\UpdateBookRequest;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface addCommentsAsync(AddCommentsRequest $request, array $optionalArgs = [])
  * @method PromiseInterface addTagAsync(AddTagRequest $request, array $optionalArgs = [])
  * @method PromiseInterface archiveBooksAsync(ArchiveBooksRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/LibraryClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/LibraryClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicDiregapic\Client;
 use Testing\BasicDiregapic\Client\BaseClient\LibraryBaseClient;
 
 /** {@inheritdoc} */
-class LibraryClient extends LibraryBaseClient
+final class LibraryClient extends LibraryBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see LibraryBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
@@ -43,6 +43,8 @@ use Testing\BasicLro\Request;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface method1Async(Request $request, array $optionalArgs = [])
  * @method PromiseInterface methodNonLro1Async(Request $request, array $optionalArgs = [])
  * @method PromiseInterface methodNonLro2Async(Request $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BasicLroClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BasicLroClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicLro\Client;
 use Testing\BasicLro\Client\BaseClient\BasicLroBaseClient;
 
 /** {@inheritdoc} */
-class BasicLroClient extends BasicLroBaseClient
+final class BasicLroClient extends BasicLroBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicLroBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
@@ -41,6 +41,8 @@ use Testing\BasicOneof\Response;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface aMethodAsync(Request $request, array $optionalArgs = [])
  */
 class BasicOneofBaseClient

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BasicOneofClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BasicOneofClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicOneof\Client;
 use Testing\BasicOneof\Client\BaseClient\BasicOneofBaseClient;
 
 /** {@inheritdoc} */
-class BasicOneofClient extends BasicOneofBaseClient
+final class BasicOneofClient extends BasicOneofBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicOneofBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
@@ -41,6 +41,8 @@ use Testing\BasicPaginated\Request;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface methodPaginatedAsync(Request $request, array $optionalArgs = [])
  */
 class BasicPaginatedBaseClient

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BasicPaginatedClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BasicPaginatedClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicPaginated\Client;
 use Testing\BasicPaginated\Client\BaseClient\BasicPaginatedBaseClient;
 
 /** {@inheritdoc} */
-class BasicPaginatedClient extends BasicPaginatedBaseClient
+final class BasicPaginatedClient extends BasicPaginatedBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicPaginatedBaseClient} class.

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BaseClient/BasicServerStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BaseClient/BasicServerStreamingBaseClient.php
@@ -39,6 +39,8 @@ use Testing\BasicServerStreaming\Request;
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
+ *
+ * @internal
  */
 class BasicServerStreamingBaseClient
 {

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
@@ -27,7 +27,7 @@ namespace Testing\BasicServerStreaming\Client;
 use Testing\BasicServerStreaming\Client\BaseClient\BasicServerStreamingBaseClient;
 
 /** {@inheritdoc} */
-class BasicServerStreamingClient extends BasicServerStreamingBaseClient
+final class BasicServerStreamingClient extends BasicServerStreamingBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see BasicServerStreamingBaseClient} class.

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
@@ -42,6 +42,8 @@ use Testing\CustomLro\CustomLroOperationsClient;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface createFooAsync(CreateFooRequest $request, array $optionalArgs = [])
  */
 class CustomLroBaseClient

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
@@ -43,6 +43,8 @@ use Testing\CustomLro\GetOperationRequest;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface cancelAsync(CancelOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteAsync(DeleteOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getAsync(GetOperationRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroClient.php
@@ -27,7 +27,7 @@ namespace Testing\CustomLro\Client;
 use Testing\CustomLro\Client\BaseClient\CustomLroBaseClient;
 
 /** {@inheritdoc} */
-class CustomLroClient extends CustomLroBaseClient
+final class CustomLroClient extends CustomLroBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CustomLroBaseClient} class.

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroOperationsClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroOperationsClient.php
@@ -27,7 +27,7 @@ namespace Testing\CustomLro\Client;
 use Testing\CustomLro\Client\BaseClient\CustomLroOperationsBaseClient;
 
 /** {@inheritdoc} */
-class CustomLroOperationsClient extends CustomLroOperationsBaseClient
+final class CustomLroOperationsClient extends CustomLroOperationsBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see CustomLroOperationsBaseClient} class.

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
@@ -41,6 +41,8 @@ use Testing\Deprecated\FibonacciRequest;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @deprecated This class will be removed in the next major version update.
  *
  * @method PromiseInterface fastFibonacciAsync(FibonacciRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/DeprecatedServiceClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/DeprecatedServiceClient.php
@@ -27,7 +27,7 @@ namespace Testing\Deprecated\Client;
 use Testing\Deprecated\Client\BaseClient\DeprecatedServiceBaseClient;
 
 /** {@inheritdoc} */
-class DeprecatedServiceClient extends DeprecatedServiceBaseClient
+final class DeprecatedServiceClient extends DeprecatedServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see DeprecatedServiceBaseClient} class.

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
@@ -41,6 +41,8 @@ use Testing\DisableSnippets\Response;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface method1Async(Request $request, array $optionalArgs = [])
  */
 class DisableSnippetsBaseClient

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/DisableSnippetsClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/DisableSnippetsClient.php
@@ -27,7 +27,7 @@ namespace Testing\DisableSnippets\Client;
 use Testing\DisableSnippets\Client\BaseClient\DisableSnippetsBaseClient;
 
 /** {@inheritdoc} */
-class DisableSnippetsClient extends DisableSnippetsBaseClient
+final class DisableSnippetsClient extends DisableSnippetsBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see DisableSnippetsBaseClient} class.

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
@@ -46,6 +46,8 @@ use Testing\GrpcServiceConfig\Response1;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface method1AAsync(Request1 $request, array $optionalArgs = [])
  * @method PromiseInterface method1BLroAsync(Request1 $request, array $optionalArgs = [])
  * @method PromiseInterface method1CServiceLevelRetryAsync(Request1 $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/GrpcServiceConfigWithRetry1Client.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/GrpcServiceConfigWithRetry1Client.php
@@ -27,7 +27,7 @@ namespace Testing\GrpcServiceConfig\Client;
 use Testing\GrpcServiceConfig\Client\BaseClient\GrpcServiceConfigWithRetry1BaseClient;
 
 /** {@inheritdoc} */
-class GrpcServiceConfigWithRetry1Client extends GrpcServiceConfigWithRetry1BaseClient
+final class GrpcServiceConfigWithRetry1Client extends GrpcServiceConfigWithRetry1BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see GrpcServiceConfigWithRetry1BaseClient} class.

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
@@ -54,6 +54,8 @@ use Testing\ResourceNames\WildcardReferenceRequest;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * @internal
+ *
  * @method PromiseInterface fileLevelChildTypeRefMethodAsync(FileLevelChildTypeRefRequest $request, array $optionalArgs = [])
  * @method PromiseInterface fileLevelTypeRefMethodAsync(FileLevelTypeRefRequest $request, array $optionalArgs = [])
  * @method PromiseInterface multiPatternMethodAsync(MultiPatternRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
@@ -27,7 +27,7 @@ namespace Testing\ResourceNames\Client;
 use Testing\ResourceNames\Client\BaseClient\ResourceNamesBaseClient;
 
 /** {@inheritdoc} */
-class ResourceNamesClient extends ResourceNamesBaseClient
+final class ResourceNamesClient extends ResourceNamesBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see ResourceNamesBaseClient} class.

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
@@ -43,6 +43,8 @@ use Testing\RoutingHeaders\SimpleRequest;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * @internal
+ *
  * @method PromiseInterface deleteMethodAsync(SimpleRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getMethodAsync(SimpleRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getNoPlaceholdersMethodAsync(SimpleRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
@@ -27,7 +27,7 @@ namespace Testing\RoutingHeaders\Client;
 use Testing\RoutingHeaders\Client\BaseClient\RoutingHeadersBaseClient;
 
 /** {@inheritdoc} */
-class RoutingHeadersClient extends RoutingHeadersBaseClient
+final class RoutingHeadersClient extends RoutingHeadersBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to
     // the generated {@see RoutingHeadersBaseClient} class.


### PR DESCRIPTION
Make the `v2` empty "service" clients `final` and the `v2` `BaseClient` classes `@internal`.

Fixes http://b/271286629