### PR TITLE
fix(v2): mark new classes experimental

### DIFF
--- a/src/Generation/EmptyClientV2Generator.php
+++ b/src/Generation/EmptyClientV2Generator.php
@@ -52,7 +52,12 @@ class EmptyClientV2Generator
     private function generateClass(): PhpClass
     {
         return AST::class($this->serviceDetails->emptyClientV2Type, $this->ctx->type($this->serviceDetails->gapicClientV2Type))
-            ->withPhpDoc(PhpDoc::block(PhpDoc::inherit()))
+            ->withPhpDoc(PhpDoc::block(
+                PhpDoc::inherit(),
+                // TODO(): Remove the following two lines when stable.
+                PhpDoc::text('This class is currently experimental and may be subject to changes.'),
+                PhpDoc::experimental()
+            ))
             ->withMember(AST::comment(PhpDoc::text(
                 'This class is intentionally empty, and is intended to hold manual additions to the generated',
                 $this->ctx->type($this->serviceDetails->gapicClientV2Type),

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -118,7 +118,10 @@ class GapicClientV2Generator
                         'a parseName method to extract the individual identifiers contained within formatted names ' .
                         'that are returned by the API.'
                     ),
-                $this->serviceDetails->isGa() ? null : PhpDoc::experimental(),
+                // TODO(): Uncomment this and remove the following two lines when stable.
+                // $this->serviceDetails->isGa() ? null : PhpDoc::experimental(),
+                PhpDoc::text('This class is currently experimental and may be subject to changes.'),
+                PhpDoc::experimental(),
                 !$this->serviceDetails->isDeprecated ? null : PhpDoc::deprecated(ServiceDetails::DEPRECATED_MSG),
                 $this->serviceDetails->streamingOnly ? null : $this->magicAsyncDocs(),
             ))

--- a/tests/Integration/goldens/asset/src/V1/Client/AssetServiceClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/AssetServiceClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Asset\V1\Client;
 
 use Google\Cloud\Asset\V1\Client\BaseClient\AssetServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class AssetServiceClient extends AssetServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
@@ -67,6 +67,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface analyzeIamPolicyAsync(AnalyzeIamPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface analyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest $request, array $optionalArgs = [])
  * @method PromiseInterface analyzeMoveAsync(AnalyzeMoveRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/compute_small/src/V1/Client/AddressesClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/AddressesClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Compute\V1\Client;
 
 use Google\Cloud\Compute\V1\Client\BaseClient\AddressesBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class AddressesClient extends AddressesBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
@@ -49,6 +49,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface aggregatedListAsync(AggregatedListAddressesRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteAsync(DeleteAddressRequest $request, array $optionalArgs = [])
  * @method PromiseInterface insertAsync(InsertAddressRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
@@ -41,6 +41,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface getAsync(GetRegionOperationRequest $request, array $optionalArgs = [])
  */
 class RegionOperationsBaseClient

--- a/tests/Integration/goldens/compute_small/src/V1/Client/RegionOperationsClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/RegionOperationsClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Compute\V1\Client;
 
 use Google\Cloud\Compute\V1\Client\BaseClient\RegionOperationsBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class RegionOperationsClient extends RegionOperationsBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
@@ -80,6 +80,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface cancelOperationAsync(CancelOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface completeIPRotationAsync(CompleteIPRotationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createClusterAsync(CreateClusterRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/container/src/V1/Client/ClusterManagerClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/ClusterManagerClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Container\V1\Client;
 
 use Google\Cloud\Container\V1\Client\BaseClient\ClusterManagerBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ClusterManagerClient extends ClusterManagerBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/dataproc/src/V1/Client/AutoscalingPolicyServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/AutoscalingPolicyServiceClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Dataproc\V1\Client;
 
 use Google\Cloud\Dataproc\V1\Client\BaseClient\AutoscalingPolicyServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class AutoscalingPolicyServiceClient extends AutoscalingPolicyServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
@@ -53,6 +53,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createAutoscalingPolicyAsync(CreateAutoscalingPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteAutoscalingPolicyAsync(DeleteAutoscalingPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getAutoscalingPolicyAsync(GetAutoscalingPolicyRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
@@ -61,6 +61,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createClusterAsync(CreateClusterRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteClusterAsync(DeleteClusterRequest $request, array $optionalArgs = [])
  * @method PromiseInterface diagnoseClusterAsync(DiagnoseClusterRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
@@ -50,6 +50,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface cancelJobAsync(CancelJobRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteJobAsync(DeleteJobRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getJobAsync(GetJobRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
@@ -59,6 +59,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createWorkflowTemplateAsync(CreateWorkflowTemplateRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteWorkflowTemplateAsync(DeleteWorkflowTemplateRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getWorkflowTemplateAsync(GetWorkflowTemplateRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/dataproc/src/V1/Client/ClusterControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/ClusterControllerClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Dataproc\V1\Client;
 
 use Google\Cloud\Dataproc\V1\Client\BaseClient\ClusterControllerBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ClusterControllerClient extends ClusterControllerBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/dataproc/src/V1/Client/JobControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/JobControllerClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Dataproc\V1\Client;
 
 use Google\Cloud\Dataproc\V1\Client\BaseClient\JobControllerBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class JobControllerClient extends JobControllerBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/dataproc/src/V1/Client/WorkflowTemplateServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/WorkflowTemplateServiceClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Dataproc\V1\Client;
 
 use Google\Cloud\Dataproc\V1\Client\BaseClient\WorkflowTemplateServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class WorkflowTemplateServiceClient extends WorkflowTemplateServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
@@ -66,6 +66,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface callFunctionAsync(CallFunctionRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createFunctionAsync(CreateFunctionRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteFunctionAsync(DeleteFunctionRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Functions\V1\Client;
 
 use Google\Cloud\Functions\V1\Client\BaseClient\CloudFunctionsServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CloudFunctionsServiceClient extends CloudFunctionsServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
@@ -68,6 +68,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface getIamPolicyAsync(GetIamPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface setIamPolicyAsync(SetIamPolicyRequest $request, array $optionalArgs = [])
  * @method PromiseInterface testIamPermissionsAsync(TestIamPermissionsRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/iam/src/V1/Client/IAMPolicyClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/IAMPolicyClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Iam\V1\Client;
 
 use Google\Cloud\Iam\V1\Client\BaseClient\IAMPolicyBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class IAMPolicyClient extends IAMPolicyBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
@@ -94,6 +94,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface asymmetricDecryptAsync(AsymmetricDecryptRequest $request, array $optionalArgs = [])
  * @method PromiseInterface asymmetricSignAsync(AsymmetricSignRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createCryptoKeyAsync(CreateCryptoKeyRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/kms/src/V1/Client/KeyManagementServiceClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/KeyManagementServiceClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Kms\V1\Client;
 
 use Google\Cloud\Kms\V1\Client\BaseClient\KeyManagementServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class KeyManagementServiceClient extends KeyManagementServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
@@ -74,6 +74,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createBucketAsync(CreateBucketRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createExclusionAsync(CreateExclusionRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createSinkAsync(CreateSinkRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
@@ -53,6 +53,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface deleteLogAsync(DeleteLogRequest $request, array $optionalArgs = [])
  * @method PromiseInterface listLogEntriesAsync(ListLogEntriesRequest $request, array $optionalArgs = [])
  * @method PromiseInterface listLogsAsync(ListLogsRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
@@ -52,6 +52,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createLogMetricAsync(CreateLogMetricRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteLogMetricAsync(DeleteLogMetricRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getLogMetricAsync(GetLogMetricRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/logging/src/V2/Client/ConfigServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/ConfigServiceV2Client.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Logging\V2\Client;
 
 use Google\Cloud\Logging\V2\Client\BaseClient\ConfigServiceV2BaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ConfigServiceV2Client extends ConfigServiceV2BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/logging/src/V2/Client/LoggingServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/LoggingServiceV2Client.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Logging\V2\Client;
 
 use Google\Cloud\Logging\V2\Client\BaseClient\LoggingServiceV2BaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class LoggingServiceV2Client extends LoggingServiceV2BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/logging/src/V2/Client/MetricsServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/MetricsServiceV2Client.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Logging\V2\Client;
 
 use Google\Cloud\Logging\V2\Client\BaseClient\MetricsServiceV2BaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class MetricsServiceV2Client extends MetricsServiceV2BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
@@ -73,6 +73,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createInstanceAsync(CreateInstanceRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteInstanceAsync(DeleteInstanceRequest $request, array $optionalArgs = [])
  * @method PromiseInterface exportInstanceAsync(ExportInstanceRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Redis\V1\Client;
 
 use Google\Cloud\Redis\V1\Client\BaseClient\CloudRedisBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CloudRedisClient extends CloudRedisBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
@@ -54,6 +54,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface getDefaultBranchAsync(GetDefaultBranchRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
@@ -57,6 +57,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface completeQueryAsync(CompleteQueryRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface predictAsync(PredictRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
@@ -62,6 +62,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface addFulfillmentPlacesAsync(AddFulfillmentPlacesRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
@@ -53,6 +53,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface searchAsync(SearchRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
@@ -58,6 +58,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface collectUserEventAsync(CollectUserEventRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/CatalogServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/CatalogServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\CatalogServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CatalogServiceClient extends CatalogServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/CompletionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/CompletionServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\CompletionServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CompletionServiceClient extends CompletionServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/PredictionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/PredictionServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\PredictionServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class PredictionServiceClient extends PredictionServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ProductServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ProductServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\ProductServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ProductServiceClient extends ProductServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/SearchServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/SearchServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\SearchServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class SearchServiceClient extends SearchServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/UserEventServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/UserEventServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Retail\V2alpha\Client;
 
 use Google\Cloud\Retail\V2alpha\Client\BaseClient\UserEventServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class UserEventServiceClient extends UserEventServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
@@ -79,6 +79,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createFindingAsync(CreateFindingRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createNotificationConfigAsync(CreateNotificationConfigRequest $request, array $optionalArgs = [])
  * @method PromiseInterface createSourceAsync(CreateSourceRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\SecurityCenter\V1\Client;
 
 use Google\Cloud\SecurityCenter\V1\Client\BaseClient\SecurityCenterBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class SecurityCenterClient extends SecurityCenterBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
@@ -47,6 +47,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface longRunningRecognizeAsync(LongRunningRecognizeRequest $request, array $optionalArgs = [])
  * @method PromiseInterface recognizeAsync(RecognizeRequest $request, array $optionalArgs = [])
  */

--- a/tests/Integration/goldens/speech/src/V1/Client/SpeechClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/SpeechClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\Speech\V1\Client;
 
 use Google\Cloud\Speech\V1\Client\BaseClient\SpeechBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class SpeechClient extends SpeechBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/ApplicationServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/ApplicationServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\ApplicationServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ApplicationServiceClient extends ApplicationServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
@@ -55,6 +55,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface createApplicationAsync(CreateApplicationRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
@@ -54,6 +54,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface createCompanyAsync(CreateCompanyRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface completeQueryAsync(CompleteQueryRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
@@ -49,6 +49,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface createClientEventAsync(CreateClientEventRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
@@ -61,6 +61,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface batchCreateJobsAsync(BatchCreateJobsRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
@@ -56,6 +56,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface createProfileAsync(CreateProfileRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
@@ -54,6 +54,8 @@ use GuzzleHttp\Promise\PromiseInterface;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
  * @experimental
  *
  * @method PromiseInterface createTenantAsync(CreateTenantRequest $request, array $optionalArgs = [])

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/CompanyServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/CompanyServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\CompanyServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CompanyServiceClient extends CompanyServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/CompletionClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/CompletionClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\CompletionBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CompletionClient extends CompletionBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/EventServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/EventServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\EventServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class EventServiceClient extends EventServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/JobServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/JobServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\JobServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class JobServiceClient extends JobServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/ProfileServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/ProfileServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\ProfileServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ProfileServiceClient extends ProfileServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/TenantServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/TenantServiceClient.php
@@ -28,7 +28,13 @@ namespace Google\Cloud\Talent\V4beta1\Client;
 
 use Google\Cloud\Talent\V4beta1\Client\BaseClient\TenantServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class TenantServiceClient extends TenantServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
@@ -45,6 +45,10 @@ use GuzzleHttp\Promise\PromiseInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface annotateVideoAsync(AnnotateVideoRequest $request, array $optionalArgs = [])
  */
 class VideoIntelligenceServiceBaseClient

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/VideoIntelligenceServiceClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/VideoIntelligenceServiceClient.php
@@ -26,7 +26,13 @@ namespace Google\Cloud\VideoIntelligence\V1\Client;
 
 use Google\Cloud\VideoIntelligence\V1\Client\BaseClient\VideoIntelligenceServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class VideoIntelligenceServiceClient extends VideoIntelligenceServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
@@ -42,6 +42,10 @@ use Testing\Basic\Response;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface aMethodAsync(Request $request, array $optionalArgs = [])
  * @method PromiseInterface methodWithArgsAsync(RequestWithArgs $request, array $optionalArgs = [])
  */

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -26,7 +26,13 @@ namespace Testing\Basic\Client;
 
 use Testing\Basic\Client\BaseClient\BasicBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicClient extends BasicBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BaseClient/BasicBidiStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BaseClient/BasicBidiStreamingBaseClient.php
@@ -37,6 +37,10 @@ use Google\Auth\FetchAuthTokenInterface;
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
  */
 class BasicBidiStreamingBaseClient
 {

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BasicBidiStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BasicBidiStreamingClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicBidiStreaming\Client;
 
 use Testing\BasicBidiStreaming\Client\BaseClient\BasicBidiStreamingBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicBidiStreamingClient extends BasicBidiStreamingBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BaseClient/BasicClientStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BaseClient/BasicClientStreamingBaseClient.php
@@ -37,6 +37,10 @@ use Google\Auth\FetchAuthTokenInterface;
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
  */
 class BasicClientStreamingBaseClient
 {

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BasicClientStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BasicClientStreamingClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicClientStreaming\Client;
 
 use Testing\BasicClientStreaming\Client\BaseClient\BasicClientStreamingBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicClientStreamingClient extends BasicClientStreamingBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryBaseClient.php
@@ -100,6 +100,10 @@ use Testing\BasicDiregapic\UpdateBookRequest;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface addCommentsAsync(AddCommentsRequest $request, array $optionalArgs = [])
  * @method PromiseInterface addTagAsync(AddTagRequest $request, array $optionalArgs = [])
  * @method PromiseInterface archiveBooksAsync(ArchiveBooksRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/LibraryClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/LibraryClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicDiregapic\Client;
 
 use Testing\BasicDiregapic\Client\BaseClient\LibraryBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class LibraryClient extends LibraryBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
@@ -43,6 +43,10 @@ use Testing\BasicLro\Request;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface method1Async(Request $request, array $optionalArgs = [])
  * @method PromiseInterface methodNonLro1Async(Request $request, array $optionalArgs = [])
  * @method PromiseInterface methodNonLro2Async(Request $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BasicLroClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BasicLroClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicLro\Client;
 
 use Testing\BasicLro\Client\BaseClient\BasicLroBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicLroClient extends BasicLroBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
@@ -41,6 +41,10 @@ use Testing\BasicOneof\Response;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface aMethodAsync(Request $request, array $optionalArgs = [])
  */
 class BasicOneofBaseClient

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BasicOneofClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BasicOneofClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicOneof\Client;
 
 use Testing\BasicOneof\Client\BaseClient\BasicOneofBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicOneofClient extends BasicOneofBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
@@ -41,6 +41,10 @@ use Testing\BasicPaginated\Request;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface methodPaginatedAsync(Request $request, array $optionalArgs = [])
  */
 class BasicPaginatedBaseClient

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BasicPaginatedClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BasicPaginatedClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicPaginated\Client;
 
 use Testing\BasicPaginated\Client\BaseClient\BasicPaginatedBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicPaginatedClient extends BasicPaginatedBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BaseClient/BasicServerStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BaseClient/BasicServerStreamingBaseClient.php
@@ -39,6 +39,10 @@ use Testing\BasicServerStreaming\Request;
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
  */
 class BasicServerStreamingBaseClient
 {

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
@@ -26,7 +26,13 @@ namespace Testing\BasicServerStreaming\Client;
 
 use Testing\BasicServerStreaming\Client\BaseClient\BasicServerStreamingBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class BasicServerStreamingClient extends BasicServerStreamingBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
@@ -42,6 +42,10 @@ use Testing\CustomLro\CustomLroOperationsClient;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface createFooAsync(CreateFooRequest $request, array $optionalArgs = [])
  */
 class CustomLroBaseClient

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
@@ -43,6 +43,10 @@ use Testing\CustomLro\GetOperationRequest;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface cancelAsync(CancelOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface deleteAsync(DeleteOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getAsync(GetOperationRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroClient.php
@@ -26,7 +26,13 @@ namespace Testing\CustomLro\Client;
 
 use Testing\CustomLro\Client\BaseClient\CustomLroBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CustomLroClient extends CustomLroBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroOperationsClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroOperationsClient.php
@@ -26,7 +26,13 @@ namespace Testing\CustomLro\Client;
 
 use Testing\CustomLro\Client\BaseClient\CustomLroOperationsBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class CustomLroOperationsClient extends CustomLroOperationsBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
@@ -41,6 +41,10 @@ use Testing\Deprecated\FibonacciRequest;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @deprecated This class will be removed in the next major version update.
  *
  * @method PromiseInterface fastFibonacciAsync(FibonacciRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/DeprecatedServiceClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/DeprecatedServiceClient.php
@@ -26,7 +26,13 @@ namespace Testing\Deprecated\Client;
 
 use Testing\Deprecated\Client\BaseClient\DeprecatedServiceBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class DeprecatedServiceClient extends DeprecatedServiceBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
@@ -41,6 +41,10 @@ use Testing\DisableSnippets\Response;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface method1Async(Request $request, array $optionalArgs = [])
  */
 class DisableSnippetsBaseClient

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/DisableSnippetsClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/DisableSnippetsClient.php
@@ -26,7 +26,13 @@ namespace Testing\DisableSnippets\Client;
 
 use Testing\DisableSnippets\Client\BaseClient\DisableSnippetsBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class DisableSnippetsClient extends DisableSnippetsBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
@@ -46,6 +46,10 @@ use Testing\GrpcServiceConfig\Response1;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface method1AAsync(Request1 $request, array $optionalArgs = [])
  * @method PromiseInterface method1BLroAsync(Request1 $request, array $optionalArgs = [])
  * @method PromiseInterface method1CServiceLevelRetryAsync(Request1 $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/GrpcServiceConfigWithRetry1Client.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/GrpcServiceConfigWithRetry1Client.php
@@ -26,7 +26,13 @@ namespace Testing\GrpcServiceConfig\Client;
 
 use Testing\GrpcServiceConfig\Client\BaseClient\GrpcServiceConfigWithRetry1BaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class GrpcServiceConfigWithRetry1Client extends GrpcServiceConfigWithRetry1BaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
@@ -54,6 +54,10 @@ use Testing\ResourceNames\WildcardReferenceRequest;
  * name, and additionally a parseName method to extract the individual identifiers
  * contained within formatted names that are returned by the API.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface fileLevelChildTypeRefMethodAsync(FileLevelChildTypeRefRequest $request, array $optionalArgs = [])
  * @method PromiseInterface fileLevelTypeRefMethodAsync(FileLevelTypeRefRequest $request, array $optionalArgs = [])
  * @method PromiseInterface multiPatternMethodAsync(MultiPatternRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
@@ -26,7 +26,13 @@ namespace Testing\ResourceNames\Client;
 
 use Testing\ResourceNames\Client\BaseClient\ResourceNamesBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class ResourceNamesClient extends ResourceNamesBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
@@ -43,6 +43,10 @@ use Testing\RoutingHeaders\SimpleRequest;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ *
  * @method PromiseInterface deleteMethodAsync(SimpleRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getMethodAsync(SimpleRequest $request, array $optionalArgs = [])
  * @method PromiseInterface getNoPlaceholdersMethodAsync(SimpleRequest $request, array $optionalArgs = [])

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
@@ -26,7 +26,13 @@ namespace Testing\RoutingHeaders\Client;
 
 use Testing\RoutingHeaders\Client\BaseClient\RoutingHeadersBaseClient;
 
-/** {@inheritdoc} */
+/**
+ * {@inheritdoc}
+ *
+ * This class is currently experimental and may be subject to changes.
+ *
+ * @experimental
+ */
 class RoutingHeadersClient extends RoutingHeadersBaseClient
 {
     // This class is intentionally empty, and is intended to hold manual additions to


### PR DESCRIPTION
Temporarily mark new `v2` client classes as `@experimental` until we are comfortable with the surface.