### PR TITLE
feat: Make constants private in GapicV2Generator

### DIFF
--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -146,6 +146,7 @@ class GapicClientV2Generator
     {
         return AST::constant('SERVICE_NAME')
             ->withPhpDocText('The name of the service.')
+            ->withAccess(Access::PRIVATE)
             ->withValue($this->serviceDetails->serviceName);
     }
 
@@ -153,6 +154,7 @@ class GapicClientV2Generator
     {
         return AST::constant('SERVICE_ADDRESS')
             ->withPhpDocText('The default address of the service.')
+            ->withAccess(Access::PRIVATE)
             ->withValue($this->serviceDetails->defaultHost);
     }
 
@@ -160,6 +162,7 @@ class GapicClientV2Generator
     {
         return AST::constant('DEFAULT_SERVICE_PORT')
             ->withPhpDocText('The default port of the service.')
+            ->withAccess(Access::PRIVATE)
             ->withValue($this->serviceDetails->defaultPort);
     }
 
@@ -167,6 +170,7 @@ class GapicClientV2Generator
     {
         return AST::constant('CODEGEN_NAME')
             ->withPhpDocText('The name of the code generator, to be included in the agent header.')
+            ->withAccess(Access::PRIVATE)
             ->withValue('gapic');
     }
 

--- a/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/BaseClient/AssetServiceBaseClient.php
@@ -89,16 +89,16 @@ class AssetServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.asset.v1.AssetService';
+    private const SERVICE_NAME = 'google.cloud.asset.v1.AssetService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'cloudasset.googleapis.com';
+    private const SERVICE_ADDRESS = 'cloudasset.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/AddressesBaseClient.php
@@ -61,16 +61,16 @@ class AddressesBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.compute.v1.Addresses';
+    private const SERVICE_NAME = 'google.cloud.compute.v1.Addresses';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'compute.googleapis.com';
+    private const SERVICE_ADDRESS = 'compute.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/BaseClient/RegionOperationsBaseClient.php
@@ -50,16 +50,16 @@ class RegionOperationsBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.compute.v1.RegionOperations';
+    private const SERVICE_NAME = 'google.cloud.compute.v1.RegionOperations';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'compute.googleapis.com';
+    private const SERVICE_ADDRESS = 'compute.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/BaseClient/ClusterManagerBaseClient.php
@@ -120,16 +120,16 @@ class ClusterManagerBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.container.v1.ClusterManager';
+    private const SERVICE_NAME = 'google.container.v1.ClusterManager';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'container.googleapis.com';
+    private const SERVICE_ADDRESS = 'container.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/AutoscalingPolicyServiceBaseClient.php
@@ -67,16 +67,16 @@ class AutoscalingPolicyServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.dataproc.v1.AutoscalingPolicyService';
+    private const SERVICE_NAME = 'google.cloud.dataproc.v1.AutoscalingPolicyService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'dataproc.googleapis.com';
+    private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/ClusterControllerBaseClient.php
@@ -78,16 +78,16 @@ class ClusterControllerBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.dataproc.v1.ClusterController';
+    private const SERVICE_NAME = 'google.cloud.dataproc.v1.ClusterController';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'dataproc.googleapis.com';
+    private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/JobControllerBaseClient.php
@@ -65,16 +65,16 @@ class JobControllerBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.dataproc.v1.JobController';
+    private const SERVICE_NAME = 'google.cloud.dataproc.v1.JobController';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'dataproc.googleapis.com';
+    private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BaseClient/WorkflowTemplateServiceBaseClient.php
@@ -75,16 +75,16 @@ class WorkflowTemplateServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.dataproc.v1.WorkflowTemplateService';
+    private const SERVICE_NAME = 'google.cloud.dataproc.v1.WorkflowTemplateService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'dataproc.googleapis.com';
+    private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
@@ -86,16 +86,16 @@ class CloudFunctionsServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.functions.v1.CloudFunctionsService';
+    private const SERVICE_NAME = 'google.cloud.functions.v1.CloudFunctionsService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'cloudfunctions.googleapis.com';
+    private const SERVICE_ADDRESS = 'cloudfunctions.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/BaseClient/IAMPolicyBaseClient.php
@@ -79,16 +79,16 @@ class IAMPolicyBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.iam.v1.IAMPolicy';
+    private const SERVICE_NAME = 'google.iam.v1.IAMPolicy';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'iam-meta-api.googleapis.com';
+    private const SERVICE_ADDRESS = 'iam-meta-api.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/BaseClient/KeyManagementServiceBaseClient.php
@@ -129,16 +129,16 @@ class KeyManagementServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.kms.v1.KeyManagementService';
+    private const SERVICE_NAME = 'google.cloud.kms.v1.KeyManagementService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'cloudkms.googleapis.com';
+    private const SERVICE_ADDRESS = 'cloudkms.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/ConfigServiceV2BaseClient.php
@@ -106,16 +106,16 @@ class ConfigServiceV2BaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.logging.v2.ConfigServiceV2';
+    private const SERVICE_NAME = 'google.logging.v2.ConfigServiceV2';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'logging.googleapis.com';
+    private const SERVICE_ADDRESS = 'logging.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/LoggingServiceV2BaseClient.php
@@ -67,16 +67,16 @@ class LoggingServiceV2BaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.logging.v2.LoggingServiceV2';
+    private const SERVICE_NAME = 'google.logging.v2.LoggingServiceV2';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'logging.googleapis.com';
+    private const SERVICE_ADDRESS = 'logging.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/BaseClient/MetricsServiceV2BaseClient.php
@@ -66,16 +66,16 @@ class MetricsServiceV2BaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.logging.v2.MetricsServiceV2';
+    private const SERVICE_NAME = 'google.logging.v2.MetricsServiceV2';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'logging.googleapis.com';
+    private const SERVICE_ADDRESS = 'logging.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/BaseClient/CloudRedisBaseClient.php
@@ -91,16 +91,16 @@ class CloudRedisBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.redis.v1.CloudRedis';
+    private const SERVICE_NAME = 'google.cloud.redis.v1.CloudRedis';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'redis.googleapis.com';
+    private const SERVICE_ADDRESS = 'redis.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CatalogServiceBaseClient.php
@@ -69,16 +69,16 @@ class CatalogServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.retail.v2alpha.CatalogService';
+    private const SERVICE_NAME = 'google.cloud.retail.v2alpha.CatalogService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'retail.googleapis.com';
+    private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/CompletionServiceBaseClient.php
@@ -70,16 +70,16 @@ class CompletionServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.retail.v2alpha.CompletionService';
+    private const SERVICE_NAME = 'google.cloud.retail.v2alpha.CompletionService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'retail.googleapis.com';
+    private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/PredictionServiceBaseClient.php
@@ -61,16 +61,16 @@ class PredictionServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.retail.v2alpha.PredictionService';
+    private const SERVICE_NAME = 'google.cloud.retail.v2alpha.PredictionService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'retail.googleapis.com';
+    private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/ProductServiceBaseClient.php
@@ -82,16 +82,16 @@ class ProductServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.retail.v2alpha.ProductService';
+    private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ProductService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'retail.googleapis.com';
+    private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/SearchServiceBaseClient.php
@@ -65,16 +65,16 @@ class SearchServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.retail.v2alpha.SearchService';
+    private const SERVICE_NAME = 'google.cloud.retail.v2alpha.SearchService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'retail.googleapis.com';
+    private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BaseClient/UserEventServiceBaseClient.php
@@ -74,16 +74,16 @@ class UserEventServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.retail.v2alpha.UserEventService';
+    private const SERVICE_NAME = 'google.cloud.retail.v2alpha.UserEventService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'retail.googleapis.com';
+    private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
@@ -111,16 +111,16 @@ class SecurityCenterBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.securitycenter.v1.SecurityCenter';
+    private const SERVICE_NAME = 'google.cloud.securitycenter.v1.SecurityCenter';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'securitycenter.googleapis.com';
+    private const SERVICE_ADDRESS = 'securitycenter.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/BaseClient/SpeechBaseClient.php
@@ -57,16 +57,16 @@ class SpeechBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.speech.v1.Speech';
+    private const SERVICE_NAME = 'google.cloud.speech.v1.Speech';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'speech.googleapis.com';
+    private const SERVICE_ADDRESS = 'speech.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ApplicationServiceBaseClient.php
@@ -71,16 +71,16 @@ class ApplicationServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.ApplicationService';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.ApplicationService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompanyServiceBaseClient.php
@@ -70,16 +70,16 @@ class CompanyServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.CompanyService';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.CompanyService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/CompletionBaseClient.php
@@ -61,16 +61,16 @@ class CompletionBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.Completion';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.Completion';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/EventServiceBaseClient.php
@@ -61,16 +61,16 @@ class EventServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.EventService';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.EventService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/JobServiceBaseClient.php
@@ -82,16 +82,16 @@ class JobServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.JobService';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.JobService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/ProfileServiceBaseClient.php
@@ -73,16 +73,16 @@ class ProfileServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.ProfileService';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.ProfileService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/BaseClient/TenantServiceBaseClient.php
@@ -70,16 +70,16 @@ class TenantServiceBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.talent.v4beta1.TenantService';
+    private const SERVICE_NAME = 'google.cloud.talent.v4beta1.TenantService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'jobs.googleapis.com';
+    private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/BaseClient/VideoIntelligenceServiceBaseClient.php
@@ -54,16 +54,16 @@ class VideoIntelligenceServiceBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.cloud.videointelligence.v1.VideoIntelligenceService';
+    private const SERVICE_NAME = 'google.cloud.videointelligence.v1.VideoIntelligenceService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'videointelligence.googleapis.com';
+    private const SERVICE_ADDRESS = 'videointelligence.googleapis.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
@@ -52,16 +52,16 @@ class BasicBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basic.Basic';
+    private const SERVICE_NAME = 'testing.basic.Basic';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'basic.example.com';
+    private const SERVICE_ADDRESS = 'basic.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BaseClient/BasicBidiStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BaseClient/BasicBidiStreamingBaseClient.php
@@ -45,16 +45,16 @@ class BasicBidiStreamingBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basicbidistreaming.BasicBidiStreaming';
+    private const SERVICE_NAME = 'testing.basicbidistreaming.BasicBidiStreaming';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'bidi.example.com';
+    private const SERVICE_ADDRESS = 'bidi.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BaseClient/BasicClientStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BaseClient/BasicClientStreamingBaseClient.php
@@ -45,16 +45,16 @@ class BasicClientStreamingBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basicclientstreaming.BasicClientStreaming';
+    private const SERVICE_NAME = 'testing.basicclientstreaming.BasicClientStreaming';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'clientstreaming.example.com';
+    private const SERVICE_ADDRESS = 'clientstreaming.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/BaseClient/LibraryBaseClient.php
@@ -138,16 +138,16 @@ class LibraryBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'google.example.library.v1.Library';
+    private const SERVICE_NAME = 'google.example.library.v1.Library';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'library-example.googleapis.com:1234';
+    private const SERVICE_ADDRESS = 'library-example.googleapis.com:1234';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BaseClient/BasicLroBaseClient.php
@@ -54,16 +54,16 @@ class BasicLroBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basiclro.BasicLro';
+    private const SERVICE_NAME = 'testing.basiclro.BasicLro';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'lro.example.com';
+    private const SERVICE_ADDRESS = 'lro.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BaseClient/BasicOneofBaseClient.php
@@ -50,16 +50,16 @@ class BasicOneofBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basiconeof.BasicOneof';
+    private const SERVICE_NAME = 'testing.basiconeof.BasicOneof';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'basic.example.com';
+    private const SERVICE_ADDRESS = 'basic.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BaseClient/BasicPaginatedBaseClient.php
@@ -50,16 +50,16 @@ class BasicPaginatedBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basicpaginated.BasicPaginated';
+    private const SERVICE_NAME = 'testing.basicpaginated.BasicPaginated';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'paginated.example.com';
+    private const SERVICE_ADDRESS = 'paginated.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BaseClient/BasicServerStreamingBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BaseClient/BasicServerStreamingBaseClient.php
@@ -47,16 +47,16 @@ class BasicServerStreamingBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.basicserverstreaming.BasicServerStreaming';
+    private const SERVICE_NAME = 'testing.basicserverstreaming.BasicServerStreaming';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'serverstreaming.example.com';
+    private const SERVICE_ADDRESS = 'serverstreaming.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroBaseClient.php
@@ -51,16 +51,16 @@ class CustomLroBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.customlro.CustomLro';
+    private const SERVICE_NAME = 'testing.customlro.CustomLro';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'customlro.example.com';
+    private const SERVICE_ADDRESS = 'customlro.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/BaseClient/CustomLroOperationsBaseClient.php
@@ -54,16 +54,16 @@ class CustomLroOperationsBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.customlro.CustomLroOperations';
+    private const SERVICE_NAME = 'testing.customlro.CustomLroOperations';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'customlro.example.com';
+    private const SERVICE_ADDRESS = 'customlro.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/BaseClient/DeprecatedServiceBaseClient.php
@@ -53,16 +53,16 @@ class DeprecatedServiceBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.deprecated_service.DeprecatedService';
+    private const SERVICE_NAME = 'testing.deprecated_service.DeprecatedService';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'localhost:7469';
+    private const SERVICE_ADDRESS = 'localhost:7469';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/BaseClient/DisableSnippetsBaseClient.php
@@ -50,16 +50,16 @@ class DisableSnippetsBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.disablesnippets.DisableSnippets';
+    private const SERVICE_NAME = 'testing.disablesnippets.DisableSnippets';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'disablesnippets.example.com';
+    private const SERVICE_ADDRESS = 'disablesnippets.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/BaseClient/GrpcServiceConfigWithRetry1BaseClient.php
@@ -58,16 +58,16 @@ class GrpcServiceConfigWithRetry1BaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1';
+    private const SERVICE_NAME = 'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'grpcserviceconfig.example.com';
+    private const SERVICE_ADDRESS = 'grpcserviceconfig.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
@@ -71,16 +71,16 @@ class ResourceNamesBaseClient
     use ResourceHelperTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.resourcenames.ResourceNames';
+    private const SERVICE_NAME = 'testing.resourcenames.ResourceNames';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'resourcenames.example.com';
+    private const SERVICE_ADDRESS = 'resourcenames.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
@@ -63,16 +63,16 @@ class RoutingHeadersBaseClient
     use GapicClientTrait;
 
     /** The name of the service. */
-    const SERVICE_NAME = 'testing.routingheaders.RoutingHeaders';
+    private const SERVICE_NAME = 'testing.routingheaders.RoutingHeaders';
 
     /** The default address of the service. */
-    const SERVICE_ADDRESS = 'routingheaders.example.com';
+    private const SERVICE_ADDRESS = 'routingheaders.example.com';
 
     /** The default port of the service. */
-    const DEFAULT_SERVICE_PORT = 443;
+    private const DEFAULT_SERVICE_PORT = 443;
 
     /** The name of the code generator, to be included in the agent header. */
-    const CODEGEN_NAME = 'gapic';
+    private const CODEGEN_NAME = 'gapic';
 
     /** The default scopes required by the service. */
     public static $serviceScopes = [];


### PR DESCRIPTION
I have 2 questions here @noahdietz @bshaffer :

1. We might need to access these constants somewhere in the code, should I add a static getter for these constants? And if I end up doing that, then what is the point of making it private 🤔 
2. We also need to change these variables sometimes for development(like staging endpoints etc when an environment variable is present), should that be done in this PR?