### PR TITLE
fix(v2): ignore mixin methods during fragment gen

### DIFF
--- a/src/Generation/BuildMethodFragmentGenerator.php
+++ b/src/Generation/BuildMethodFragmentGenerator.php
@@ -55,7 +55,7 @@ class BuildMethodFragmentGenerator
     {
         $buildMethodSnippets = Map::new([]);
         foreach ($this->serviceDetails->methods as $methodDetails) {
-            if ($methodDetails->methodSignature) {
+            if ($methodDetails->methodSignature && !$methodDetails->isMixin()) {
                 $buildMethods = Vector::new();
                 foreach ($methodDetails->methodSignature as $i => $methodSignature) {
                     if (empty($methodSignature)) {


### PR DESCRIPTION
Mixin methods don't have their request/response messages as part of the `php_gapic_assembly_pkg`, so they aren't able to be `PostProcessor`'d, and thus cannot have a build method fragment generated for them. We could potentially look at fixing this later, but for now, this is the most reasonable solution.

Tested via googleapis build that failed before, but passes now. 