### PR TITLE
fix: lower hashing constant to avoid overflow

### DIFF
--- a/src/Collections/Vector.php
+++ b/src/Collections/Vector.php
@@ -144,7 +144,7 @@ class Vector implements \IteratorAggregate, \Countable, \ArrayAccess, Equality
     {
         $hash = 1;
         foreach ($this->data as $item) {
-            $hash *= 23;
+            $hash *= 13;
             $hash ^= static::hash($item);
         }
         return $hash;


### PR DESCRIPTION
For some reason, certain APIs would trigger an integer overflow in `Vector::getHash`, forcing a float type coercion by PHP, which is deprecated, resulting in Deprecated warnings being emitted on stdout, ruining protoc plugin output.

This is a partial fix, because we should probably figure out how to also disable language deprecation warnings (or at least redirect to stderr) in the googleapis.