### PR TITLE
fix: reduce noise by reverting sample comment

### DIFF
--- a/src/Generation/SnippetGenerator.php
+++ b/src/Generation/SnippetGenerator.php
@@ -393,7 +393,9 @@ class SnippetGenerator
                         AST::new($snippetDetails->context->type($clientType))()
                     ),
                     $hasSampleAssignments ? PHP_EOL : null,
-                    $hasSampleAssignments ? '// Prepare the request message.' : null,
+                    $hasSampleAssignments ? ($clientType === $this->serviceDetails->emptyClientType
+                        ? '// Prepare any non-scalar elements to be passed along with the request.'
+                        : '// Prepare the request message.') : null,
                     $snippetDetails->sampleAssignments,
                     PHP_EOL,
                     '// Call the API and handle any network failures.',

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_bidi.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_bidi.php
@@ -35,7 +35,7 @@ function method_bidi_sample(int $aNumber): void
     // Create a client.
     $basicBidiStreamingClient = new BasicBidiStreamingClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $request = (new Request())
         ->setANumber($aNumber);
 

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_empty.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_empty.php
@@ -41,7 +41,7 @@ function method_empty_sample(): void
     // Create a client.
     $basicBidiStreamingClient = new BasicBidiStreamingClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $request = new EmptyRequest();
 
     // Call the API and handle any network failures.

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_client.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_client.php
@@ -35,7 +35,7 @@ function method_client_sample(int $aNumber): void
     // Create a client.
     $basicClientStreamingClient = new BasicClientStreamingClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $request = (new Request())
         ->setANumber($aNumber);
 

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_empty.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_empty.php
@@ -41,7 +41,7 @@ function method_empty_sample(): void
     // Create a client.
     $basicClientStreamingClient = new BasicClientStreamingClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $request = new EmptyRequest();
 
     // Call the API and handle any network failures.

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/add_comments.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/add_comments.php
@@ -37,7 +37,7 @@ function add_comments_sample(string $formattedName): void
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $comments = [new Comment()];
 
     // Call the API and handle any network failures.

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_book.php
@@ -42,7 +42,7 @@ function create_book_sample(string $formattedName, string $formattedBookName): v
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $book = (new BookResponse())
         ->setName($formattedBookName);
 

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_inventory.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_inventory.php
@@ -44,7 +44,7 @@ function create_inventory_sample(
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $assets = [$assetsElement,];
 
     // Call the API and handle any network failures.

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_shelf.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_shelf.php
@@ -39,7 +39,7 @@ function create_shelf_sample(string $shelfName): void
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $shelf = (new ShelfResponse())
         ->setName($shelfName);
 

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/find_related_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/find_related_books.php
@@ -38,7 +38,7 @@ function find_related_books_sample(
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $formattedNames = [$formattedNamesElement,];
     $formattedShelves = [$formattedShelvesElement,];
 

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/publish_series.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/publish_series.php
@@ -51,7 +51,7 @@ function publish_series_sample(
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $shelf = (new ShelfResponse())
         ->setName($shelfName);
     $bookResponse = (new BookResponse())

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book.php
@@ -42,7 +42,7 @@ function update_book_sample(string $formattedName, string $formattedBookName): v
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $book = (new BookResponse())
         ->setName($formattedBookName);
 

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book_index.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book_index.php
@@ -38,7 +38,7 @@ function update_book_index_sample(string $formattedName, string $indexName): voi
     // Create a client.
     $libraryClient = new LibraryClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $indexMap = [];
 
     // Call the API and handle any network failures.

--- a/tests/Unit/ProtoTests/BasicOneof/out/samples/BasicOneofClient/a_method.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/samples/BasicOneofClient/a_method.php
@@ -44,7 +44,7 @@ function a_method_sample(
     // Create a client.
     $basicOneofClient = new BasicOneofClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $supplementaryData = (new SupplementaryDataOneof())
         ->setExtraDescription($supplementaryDataExtraDescription);
     $other = (new Other())

--- a/tests/Unit/ProtoTests/BasicPaginated/out/samples/BasicPaginatedClient/method_paginated.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/samples/BasicPaginatedClient/method_paginated.php
@@ -40,7 +40,7 @@ function method_paginated_sample(string $aField, string $pageToken): void
     // Create a client.
     $basicPaginatedClient = new BasicPaginatedClient();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $partOfRequestA = [new PartOfRequestA()];
 
     // Call the API and handle any network failures.

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_bidi_streaming.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_bidi_streaming.php
@@ -41,7 +41,7 @@ function method1_bidi_streaming_sample(): void
     // Create a client.
     $grpcServiceConfigWithRetry1Client = new GrpcServiceConfigWithRetry1Client();
 
-    // Prepare the request message.
+    // Prepare any non-scalar elements to be passed along with the request.
     $request = new Request1();
 
     // Call the API and handle any network failures.


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-php/pull/6154

We have generated PRs across the repo to update a single comment in snippets, and this is not very useful.