### PR TITLE
fix: increase php memory limit

### DIFF
--- a/rules_php_gapic/php.bzl
+++ b/rules_php_gapic/php.bzl
@@ -62,7 +62,7 @@ tar cf - --dereference src/ generated/ googleapis/ tools/ vendor/ composer.json 
 WD="$(pwd)"
 PHP="$WD/$(dirname $0)/{run_name}.runfiles/$(basename $WD)/{php_short_path}"
 cd "$(dirname $0)/{run_name}.runfiles/$(basename $WD)/{out_short_path}/install"
-"$PHP" -n -d memory_limit=512M './{entry_point}' {working_directory_flag} $@
+"$PHP" -n -d memory_limit=1024M './{entry_point}' {working_directory_flag} $@
     """.format(
         php_short_path = ctx.file.php.short_path,
         out_short_path = out_dir.short_path,


### PR DESCRIPTION
Increase PHP memory limit for compute + v2 surface, as the build is currently crashing because it's running out of memory

Should allow builds in https://github.com/googleapis/googleapis/pull/807 to pass!