### PR TITLE
fix: include non-required resource fields in helpers

### DIFF
--- a/src/Generation/ServiceDetails.php
+++ b/src/Generation/ServiceDetails.php
@@ -255,9 +255,8 @@ class ServiceDetails
                 return substr($fd->fullname, 0, 1) === '.' ? substr($fd->fullname, 1) : $fd->fullname;
             };
             $fieldResourceRefs = $fieldDetails
-            ->filter(fn ($x) => $x->isRequired
-                && $x->isMessage
-                && !is_null($x->fullname))
+                ->filter(fn ($x) => $x->isMessage
+                    && !is_null($x->fullname))
                 ->map(fn ($x) => $catalog->msgResourcesByFullname->get($fullnameFn($x), null))
                 ->filter(fn ($x) => !is_null($x));
             $typeFieldRefResourceDefs = $fieldResourceRefs

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/nested_reference_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/nested_reference_method.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * GENERATED CODE WARNING
+ * This file was automatically generated - do not edit!
+ */
+
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+// [START resourcenames_generated_ResourceNames_NestedReferenceMethod_sync]
+use Google\ApiCore\ApiException;
+use Testing\ResourceNames\PlaceholderResponse;
+use Testing\ResourceNames\ResourceNamesClient;
+
+/**
+ * This sample has been automatically generated and should be regarded as a code
+ * template only. It will require modifications to work:
+ *  - It may require correct/in-range values for request initialization.
+ *  - It may require specifying regional endpoints when creating the service client,
+ *    please see the apiEndpoint client configuration option for more details.
+ */
+function nested_reference_method_sample(): void
+{
+    // Create a client.
+    $resourceNamesClient = new ResourceNamesClient();
+
+    // Call the API and handle any network failures.
+    try {
+        /** @var PlaceholderResponse $response */
+        $response = $resourceNamesClient->nestedReferenceMethod();
+        printf('Response data: %s' . PHP_EOL, $response->serializeToJsonString());
+    } catch (ApiException $ex) {
+        printf('Call failed with message: %s' . PHP_EOL, $ex->getMessage());
+    }
+}
+// [END resourcenames_generated_ResourceNames_NestedReferenceMethod_sync]

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/BaseClient/ResourceNamesBaseClient.php
@@ -36,6 +36,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Testing\ResourceNames\FileLevelChildTypeRefRequest;
 use Testing\ResourceNames\FileLevelTypeRefRequest;
 use Testing\ResourceNames\MultiPatternRequest;
+use Testing\ResourceNames\NestedReferenceRequest;
 use Testing\ResourceNames\PlaceholderResponse;
 use Testing\ResourceNames\SinglePatternRequest;
 use Testing\ResourceNames\WildcardChildReferenceRequest;
@@ -63,6 +64,7 @@ use Testing\ResourceNames\WildcardReferenceRequest;
  * @method PromiseInterface fileLevelChildTypeRefMethodAsync(FileLevelChildTypeRefRequest $request, array $optionalArgs = [])
  * @method PromiseInterface fileLevelTypeRefMethodAsync(FileLevelTypeRefRequest $request, array $optionalArgs = [])
  * @method PromiseInterface multiPatternMethodAsync(MultiPatternRequest $request, array $optionalArgs = [])
+ * @method PromiseInterface nestedReferenceMethodAsync(NestedReferenceRequest $request, array $optionalArgs = [])
  * @method PromiseInterface singlePatternMethodAsync(SinglePatternRequest $request, array $optionalArgs = [])
  * @method PromiseInterface wildcardChildReferenceMethodAsync(WildcardChildReferenceRequest $request, array $optionalArgs = [])
  * @method PromiseInterface wildcardMethodAsync(WildcardPatternRequest $request, array $optionalArgs = [])
@@ -290,6 +292,21 @@ abstract class ResourceNamesBaseClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * nested_reference_message resource.
+     *
+     * @param string $nestedReferenceMessage
+     *
+     * @return string The formatted nested_reference_message resource.
+     */
+    public static function nestedReferenceMessageName(string $nestedReferenceMessage): string
+    {
+        return self::getPathTemplate('nestedReferenceMessage')->render([
+            'nested_reference_message' => $nestedReferenceMessage,
+        ]);
+    }
+
+    /**
      * Formats a string containing the fully-qualified path to represent a order1
      * resource.
      *
@@ -331,6 +348,21 @@ abstract class ResourceNamesBaseClient
     {
         return self::getPathTemplate('order3')->render([
             'order3_id' => $order3Id,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * other_reference_resource resource.
+     *
+     * @param string $otherReferenceResource
+     *
+     * @return string The formatted other_reference_resource resource.
+     */
+    public static function otherReferenceResourceName(string $otherReferenceResource): string
+    {
+        return self::getPathTemplate('otherReferenceResource')->render([
+            'other_reference_resource' => $otherReferenceResource,
         ]);
     }
 
@@ -381,9 +413,11 @@ abstract class ResourceNamesBaseClient
      * - item3Id: items3/{item3_id}
      * - item4IdItem5aIdItem5bIdItem5cIdItem5dIdItem5eIdItem6Id: items4/{item4_id}/items5/{item5a_id}_{item5b_id}-{item5c_id}.{item5d_id}~{item5e_id}/items6/{item6_id}
      * - multiPattern: items1/{item1_id}/items2/{item2_id}
+     * - nestedReferenceMessage: nestedReferenceMessages/{nested_reference_message}
      * - order1: orders1/{order1_id}
      * - order2: orders2/{order2_id}
      * - order3: orders3/{order3_id}
+     * - otherReferenceResource: otherReferenceResource/{other_reference_resource}
      * - singlePattern: items1/{item1_id}/items2/{item2_id}
      * - wildcardMultiPattern: items1/{item1_id}
      *
@@ -540,6 +574,28 @@ abstract class ResourceNamesBaseClient
     public function multiPatternMethod(MultiPatternRequest $request, array $callOptions = []): PlaceholderResponse
     {
         return $this->startApiCall('MultiPatternMethod', $request, $callOptions)->wait();
+    }
+
+    /**
+     * The async variant is {@see self::nestedReferenceMethodAsync()} .
+     *
+     * @param NestedReferenceRequest $request     A request to house fields associated with the call.
+     * @param array                  $callOptions {
+     *     Optional.
+     *
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     *
+     * @return PlaceholderResponse
+     *
+     * @throws ApiException Thrown if the API call fails.
+     */
+    public function nestedReferenceMethod(NestedReferenceRequest $request, array $callOptions = []): PlaceholderResponse
+    {
+        return $this->startApiCall('NestedReferenceMethod', $request, $callOptions)->wait();
     }
 
     /**

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Gapic/ResourceNamesGapicClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Gapic/ResourceNamesGapicClient.php
@@ -36,6 +36,8 @@ use Testing\ResourceNames\FileLevelChildTypeRefRequest;
 use Testing\ResourceNames\FileLevelTypeRefRequest;
 use Testing\ResourceNames\FileLevelTypeRefRequest\Nested1;
 use Testing\ResourceNames\MultiPatternRequest;
+use Testing\ResourceNames\NestedReferenceMessage;
+use Testing\ResourceNames\NestedReferenceRequest;
 use Testing\ResourceNames\PlaceholderResponse;
 use Testing\ResourceNames\SinglePatternRequest;
 use Testing\ResourceNames\WildcardChildReferenceRequest;
@@ -109,11 +111,15 @@ class ResourceNamesGapicClient
 
     private static $multiPatternNameTemplate;
 
+    private static $nestedReferenceMessageNameTemplate;
+
     private static $order1NameTemplate;
 
     private static $order2NameTemplate;
 
     private static $order3NameTemplate;
+
+    private static $otherReferenceResourceNameTemplate;
 
     private static $singlePatternNameTemplate;
 
@@ -239,6 +245,15 @@ class ResourceNamesGapicClient
         return self::$multiPatternNameTemplate;
     }
 
+    private static function getNestedReferenceMessageNameTemplate()
+    {
+        if (self::$nestedReferenceMessageNameTemplate == null) {
+            self::$nestedReferenceMessageNameTemplate = new PathTemplate('nestedReferenceMessages/{nested_reference_message}');
+        }
+
+        return self::$nestedReferenceMessageNameTemplate;
+    }
+
     private static function getOrder1NameTemplate()
     {
         if (self::$order1NameTemplate == null) {
@@ -264,6 +279,15 @@ class ResourceNamesGapicClient
         }
 
         return self::$order3NameTemplate;
+    }
+
+    private static function getOtherReferenceResourceNameTemplate()
+    {
+        if (self::$otherReferenceResourceNameTemplate == null) {
+            self::$otherReferenceResourceNameTemplate = new PathTemplate('otherReferenceResource/{other_reference_resource}');
+        }
+
+        return self::$otherReferenceResourceNameTemplate;
     }
 
     private static function getSinglePatternNameTemplate()
@@ -299,9 +323,11 @@ class ResourceNamesGapicClient
                 'item3Id' => self::getItem3IdNameTemplate(),
                 'item4IdItem5aIdItem5bIdItem5cIdItem5dIdItem5eIdItem6Id' => self::getItem4IdItem5aIdItem5bIdItem5cIdItem5dIdItem5eIdItem6IdNameTemplate(),
                 'multiPattern' => self::getMultiPatternNameTemplate(),
+                'nestedReferenceMessage' => self::getNestedReferenceMessageNameTemplate(),
                 'order1' => self::getOrder1NameTemplate(),
                 'order2' => self::getOrder2NameTemplate(),
                 'order3' => self::getOrder3NameTemplate(),
+                'otherReferenceResource' => self::getOtherReferenceResourceNameTemplate(),
                 'singlePattern' => self::getSinglePatternNameTemplate(),
                 'wildcardMultiPattern' => self::getWildcardMultiPatternNameTemplate(),
             ];
@@ -492,6 +518,21 @@ class ResourceNamesGapicClient
     }
 
     /**
+     * Formats a string containing the fully-qualified path to represent a
+     * nested_reference_message resource.
+     *
+     * @param string $nestedReferenceMessage
+     *
+     * @return string The formatted nested_reference_message resource.
+     */
+    public static function nestedReferenceMessageName($nestedReferenceMessage)
+    {
+        return self::getNestedReferenceMessageNameTemplate()->render([
+            'nested_reference_message' => $nestedReferenceMessage,
+        ]);
+    }
+
+    /**
      * Formats a string containing the fully-qualified path to represent a order1
      * resource.
      *
@@ -533,6 +574,21 @@ class ResourceNamesGapicClient
     {
         return self::getOrder3NameTemplate()->render([
             'order3_id' => $order3Id,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent a
+     * other_reference_resource resource.
+     *
+     * @param string $otherReferenceResource
+     *
+     * @return string The formatted other_reference_resource resource.
+     */
+    public static function otherReferenceResourceName($otherReferenceResource)
+    {
+        return self::getOtherReferenceResourceNameTemplate()->render([
+            'other_reference_resource' => $otherReferenceResource,
         ]);
     }
 
@@ -583,9 +639,11 @@ class ResourceNamesGapicClient
      * - item3Id: items3/{item3_id}
      * - item4IdItem5aIdItem5bIdItem5cIdItem5dIdItem5eIdItem6Id: items4/{item4_id}/items5/{item5a_id}_{item5b_id}-{item5c_id}.{item5d_id}~{item5e_id}/items6/{item6_id}
      * - multiPattern: items1/{item1_id}/items2/{item2_id}
+     * - nestedReferenceMessage: nestedReferenceMessages/{nested_reference_message}
      * - order1: orders1/{order1_id}
      * - order2: orders2/{order2_id}
      * - order3: orders3/{order3_id}
+     * - otherReferenceResource: otherReferenceResource/{other_reference_resource}
      * - singlePattern: items1/{item1_id}/items2/{item2_id}
      * - wildcardMultiPattern: items1/{item1_id}
      *
@@ -820,6 +878,42 @@ class ResourceNamesGapicClient
         }
 
         return $this->startCall('MultiPatternMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
+    }
+
+    /**
+     *
+     * Sample code:
+     * ```
+     * $resourceNamesClient = new ResourceNamesClient();
+     * try {
+     *     $response = $resourceNamesClient->nestedReferenceMethod();
+     * } finally {
+     *     $resourceNamesClient->close();
+     * }
+     * ```
+     *
+     * @param array $optionalArgs {
+     *     Optional.
+     *
+     *     @type NestedReferenceMessage $nestedReferenceMessage
+     *     @type RetrySettings|array $retrySettings
+     *           Retry settings to use for this call. Can be a {@see RetrySettings} object, or an
+     *           associative array of retry settings parameters. See the documentation on
+     *           {@see RetrySettings} for example usage.
+     * }
+     *
+     * @return \Testing\ResourceNames\PlaceholderResponse
+     *
+     * @throws ApiException if the remote call fails
+     */
+    public function nestedReferenceMethod(array $optionalArgs = [])
+    {
+        $request = new NestedReferenceRequest();
+        if (isset($optionalArgs['nestedReferenceMessage'])) {
+            $request->setNestedReferenceMessage($optionalArgs['nestedReferenceMessage']);
+        }
+
+        return $this->startCall('NestedReferenceMethod', PlaceholderResponse::class, $optionalArgs, $request)->wait();
     }
 
     /**

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/gapic_metadata.json
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/gapic_metadata.json
@@ -25,6 +25,11 @@
                                 "multiPatternMethod"
                             ]
                         },
+                        "NestedReferenceMethod": {
+                            "methods": [
+                                "nestedReferenceMethod"
+                            ]
+                        },
                         "SinglePatternMethod": {
                             "methods": [
                                 "singlePatternMethod"

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_client_config.json
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_client_config.json
@@ -35,6 +35,11 @@
                     "retry_codes_name": "non_idempotent",
                     "retry_params_name": "default"
                 },
+                "NestedReferenceMethod": {
+                    "timeout_millis": 60000,
+                    "retry_codes_name": "non_idempotent",
+                    "retry_params_name": "default"
+                },
                 "SinglePatternMethod": {
                     "timeout_millis": 60000,
                     "retry_codes_name": "non_idempotent",

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_descriptor_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_descriptor_config.php
@@ -15,6 +15,10 @@ return [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
             ],
+            'NestedReferenceMethod' => [
+                'callType' => \Google\ApiCore\Call::UNARY_CALL,
+                'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
+            ],
             'SinglePatternMethod' => [
                 'callType' => \Google\ApiCore\Call::UNARY_CALL,
                 'responseType' => 'Testing\ResourceNames\PlaceholderResponse',
@@ -47,9 +51,11 @@ return [
                 'item3Id' => 'items3/{item3_id}',
                 'item4IdItem5aIdItem5bIdItem5cIdItem5dIdItem5eIdItem6Id' => 'items4/{item4_id}/items5/{item5a_id}_{item5b_id}-{item5c_id}.{item5d_id}~{item5e_id}/items6/{item6_id}',
                 'multiPattern' => 'items1/{item1_id}/items2/{item2_id}',
+                'nestedReferenceMessage' => 'nestedReferenceMessages/{nested_reference_message}',
                 'order1' => 'orders1/{order1_id}',
                 'order2' => 'orders2/{order2_id}',
                 'order3' => 'orders3/{order3_id}',
+                'otherReferenceResource' => 'otherReferenceResource/{other_reference_resource}',
                 'singlePattern' => 'items1/{item1_id}/items2/{item2_id}',
                 'wildcardMultiPattern' => 'items1/{item1_id}',
             ],

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
@@ -18,6 +18,11 @@ return [
                 'uriTemplate' => '/path:multiPatternMethod',
                 'body' => '*',
             ],
+            'NestedReferenceMethod' => [
+                'method' => 'post',
+                'uriTemplate' => '/path:nestedReferenceMethod',
+                'body' => '*',
+            ],
             'SinglePatternMethod' => [
                 'method' => 'post',
                 'uriTemplate' => '/path:singlePatternMethod',

--- a/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/Client/ResourceNamesClientTest.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/Client/ResourceNamesClientTest.php
@@ -31,6 +31,7 @@ use Testing\ResourceNames\Client\ResourceNamesClient;
 use Testing\ResourceNames\FileLevelChildTypeRefRequest;
 use Testing\ResourceNames\FileLevelTypeRefRequest;
 use Testing\ResourceNames\MultiPatternRequest;
+use Testing\ResourceNames\NestedReferenceRequest;
 use Testing\ResourceNames\PlaceholderResponse;
 use Testing\ResourceNames\SinglePatternRequest;
 use Testing\ResourceNames\WildcardChildReferenceRequest;
@@ -250,6 +251,60 @@ class ResourceNamesClientTest extends GeneratedTest
         $request = new MultiPatternRequest();
         try {
             $gapicClient->multiPatternMethod($request);
+            // If the $gapicClient method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function nestedReferenceMethodTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new PlaceholderResponse();
+        $transport->addResponse($expectedResponse);
+        $request = new NestedReferenceRequest();
+        $response = $gapicClient->nestedReferenceMethod($request);
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.resourcenames.ResourceNames/NestedReferenceMethod', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function nestedReferenceMethodExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        $request = new NestedReferenceRequest();
+        try {
+            $gapicClient->nestedReferenceMethod($request);
             // If the $gapicClient method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/ResourceNamesClientTest.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/ResourceNamesClientTest.php
@@ -238,6 +238,58 @@ class ResourceNamesClientTest extends GeneratedTest
     }
 
     /** @test */
+    public function nestedReferenceMethodTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        // Mock response
+        $expectedResponse = new PlaceholderResponse();
+        $transport->addResponse($expectedResponse);
+        $response = $gapicClient->nestedReferenceMethod();
+        $this->assertEquals($expectedResponse, $response);
+        $actualRequests = $transport->popReceivedCalls();
+        $this->assertSame(1, count($actualRequests));
+        $actualFuncCall = $actualRequests[0]->getFuncCall();
+        $actualRequestObject = $actualRequests[0]->getRequestObject();
+        $this->assertSame('/testing.resourcenames.ResourceNames/NestedReferenceMethod', $actualFuncCall);
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
+    public function nestedReferenceMethodExceptionTest()
+    {
+        $transport = $this->createTransport();
+        $gapicClient = $this->createClient([
+            'transport' => $transport,
+        ]);
+        $this->assertTrue($transport->isExhausted());
+        $status = new stdClass();
+        $status->code = Code::DATA_LOSS;
+        $status->details = 'internal error';
+        $expectedExceptionMessage  = json_encode([
+            'message' => 'internal error',
+            'code' => Code::DATA_LOSS,
+            'status' => 'DATA_LOSS',
+            'details' => [],
+        ], JSON_PRETTY_PRINT);
+        $transport->addResponse(null, $status);
+        try {
+            $gapicClient->nestedReferenceMethod();
+            // If the $gapicClient method call did not throw, fail the test
+            $this->fail('Expected an ApiException, but no exception was thrown.');
+        } catch (ApiException $ex) {
+            $this->assertEquals($status->code, $ex->getCode());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
+        }
+        // Call popReceivedCalls to ensure the stub is exhausted
+        $transport->popReceivedCalls();
+        $this->assertTrue($transport->isExhausted());
+    }
+
+    /** @test */
     public function singlePatternMethodTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/ResourceNames/resource-names.proto
+++ b/tests/Unit/ProtoTests/ResourceNames/resource-names.proto
@@ -72,6 +72,13 @@ service ResourceNames {
       body: "*"
     };
   }
+
+  rpc NestedReferenceMethod(NestedReferenceRequest) returns (PlaceholderResponse) {
+    option (google.api.http) = {
+      post: "/path:nestedReferenceMethod"
+      body: "*"
+    };
+  }
 }
 
 message SinglePatternRequest {
@@ -271,3 +278,26 @@ option (google.api.resource_definition) = {
 };
 
 message PlaceholderResponse {}
+
+message NestedReferenceRequest {
+  NestedReferenceMessage nested_reference_message = 1;
+}
+
+// Only referenced by name in NestedReferenceMessage
+option (google.api.resource_definition) = {
+  type: "resourcenames.example.com/OtherReferenceResource",
+  pattern: "otherReferenceResource/{other_reference_resource}"
+};
+
+message NestedReferenceMessage {
+  option (google.api.resource) = {
+    type: "resourcenames.example.com/NestedReferenceMessage",
+    pattern: "nestedReferenceMessages/{nested_reference_message}"
+  };
+
+  string name = 1;
+
+  string other = 2 [(google.api.resource_reference).type = "resourcenames.example.com/OtherReferenceResource"];
+}
+
+


### PR DESCRIPTION
Previously, the algorithm for identifying resources in scope of helper generation only traversed fields of type message that were annotated as required (and of course, represented a resource). This resulted in some such fields being excluded from helper generation, when they are in fact part of the request message tree.

This just removes that check on `isRequired` field, bringing such references in scope.

Updates #453