### PR TITLE
feat: add phpdoc examples tag

### DIFF
--- a/src/Ast/PhpDoc.php
+++ b/src/Ast/PhpDoc.php
@@ -443,8 +443,31 @@ abstract class PhpDoc
         };
     }
 
+    /**
+     * Add a code example to the PHP doc block via the @example tag.
+     *
+     * @param string $sampleFile The relative path to the generated sample file
+     *
+     * @return PhpDoc
+     */
+    public static function sample(string $sampleFile): PhpDoc
+    {
+        return new class($sampleFile) extends PhpDoc {
+            public function __construct($sampleFile)
+            {
+                $this->sampleFile = $sampleFile;
+                $this->isMethodDoc = true;
+            }
+            protected function toLines(Map $info = null): Vector
+            {
+                // @example samples/V1/ExampleClient/create_instance.php
+                return Vector::new(["@example {$this->sampleFile}", ""]);
+            }
+        };
+    }
+
     public static function method(string $name, string $response, string $request): PhpDoc
-    { 
+    {
         return new class($name, $response, $request) extends PhpDoc {
             public function __construct($name, $response, $request)
             {

--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -345,7 +345,7 @@ class CodeGenerator
             // [Start V2 GAPIC surface generation]
             if ($migrationMode != MigrationMode::PRE_MIGRATION_SURFACE_ONLY) {
                 $ctx = new SourceFileContext($service->gapicClientType->getNamespace(), $licenseYear);
-                $file = GapicClientV2Generator::generate($ctx, $service);
+                $file = GapicClientV2Generator::generate($ctx, $service, $generateSnippets);
                 $code = $file->toCode();
                 $code = Formatter::format($code);
                 yield ["src/{$version}Client/BaseClient/{$service->gapicClientV2Type->name}.php", $code];

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -38,6 +38,8 @@ use Google\Generator\Ast\PhpDoc;
 use Google\Generator\Ast\PhpFile;
 use Google\Generator\Collections\Map;
 use Google\Generator\Collections\Vector;
+use Google\Generator\Utils\Helpers;
+use Google\Generator\Utils\MigrationMode;
 use Google\Generator\Utils\ResolvedType;
 use Google\Generator\Utils\Transport;
 use Google\Generator\Utils\Type;
@@ -682,6 +684,9 @@ class GapicClientV2Generator
                                 AST::method($method->methodName . 'Async'))(),
                             '.')
                         : null,
+                    in_array($this->serviceDetails->migrationMode, [MigrationMode::MIGRATING, MigrationMode::NEW_SURFACE_ONLY])
+                        ? PhpDoc::sample($this->snippetPathForMethod($method))
+                        : null,
                     $usesRequest
                         ? PhpDoc::param($required, PhpDoc::text('A request to house fields associated with the call.'))
                         : null,
@@ -749,5 +754,14 @@ class GapicClientV2Generator
       }
 
       return $call;
+    }
+
+    private function snippetPathForMethod(MethodDetails $method): string
+    {
+        $methodName = Helpers::toSnakeCase($method->name);
+        $version = Helpers::nsVersionAndSuffixPath($this->serviceDetails->namespace);
+        $emptyClientName = $this->serviceDetails->emptyClientV2Type->name;
+
+        return "samples/{$version}{$emptyClientName}/{$methodName}.php";
     }
 }

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -760,6 +760,9 @@ class GapicClientV2Generator
     {
         $methodName = Helpers::toSnakeCase($method->name);
         $version = Helpers::nsVersionAndSuffixPath($this->serviceDetails->namespace);
+        if ($version !== '') {
+            $version .= '/';
+        }
         $emptyClientName = $this->serviceDetails->emptyClientV2Type->name;
 
         return "samples/{$version}{$emptyClientName}/{$methodName}.php";

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -49,18 +49,21 @@ class GapicClientV2Generator
 {
     private const CALL_OPTIONS_VAR = 'callOptions';
 
-    public static function generate(SourceFileContext $ctx, ServiceDetails $serviceDetails): PhpFile
+    public static function generate(SourceFileContext $ctx, ServiceDetails $serviceDetails, bool $generateSnippets): PhpFile
     {
-        return (new GapicClientV2Generator($ctx, $serviceDetails))->generateImpl();
+        return (new GapicClientV2Generator($ctx, $serviceDetails, $generateSnippets))->generateImpl();
     }
 
     private SourceFileContext $ctx;
     private ServiceDetails $serviceDetails;
+    // TODO(v2): This can be cleaned up after the v2 migration is complete.
+    private bool $generateSnippets;
 
-    private function __construct(SourceFileContext $ctx, ServiceDetails $serviceDetails)
+    private function __construct(SourceFileContext $ctx, ServiceDetails $serviceDetails, bool $generateSnippets)
     {
         $this->ctx = $ctx;
         $this->serviceDetails = $serviceDetails;
+        $this->generateSnippets = $generateSnippets;
     }
 
     private function generateImpl(): PhpFile
@@ -684,7 +687,10 @@ class GapicClientV2Generator
                                 AST::method($method->methodName . 'Async'))(),
                             '.')
                         : null,
-                    in_array($this->serviceDetails->migrationMode, [MigrationMode::MIGRATING, MigrationMode::NEW_SURFACE_ONLY])
+                    $this->generateSnippets && in_array(
+                        $this->serviceDetails->migrationMode,
+                        [MigrationMode::MIGRATING, MigrationMode::NEW_SURFACE_ONLY]
+                    )
                         ? PhpDoc::sample($this->snippetPathForMethod($method))
                         : null,
                     $usesRequest

--- a/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/BaseClient/CloudFunctionsServiceBaseClient.php
@@ -297,6 +297,8 @@ abstract class CloudFunctionsServiceBaseClient
      *
      * The async variant is {@see self::callFunctionAsync()} .
      *
+     * @example samples/V1/CloudFunctionsServiceClient/call_function.php
+     *
      * @param CallFunctionRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
      *     Optional.
@@ -323,6 +325,8 @@ abstract class CloudFunctionsServiceBaseClient
      *
      * The async variant is {@see self::createFunctionAsync()} .
      *
+     * @example samples/V1/CloudFunctionsServiceClient/create_function.php
+     *
      * @param CreateFunctionRequest $request     A request to house fields associated with the call.
      * @param array                 $callOptions {
      *     Optional.
@@ -348,6 +352,8 @@ abstract class CloudFunctionsServiceBaseClient
      * remove this function.
      *
      * The async variant is {@see self::deleteFunctionAsync()} .
+     *
+     * @example samples/V1/CloudFunctionsServiceClient/delete_function.php
      *
      * @param DeleteFunctionRequest $request     A request to house fields associated with the call.
      * @param array                 $callOptions {
@@ -376,6 +382,8 @@ abstract class CloudFunctionsServiceBaseClient
      * https://cloud.google.com/storage/docs/access-control/signed-urls
      *
      * The async variant is {@see self::generateDownloadUrlAsync()} .
+     *
+     * @example samples/V1/CloudFunctionsServiceClient/generate_download_url.php
      *
      * @param GenerateDownloadUrlRequest $request     A request to house fields associated with the call.
      * @param array                      $callOptions {
@@ -425,6 +433,8 @@ abstract class CloudFunctionsServiceBaseClient
      *
      * The async variant is {@see self::generateUploadUrlAsync()} .
      *
+     * @example samples/V1/CloudFunctionsServiceClient/generate_upload_url.php
+     *
      * @param GenerateUploadUrlRequest $request     A request to house fields associated with the call.
      * @param array                    $callOptions {
      *     Optional.
@@ -448,6 +458,8 @@ abstract class CloudFunctionsServiceBaseClient
      * Returns a function with the given name from the requested project.
      *
      * The async variant is {@see self::getFunctionAsync()} .
+     *
+     * @example samples/V1/CloudFunctionsServiceClient/get_function.php
      *
      * @param GetFunctionRequest $request     A request to house fields associated with the call.
      * @param array              $callOptions {
@@ -475,6 +487,8 @@ abstract class CloudFunctionsServiceBaseClient
      *
      * The async variant is {@see self::getIamPolicyAsync()} .
      *
+     * @example samples/V1/CloudFunctionsServiceClient/get_iam_policy.php
+     *
      * @param GetIamPolicyRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
      *     Optional.
@@ -498,6 +512,8 @@ abstract class CloudFunctionsServiceBaseClient
      * Returns a list of functions that belong to the requested project.
      *
      * The async variant is {@see self::listFunctionsAsync()} .
+     *
+     * @example samples/V1/CloudFunctionsServiceClient/list_functions.php
      *
      * @param ListFunctionsRequest $request     A request to house fields associated with the call.
      * @param array                $callOptions {
@@ -523,6 +539,8 @@ abstract class CloudFunctionsServiceBaseClient
      * Replaces any existing policy.
      *
      * The async variant is {@see self::setIamPolicyAsync()} .
+     *
+     * @example samples/V1/CloudFunctionsServiceClient/set_iam_policy.php
      *
      * @param SetIamPolicyRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
@@ -551,6 +569,8 @@ abstract class CloudFunctionsServiceBaseClient
      *
      * The async variant is {@see self::testIamPermissionsAsync()} .
      *
+     * @example samples/V1/CloudFunctionsServiceClient/test_iam_permissions.php
+     *
      * @param TestIamPermissionsRequest $request     A request to house fields associated with the call.
      * @param array                     $callOptions {
      *     Optional.
@@ -574,6 +594,8 @@ abstract class CloudFunctionsServiceBaseClient
      * Updates existing function.
      *
      * The async variant is {@see self::updateFunctionAsync()} .
+     *
+     * @example samples/V1/CloudFunctionsServiceClient/update_function.php
      *
      * @param UpdateFunctionRequest $request     A request to house fields associated with the call.
      * @param array                 $callOptions {

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/BaseClient/SecurityCenterBaseClient.php
@@ -666,6 +666,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::createFindingAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/create_finding.php
+     *
      * @param CreateFindingRequest $request     A request to house fields associated with the call.
      * @param array                $callOptions {
      *     Optional.
@@ -689,6 +691,8 @@ abstract class SecurityCenterBaseClient
      * Creates a notification config.
      *
      * The async variant is {@see self::createNotificationConfigAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/create_notification_config.php
      *
      * @param CreateNotificationConfigRequest $request     A request to house fields associated with the call.
      * @param array                           $callOptions {
@@ -714,6 +718,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::createSourceAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/create_source.php
+     *
      * @param CreateSourceRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
      *     Optional.
@@ -738,6 +744,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::deleteNotificationConfigAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/delete_notification_config.php
+     *
      * @param DeleteNotificationConfigRequest $request     A request to house fields associated with the call.
      * @param array                           $callOptions {
      *     Optional.
@@ -759,6 +767,8 @@ abstract class SecurityCenterBaseClient
      * Gets the access control policy on the specified Source.
      *
      * The async variant is {@see self::getIamPolicyAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/get_iam_policy.php
      *
      * @param GetIamPolicyRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
@@ -784,6 +794,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::getNotificationConfigAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/get_notification_config.php
+     *
      * @param GetNotificationConfigRequest $request     A request to house fields associated with the call.
      * @param array                        $callOptions {
      *     Optional.
@@ -807,6 +819,8 @@ abstract class SecurityCenterBaseClient
      * Gets the settings for an organization.
      *
      * The async variant is {@see self::getOrganizationSettingsAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/get_organization_settings.php
      *
      * @param GetOrganizationSettingsRequest $request     A request to house fields associated with the call.
      * @param array                          $callOptions {
@@ -832,6 +846,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::getSourceAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/get_source.php
+     *
      * @param GetSourceRequest $request     A request to house fields associated with the call.
      * @param array            $callOptions {
      *     Optional.
@@ -856,6 +872,8 @@ abstract class SecurityCenterBaseClient
      * properties.
      *
      * The async variant is {@see self::groupAssetsAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/group_assets.php
      *
      * @param GroupAssetsRequest $request     A request to house fields associated with the call.
      * @param array              $callOptions {
@@ -887,6 +905,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::groupFindingsAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/group_findings.php
+     *
      * @param GroupFindingsRequest $request     A request to house fields associated with the call.
      * @param array                $callOptions {
      *     Optional.
@@ -910,6 +930,8 @@ abstract class SecurityCenterBaseClient
      * Lists an organization's assets.
      *
      * The async variant is {@see self::listAssetsAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/list_assets.php
      *
      * @param ListAssetsRequest $request     A request to house fields associated with the call.
      * @param array             $callOptions {
@@ -938,6 +960,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::listFindingsAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/list_findings.php
+     *
      * @param ListFindingsRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
      *     Optional.
@@ -962,6 +986,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::listNotificationConfigsAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/list_notification_configs.php
+     *
      * @param ListNotificationConfigsRequest $request     A request to house fields associated with the call.
      * @param array                          $callOptions {
      *     Optional.
@@ -985,6 +1011,8 @@ abstract class SecurityCenterBaseClient
      * Lists all sources belonging to an organization.
      *
      * The async variant is {@see self::listSourcesAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/list_sources.php
      *
      * @param ListSourcesRequest $request     A request to house fields associated with the call.
      * @param array              $callOptions {
@@ -1015,6 +1043,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::runAssetDiscoveryAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/run_asset_discovery.php
+     *
      * @param RunAssetDiscoveryRequest $request     A request to house fields associated with the call.
      * @param array                    $callOptions {
      *     Optional.
@@ -1038,6 +1068,8 @@ abstract class SecurityCenterBaseClient
      * Updates the state of a finding.
      *
      * The async variant is {@see self::setFindingStateAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/set_finding_state.php
      *
      * @param SetFindingStateRequest $request     A request to house fields associated with the call.
      * @param array                  $callOptions {
@@ -1063,6 +1095,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::setIamPolicyAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/set_iam_policy.php
+     *
      * @param SetIamPolicyRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {
      *     Optional.
@@ -1086,6 +1120,8 @@ abstract class SecurityCenterBaseClient
      * Returns the permissions that a caller has on the specified source.
      *
      * The async variant is {@see self::testIamPermissionsAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/test_iam_permissions.php
      *
      * @param TestIamPermissionsRequest $request     A request to house fields associated with the call.
      * @param array                     $callOptions {
@@ -1111,6 +1147,8 @@ abstract class SecurityCenterBaseClient
      * finding creation to succeed.
      *
      * The async variant is {@see self::updateFindingAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/update_finding.php
      *
      * @param UpdateFindingRequest $request     A request to house fields associated with the call.
      * @param array                $callOptions {
@@ -1138,6 +1176,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::updateNotificationConfigAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/update_notification_config.php
+     *
      * @param UpdateNotificationConfigRequest $request     A request to house fields associated with the call.
      * @param array                           $callOptions {
      *     Optional.
@@ -1161,6 +1201,8 @@ abstract class SecurityCenterBaseClient
      * Updates an organization's settings.
      *
      * The async variant is {@see self::updateOrganizationSettingsAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/update_organization_settings.php
      *
      * @param UpdateOrganizationSettingsRequest $request     A request to house fields associated with the call.
      * @param array                             $callOptions {
@@ -1186,6 +1228,8 @@ abstract class SecurityCenterBaseClient
      *
      * The async variant is {@see self::updateSecurityMarksAsync()} .
      *
+     * @example samples/V1/SecurityCenterClient/update_security_marks.php
+     *
      * @param UpdateSecurityMarksRequest $request     A request to house fields associated with the call.
      * @param array                      $callOptions {
      *     Optional.
@@ -1209,6 +1253,8 @@ abstract class SecurityCenterBaseClient
      * Updates a source.
      *
      * The async variant is {@see self::updateSourceAsync()} .
+     *
+     * @example samples/V1/SecurityCenterClient/update_source.php
      *
      * @param UpdateSourceRequest $request     A request to house fields associated with the call.
      * @param array               $callOptions {

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BaseClient/BasicBaseClient.php
@@ -168,6 +168,8 @@ abstract class BasicBaseClient
      *
      * The async variant is {@see self::aMethodAsync()} .
      *
+     * @example samples/BasicClient/a_method.php
+     *
      * @param Request $request     A request to house fields associated with the call.
      * @param array   $callOptions {
      *     Optional.
@@ -191,6 +193,8 @@ abstract class BasicBaseClient
      * Test including method args.
      *
      * The async variant is {@see self::methodWithArgsAsync()} .
+     *
+     * @example samples/BasicClient/method_with_args.php
      *
      * @param RequestWithArgs $request     A request to house fields associated with the call.
      * @param array           $callOptions {

--- a/tests/Unit/ProtoTests/BasicOneofNew/out/src/Client/BaseClient/BasicOneofNewBaseClient.php
+++ b/tests/Unit/ProtoTests/BasicOneofNew/out/src/Client/BaseClient/BasicOneofNewBaseClient.php
@@ -166,6 +166,8 @@ abstract class BasicOneofNewBaseClient
      *
      * The async variant is {@see self::aMethodAsync()} .
      *
+     * @example samples/BasicOneofNewClient/a_method.php
+     *
      * @param Request $request     A request to house fields associated with the call.
      * @param array   $callOptions {
      *     Optional.

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/BaseClient/RoutingHeadersBaseClient.php
@@ -174,6 +174,8 @@ abstract class RoutingHeadersBaseClient
     /**
      * The async variant is {@see self::deleteMethodAsync()} .
      *
+     * @example samples/RoutingHeadersClient/delete_method.php
+     *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
      *     Optional.
@@ -195,6 +197,8 @@ abstract class RoutingHeadersBaseClient
 
     /**
      * The async variant is {@see self::getMethodAsync()} .
+     *
+     * @example samples/RoutingHeadersClient/get_method.php
      *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
@@ -218,6 +222,8 @@ abstract class RoutingHeadersBaseClient
     /**
      * The async variant is {@see self::getNoPlaceholdersMethodAsync()} .
      *
+     * @example samples/RoutingHeadersClient/get_no_placeholders_method.php
+     *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
      *     Optional.
@@ -239,6 +245,8 @@ abstract class RoutingHeadersBaseClient
 
     /**
      * The async variant is {@see self::getNoTemplateMethodAsync()} .
+     *
+     * @example samples/RoutingHeadersClient/get_no_template_method.php
      *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
@@ -262,6 +270,8 @@ abstract class RoutingHeadersBaseClient
     /**
      * The async variant is {@see self::nestedMethodAsync()} .
      *
+     * @example samples/RoutingHeadersClient/nested_method.php
+     *
      * @param NestedRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
      *     Optional.
@@ -283,6 +293,8 @@ abstract class RoutingHeadersBaseClient
 
     /**
      * The async variant is {@see self::nestedMultiMethodAsync()} .
+     *
+     * @example samples/RoutingHeadersClient/nested_multi_method.php
      *
      * @param NestedRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
@@ -306,6 +318,8 @@ abstract class RoutingHeadersBaseClient
     /**
      * The async variant is {@see self::orderingMethodAsync()} .
      *
+     * @example samples/RoutingHeadersClient/ordering_method.php
+     *
      * @param OrderRequest $request     A request to house fields associated with the call.
      * @param array        $callOptions {
      *     Optional.
@@ -327,6 +341,8 @@ abstract class RoutingHeadersBaseClient
 
     /**
      * The async variant is {@see self::patchMethodAsync()} .
+     *
+     * @example samples/RoutingHeadersClient/patch_method.php
      *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
@@ -350,6 +366,8 @@ abstract class RoutingHeadersBaseClient
     /**
      * The async variant is {@see self::postMethodAsync()} .
      *
+     * @example samples/RoutingHeadersClient/post_method.php
+     *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
      *     Optional.
@@ -371,6 +389,8 @@ abstract class RoutingHeadersBaseClient
 
     /**
      * The async variant is {@see self::putMethodAsync()} .
+     *
+     * @example samples/RoutingHeadersClient/put_method.php
      *
      * @param SimpleRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
@@ -394,6 +414,8 @@ abstract class RoutingHeadersBaseClient
     /**
      * The async variant is {@see self::routingRuleWithOutParametersAsync()} .
      *
+     * @example samples/RoutingHeadersClient/routing_rule_with_out_parameters.php
+     *
      * @param NestedRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {
      *     Optional.
@@ -415,6 +437,8 @@ abstract class RoutingHeadersBaseClient
 
     /**
      * The async variant is {@see self::routingRuleWithParametersAsync()} .
+     *
+     * @example samples/RoutingHeadersClient/routing_rule_with_parameters.php
      *
      * @param NestedRequest $request     A request to house fields associated with the call.
      * @param array         $callOptions {


### PR DESCRIPTION
fixes #547

With phpDocumentor we could remove the prefixed `samples/` by passing in `--examplesdir=samples` when we run `phpdoc`. However, I think including `samples/` in the path is better, since it makes things less ambiguous for anyone looking at the code rather than the published docs.