### PR TITLE
chore: rename processor interface

### DIFF
--- a/src/PostProcessor/FragmentInjectionProcessor.php
+++ b/src/PostProcessor/FragmentInjectionProcessor.php
@@ -26,7 +26,7 @@ use Microsoft\PhpParser\DiagnosticsProvider;
 use LogicException;
 use ParseError;
 
-class FragmentInjectionProcessor implements Processor
+class FragmentInjectionProcessor implements ProcessorInterface
 {
     private ClassDeclaration $classNode;
 
@@ -38,7 +38,7 @@ class FragmentInjectionProcessor implements Processor
         foreach($fragmentItr as $finding) {
             $fragmentPath = $finding[0];
             $protoPath = str_replace(['fragments', '.build.txt'], ['proto/src', '.php'], $fragmentPath);
-            
+
             self::inject($fragmentPath, $protoPath);
         }
     }

--- a/src/PostProcessor/ProcessorInterface.php
+++ b/src/PostProcessor/ProcessorInterface.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 
 namespace Google\PostProcessor;
 
-interface Processor
+interface ProcessorInterface
 {
     public static function run(string $inputDir);
 }


### PR DESCRIPTION
I missed this the first time around, but all interfaces should be suffixed with `Interface`. This is not an official PHP standard, but it is standard across all the `googleapis` libraries we maintain.