### PR TITLE
fix: add optional-to-required fix for analytics admin

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -138,6 +138,7 @@ class FieldDetails
      * AFTER a package's 1.0 release, back to being optional.
      */
     private static $optionalToRequiredFixes = [
+        'google.analytics.admin.v1beta.UpdateMeasurementProtocolSecretRequest' => ['updateMask'],
         'google.logging.v2.UpdateCmekSettingsRequest' => ['name', 'cmek_settings'],
         'google.logging.v2.GetCmekSettingsRequest' => ['name'],
         'google.cloud.videointelligence.v1.AnnotateVideoRequest' => ['features'],


### PR DESCRIPTION
Fix optional field which was changed to required in AnalyticsAdmin

See https://github.com/googleapis/googleapis/blob/master/google/analytics/admin/v1beta/analytics_admin.proto#L275 See https://github.com/googleapis/google-cloud-php/pull/6588

**NOTE**: This API is NOT GA, so it may be best to just take the breaking change