### PR TITLE
Revert "fix: optional-to-required parameter in NetworkConnectivity policy based routing"

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -115,7 +115,6 @@ class FieldDetails
         'google.bigtable.admin.v2.Instance' => ['name', 'type', 'labels'],
         'google.cloud.asset.v1.BatchGetAssetsHistoryRequest' => ['content_type', 'read_time_window'],
         'google.cloud.datacatalog.v1.SearchCatalogRequest' => ['query'],
-        'google.cloud.networkconnectivity.v1.CreatePolicyBasedRouteRequest' => ['policy_based_route_id'],
         'google.cloud.scheduler.v1.UpdateJobRequest' => ['update_mask'],
         'google.datastore.v1.CommitRequest' => ['mode', 'mutations'],
         'google.datastore.v1.RunQueryRequest' => ['partition_id'],


### PR DESCRIPTION
Reverts googleapis/gapic-generator-php#653 - this was in the wrong place, and also we don't want to make this fix anyway.