### PR TITLE
fix: correct method for supportedTransports

### DIFF
--- a/src/Generation/GapicClientGenerator.php
+++ b/src/Generation/GapicClientGenerator.php
@@ -139,7 +139,7 @@ class GapicClientGenerator
             ->withMember($this->operationsClient())
             ->withMember($this->getClientDefaults())
             ->withMember($this->defaultTransport())
-            ->withMember($this->getSupportedTransports())
+            ->withMember($this->supportedTransports())
             ->withMembers($this->resourceMethods())
             ->withMembers($this->operationMethods())
             ->withMember($this->construct())
@@ -488,13 +488,13 @@ class GapicClientGenerator
             ));
     }
 
-    private function getSupportedTransports()
+    private function supportedTransports()
     {
         if ($this->serviceDetails->transportType !== Transport::REST) {
             return null;
         }
-        return AST::method('getSupportedTransports')
-            ->withPhpDocText('Implements GapicClientTrait::getSupportedTransports.')
+        return AST::method('supportedTransports')
+            ->withPhpDocText('Implements GapicClientTrait::supportedTransports.')
             ->withAccess(Access::PRIVATE, Access::STATIC)
             ->withBody(AST::block(
                 AST::return(AST::array(['rest']))

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -143,7 +143,7 @@ class GapicClientV2Generator
             ->withMember($this->operationsClient())
             ->withMember($this->getClientDefaults())
             ->withMember($this->defaultTransport())
-            ->withMember($this->getSupportedTransports())
+            ->withMember($this->supportedTransports())
             ->withMembers($this->operationMethods())
             ->withMembers($this->resourceMethods())
             ->withMember($this->construct())
@@ -476,13 +476,13 @@ class GapicClientV2Generator
             ));
     }
 
-    private function getSupportedTransports()
+    private function supportedTransports()
     {
         if ($this->serviceDetails->transportType !== Transport::REST) {
             return null;
         }
-        return AST::method('getSupportedTransports')
-            ->withPhpDocText('Implements GapicClientTrait::getSupportedTransports.')
+        return AST::method('supportedTransports')
+            ->withPhpDocText('Implements GapicClientTrait::supportedTransports.')
             ->withAccess(Access::PRIVATE, Access::STATIC)
             ->withBody(AST::block(
                 AST::return(AST::array(['rest']))

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
@@ -133,8 +133,8 @@ class AddressesGapicClient
         return 'rest';
     }
 
-    /** Implements GapicClientTrait::getSupportedTransports. */
-    private static function getSupportedTransports()
+    /** Implements GapicClientTrait::supportedTransports. */
+    private static function supportedTransports()
     {
         return [
             'rest',

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/RegionOperationsGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/RegionOperationsGapicClient.php
@@ -110,8 +110,8 @@ class RegionOperationsGapicClient
         return 'rest';
     }
 
-    /** Implements GapicClientTrait::getSupportedTransports. */
-    private static function getSupportedTransports()
+    /** Implements GapicClientTrait::supportedTransports. */
+    private static function supportedTransports()
     {
         return [
             'rest',

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryGapicClient.php
@@ -229,8 +229,8 @@ class LibraryGapicClient
         return 'rest';
     }
 
-    /** Implements GapicClientTrait::getSupportedTransports. */
-    private static function getSupportedTransports()
+    /** Implements GapicClientTrait::supportedTransports. */
+    private static function supportedTransports()
     {
         return [
             'rest',

--- a/tests/Unit/ProtoTests/ClientTest.php
+++ b/tests/Unit/ProtoTests/ClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Unit/ProtoTests/ClientTest.php
+++ b/tests/Unit/ProtoTests/ClientTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Generator\Tests\Unit\ProtoTests;
+
+use PHPUnit\Framework\TestCase;
+use Testing\BasicDiregapic\LibraryClient;
+use Google\ApiCore\InsecureCredentialsWrapper;
+use Google\ApiCore\ValidationException;
+
+final class ClientTest extends TestCase
+{
+    public function testUnsupportedTransportThrowsException()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Unexpected transport option "grpc". Supported transports: rest');
+
+        $client = new LibraryClient([
+            'transport' => 'grpc',
+            'credentials' => new InsecureCredentialsWrapper(),
+        ]);
+    }
+}

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
@@ -128,8 +128,8 @@ class CustomLroGapicClient
         return 'rest';
     }
 
-    /** Implements GapicClientTrait::getSupportedTransports. */
-    private static function getSupportedTransports()
+    /** Implements GapicClientTrait::supportedTransports. */
+    private static function supportedTransports()
     {
         return [
             'rest',

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
@@ -102,8 +102,8 @@ class CustomLroOperationsGapicClient
         return 'rest';
     }
 
-    /** Implements GapicClientTrait::getSupportedTransports. */
-    private static function getSupportedTransports()
+    /** Implements GapicClientTrait::supportedTransports. */
+    private static function supportedTransports()
     {
         return [
             'rest',


### PR DESCRIPTION
Woops! We've been writing the wrong method name all this time. The method is actually `supportedTransports`, but we've been generating `getSupportedTransports`. OH NO!

See [`ClientOptionsTrait::supportedTransports`](https://github.com/googleapis/gax-php/blob/54a863e63ee318308637adb283f6157ccc3aabbb/src/ClientOptionsTrait.php#L284) (called [here](https://github.com/googleapis/gax-php/blob/54a863e63ee318308637adb283f6157ccc3aabbb/src/ClientOptionsTrait.php#L103))