### PR TITLE
chore: Add Bazel's MODULE files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 vendor/
 bazel-*
+MODULE.bazel.lock
+MODULE.bazel
 
 # PHP
 .php_cs.cache


### PR DESCRIPTION
Add Bazel's `MODULE` file to git ignore. This is due a previous PR having them in the files change by accident, meaning that this could easily happen to any other new member of the team. After a small conversation [here](https://github.com/googleapis/gapic-generator-php/pull/696#pullrequestreview-1958994516), I decided to add them to the `.gitignore`.
