### PR TITLE
feat: add patches for bigtable required to optional changes

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -120,6 +120,12 @@ class FieldDetails
     private static $requiredToOptionalFixes = [
         'google.bigtable.admin.v2.Cluster' => ['name', 'serve_nodes'],
         'google.bigtable.admin.v2.Instance' => ['name', 'type', 'labels'],
+        'google.bigtable.v2.CheckAndMutateRowRequest' => ['table_name', 'row_key'],
+        'google.bigtable.v2.MutateRowRequest' => ['table_name', 'row_key', 'mutations'],
+        'google.bigtable.v2.MutateRowsRequest' => ['table_name', 'entries'],
+        'google.bigtable.v2.ReadModifyWriteRowRequest' => ['table_name', 'row_key', 'rules'],
+        'google.bigtable.v2.ReadRowsRequest' => ['table_name'],
+        'google.bigtable.v2.SampleRowKeysRequest' => ['table_name'],
         'google.cloud.asset.v1.BatchGetAssetsHistoryRequest' => ['content_type', 'read_time_window'],
         'google.cloud.datacatalog.v1.SearchCatalogRequest' => ['query'],
         'google.cloud.scheduler.v1.UpdateJobRequest' => ['update_mask'],


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-php/pull/7118

Recent Bigtable changes have broken BC for the V1 clients because of moving multiple RPC signatures from required to optional. This PR adds patches to revert those changes for the PHP V1 generator.