### PR TITLE
feat: use createNewSurfaceOperationsClient for NEW_SURFACE_ONLY clients

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "google/gax": "^1.19.1"
+        "google/gax": "dev-add-create-new-surfaceoperations-client as 1.34.0"
     },
     "scripts": {
         "update-all-tests": [

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -459,7 +459,7 @@ class GapicClientV2Generator
             $credentialsConfig['useJwtAccessWithScope'] = false;
         }
         $clientDefaultValues['credentialsConfig'] = AST::array($credentialsConfig);
-        
+
         if ($this->serviceDetails->transportType !== Transport::GRPC) {
             $clientDefaultValues['transportConfig'] = AST::array([
                 'rest' => AST::array([
@@ -467,7 +467,7 @@ class GapicClientV2Generator
                 ])
             ]);
         }
-        
+
         if ($this->serviceDetails->hasCustomOp) {
             $clientDefaultValues['operationsClientClass'] = AST::access(
                 $this->ctx->type($this->serviceDetails->customOperationServiceClientType),
@@ -537,7 +537,7 @@ class GapicClientV2Generator
                 'object. Note that when this object is provided, any settings in $transportConfig, and any $apiEndpoint',
                 'setting, will be ignored.'
             );
-        
+
         $transportConfigSampleValues = [
             'grpc' => AST::arrayEllipsis(),
             'rest' => AST::arrayEllipsis()
@@ -598,7 +598,9 @@ class GapicClientV2Generator
                 $this->serviceDetails->hasLro || $this->serviceDetails->hasCustomOp
                     ? AST::assign(
                         AST::access(AST::THIS, $this->operationsClient()),
-                        AST::call(AST::THIS, AST::method('createOperationsClient'))($clientOptions)
+                        $this->serviceDetails->migrationMode === MigrationMode::NEW_SURFACE_ONLY
+                            ? AST::call(AST::THIS, AST::method('createNewSurfaceOperationsClient'))($clientOptions)
+                            : AST::call(AST::THIS, AST::method('createOperationsClient'))($clientOptions)
                     )
                     : null
             ))

--- a/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
@@ -318,7 +318,7 @@ final class CloudFunctionsServiceClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
-        $this->operationsClient = $this->createOperationsClient($clientOptions);
+        $this->operationsClient = $this->createNewSurfaceOperationsClient($clientOptions);
     }
 
     /** Handles execution of the async variants for each documented method. */

--- a/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
@@ -292,7 +292,7 @@ final class CloudRedisClient
     {
         $clientOptions = $this->buildClientOptions($options);
         $this->setClientOptions($clientOptions);
-        $this->operationsClient = $this->createOperationsClient($clientOptions);
+        $this->operationsClient = $this->createNewSurfaceOperationsClient($clientOptions);
     }
 
     /** Handles execution of the async variants for each documented method. */


### PR DESCRIPTION
Depends on https://github.com/googleapis/gax-php/pull/571

Uses new `GapicClientTrait::createNewSurfaceOperationsClient` method when clients have `migration_mode = NEW_SURFACE_ONLY`.

In these cases, the clients are either pre-1.0 or already 2.0, so they can safely use the new surface clients.