### PR TITLE
fix: Add two optional to required fields on dialogflow

### DIFF
--- a/src/Generation/FieldDetails.php
+++ b/src/Generation/FieldDetails.php
@@ -156,6 +156,7 @@ class FieldDetails
         'google.cloud.bigquery.datatransfer.v1.StartManualTransferRunsRequest' => ['parent'],
         'google.cloud.clouddms.v1.DescribeDatabaseEntitiesRequest' => ['tree'],
         'google.cloud.clouddms.v1.ImportMappingRulesRequest' => ['rules_format', 'rules_files', 'auto_commit'],
+        'google.cloud.dialogflow.v2.SearchKnowledgeRequest' => ['parent', 'session_id'],
         'google.cloud.texttospeech.v1.SynthesizeLongAudioRequest' => ['output_gcs_uri', 'voice'],
         'google.cloud.videointelligence.v1.AnnotateVideoRequest' => ['features'],
         'google.devtools.artifactregistry.v1beta2.ListFilesRequest' => ['parent'],


### PR DESCRIPTION
Related:
https://github.com/googleapis/google-cloud-php/pull/7579

Add an fix to the Dialogflow `SearchKnowledgeRequest` by reverting them to optional after the API made a breaking change changing two fields to mandatory when before were optional.