### PR TITLE
fix: add emulator support for pubsub clients

### DIFF
--- a/src/Generation/EmulatorSupportGenerator.php
+++ b/src/Generation/EmulatorSupportGenerator.php
@@ -36,6 +36,9 @@ class EmulatorSupportGenerator
         '\Google\Cloud\Bigtable\Admin\V2\Client\BigtableInstanceAdminClient' => 'BIGTABLE_EMULATOR_HOST',
         '\Google\Cloud\Bigtable\Admin\V2\Client\BigtableTableAdminClient' => 'BIGTABLE_EMULATOR_HOST',
         '\Google\Cloud\Bigtable\V2\Client\BigtableClient' => 'BIGTABLE_EMULATOR_HOST',
+        '\Google\Cloud\PubSub\V1\Client\PublisherClient' => 'PUBSUB_EMULATOR_HOST',
+        '\Google\Cloud\PubSub\V1\Client\SubscriberClient' => 'PUBSUB_EMULATOR_HOST',
+        '\Google\Cloud\PubSub\V1\Client\SchemaServiceClient' => 'PUBSUB_EMULATOR_HOST',
         // Added for unittesting
         '\Testing\Basic\Client\BasicClient' => 'BASIC_EMULATOR_HOST'
     ];


### PR DESCRIPTION
This logic is currently being handled in [RequestHandler](https://github.com/googleapis/google-cloud-php/blob/37844cbfe1f348df180f19648ee18d718e8f9f64/Core/src/RequestHandler.php#L71-L77) for PubSub V2, but for consistency with other GAPICs (and also to encourage users to consume the GAPICs directly), we should support it in the GAPIC clients as well.

TODO: Verify this plays nicely with the current implementation