### PR TITLE
fix: ensure ChannelCredentials class exists

### DIFF
--- a/src/Ast/AST.php
+++ b/src/Ast/AST.php
@@ -92,6 +92,9 @@ abstract class AST
     /** @var string Constant to reference `getenv`. */
     public const GET_ENV = "\0getenv";
 
+    /** @var string Constant to reference `class_exists`. */
+    public const CLASS_EXISTS = "\0class_exists";
+
     protected static function deref($obj): string
     {
         return $obj === static::SELF || $obj instanceof ResolvedType ? '::' : '->';

--- a/src/Generation/EmulatorSupportGenerator.php
+++ b/src/Generation/EmulatorSupportGenerator.php
@@ -75,10 +75,15 @@ class EmulatorSupportGenerator
                         AST::assign($emulatorHostVar, AST::call(AST::STRING_REPLACE)($searchVar, '', $emulatorHostVar)),
                     )),
                 AST::nullCoalescingAssign(AST::index($optionsVar, 'apiEndpoint'), $emulatorHostVar),
-                AST::nullCoalescingAssign($transportConfigIndexVar, AST::staticCall(
-                    $ctx->type((Type::fromName("Grpc\ChannelCredentials"))),
-                    AST::method('createInsecure')
-                )()),
+                AST::if(AST::call(AST::CLASS_EXISTS)(
+                    AST::access($ctx->type(Type::fromName("Grpc\ChannelCredentials")), AST::CLS)
+                ))
+                    ->then(AST::block(
+                        AST::nullCoalescingAssign($transportConfigIndexVar, AST::staticCall(
+                            $ctx->type((Type::fromName("Grpc\ChannelCredentials"))),
+                            AST::method('createInsecure')
+                        )()),
+                    )),
                 AST::nullCoalescingAssign(
                     AST::index($optionsVar,'credentials'),
                     AST::new($ctx->type((Type::fromName("Google\ApiCore\InsecureCredentialsWrapper"))))()

--- a/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
+++ b/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
@@ -1065,7 +1065,10 @@ final class DatabaseAdminClient
         }
 
         $options['apiEndpoint'] ??= $emulatorHost;
-        $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        if (class_exists(ChannelCredentials::class)) {
+            $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        }
+
         $options['credentials'] ??= new InsecureCredentialsWrapper();
         return $options;
     }

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -243,7 +243,10 @@ final class BasicClient
         }
 
         $options['apiEndpoint'] ??= $emulatorHost;
-        $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        if (class_exists(ChannelCredentials::class)) {
+            $options['transportConfig']['grpc']['stubOpts']['credentials'] ??= ChannelCredentials::createInsecure();
+        }
+
         $options['credentials'] ??= new InsecureCredentialsWrapper();
         return $options;
     }


### PR DESCRIPTION
addresses https://github.com/googleapis/google-cloud-php/pull/8053 and https://github.com/googleapis/google-cloud-php/issues/8052