### PR TITLE
Remove final from client without interfaces

### DIFF
--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -108,7 +108,7 @@ class GapicClientV2Generator
     {
         return AST::class(
                 $this->serviceDetails->gapicClientV2Type,
-                final: true)
+                )
             ->withPhpDoc(PhpDoc::block(
                 PhpDoc::preFormattedText(
                     $this->serviceDetails->docLines->skip(1)

--- a/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
@@ -79,7 +79,7 @@ use Psr\Log\LoggerInterface;
  * @method PromiseInterface<TestIamPermissionsResponse> testIamPermissionsAsync(TestIamPermissionsRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<OperationResponse> updateFunctionAsync(UpdateFunctionRequest $request, array $optionalArgs = [])
  */
-final class CloudFunctionsServiceClient
+class CloudFunctionsServiceClient
 {
     use GapicClientTrait;
     use ResourceHelperTrait;

--- a/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
@@ -94,7 +94,7 @@ use Psr\Log\LoggerInterface;
  * @method PromiseInterface<Location> getLocationAsync(GetLocationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<PagedListResponse> listLocationsAsync(ListLocationsRequest $request, array $optionalArgs = [])
  */
-final class CloudRedisClient
+class CloudRedisClient
 {
     use GapicClientTrait;
     use ResourceHelperTrait;

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
@@ -154,7 +154,7 @@ use Psr\Log\LoggerInterface;
  * @method PromiseInterface<SecurityMarks> updateSecurityMarksAsync(UpdateSecurityMarksRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<Source> updateSourceAsync(UpdateSourceRequest $request, array $optionalArgs = [])
  */
-final class SecurityCenterClient
+class SecurityCenterClient
 {
     use GapicClientTrait;
     use ResourceHelperTrait;

--- a/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
+++ b/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
@@ -110,7 +110,7 @@ use Psr\Log\LoggerInterface;
  * @method PromiseInterface<OperationResponse> updateDatabaseAsync(UpdateDatabaseRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<OperationResponse> updateDatabaseDdlAsync(UpdateDatabaseDdlRequest $request, array $optionalArgs = [])
  */
-final class DatabaseAdminClient
+class DatabaseAdminClient
 {
     use GapicClientTrait;
     use ResourceHelperTrait;

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -48,7 +48,7 @@ use Testing\Basic\Response;
  * @method PromiseInterface<Response> aMethodAsync(Request $request, array $optionalArgs = [])
  * @method PromiseInterface<Response> methodWithArgsAsync(RequestWithArgs $request, array $optionalArgs = [])
  */
-final class BasicClient
+class BasicClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Client/BasicExplicitPaginatedClient.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Client/BasicExplicitPaginatedClient.php
@@ -44,7 +44,7 @@ use Testing\BasicExplicitPaginated\ExplicitRequest;
  *
  * @method PromiseInterface<PagedListResponse> methodExplicitPaginatedAsync(ExplicitRequest $request, array $optionalArgs = [])
  */
-final class BasicExplicitPaginatedClient
+class BasicExplicitPaginatedClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/Client/BasicGrpcOnlyClient.php
+++ b/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/Client/BasicGrpcOnlyClient.php
@@ -37,7 +37,7 @@ use Psr\Log\LoggerInterface;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  */
-final class BasicGrpcOnlyClient
+class BasicGrpcOnlyClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/BasicOneofNew/out/src/Client/BasicOneofNewClient.php
+++ b/tests/Unit/ProtoTests/BasicOneofNew/out/src/Client/BasicOneofNewClient.php
@@ -44,7 +44,7 @@ use Testing\BasicOneofNew\Response;
  *
  * @method PromiseInterface<Response> aMethodAsync(Request $request, array $optionalArgs = [])
  */
-final class BasicOneofNewClient
+class BasicOneofNewClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroClient.php
+++ b/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroClient.php
@@ -44,7 +44,7 @@ use Testing\CustomLroNew\CreateFooRequest;
  *
  * @method PromiseInterface<OperationResponse> createFooAsync(CreateFooRequest $request, array $optionalArgs = [])
  */
-final class CustomLroClient
+class CustomLroClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroOperationsClient.php
+++ b/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroOperationsClient.php
@@ -48,7 +48,7 @@ use Testing\CustomLroNew\GetOperationRequest;
  * @method PromiseInterface<void> deleteAsync(DeleteOperationRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<CustomOperationResponse> getAsync(GetOperationRequest $request, array $optionalArgs = [])
  */
-final class CustomLroOperationsClient
+class CustomLroOperationsClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Client/HeuristicPaginationClientClient.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Client/HeuristicPaginationClientClient.php
@@ -53,7 +53,7 @@ use Testing\DiregapicPaginated\Request;
  * @method PromiseInterface<PagedListResponse> multipleListMethodAsync(Request $request, array $optionalArgs = [])
  * @method PromiseInterface<NonPaginatedResponse> nonPaginatedMethodAsync(Request $request, array $optionalArgs = [])
  */
-final class HeuristicPaginationClientClient
+class HeuristicPaginationClientClient
 {
     use GapicClientTrait;
 

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
@@ -66,7 +66,7 @@ use Testing\ResourceNames\WildcardReferenceRequest;
  * @method PromiseInterface<PlaceholderResponse> wildcardMultiMethodAsync(WildcardMultiPatternRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<PlaceholderResponse> wildcardReferenceMethodAsync(WildcardReferenceRequest $request, array $optionalArgs = [])
  */
-final class ResourceNamesClient
+class ResourceNamesClient
 {
     use GapicClientTrait;
     use ResourceHelperTrait;

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
@@ -57,7 +57,7 @@ use Testing\RoutingHeaders\SimpleRequest;
  * @method PromiseInterface<Response> routingRuleWithOutParametersAsync(NestedRequest $request, array $optionalArgs = [])
  * @method PromiseInterface<Response> routingRuleWithParametersAsync(NestedRequest $request, array $optionalArgs = [])
  */
-final class RoutingHeadersClient
+class RoutingHeadersClient
 {
     use GapicClientTrait;
 


### PR DESCRIPTION
Resolve https://github.com/googleapis/google-cloud-php/pull/8492

Currently:
- It's not possible to mock any ServiceClient like the TranslateServiceClient because
  - It's final
  - It does not implements an interface

- The proposed solution of using bypass-final has drawbacks
  - the lib bypass-final is highly opinionated and source of debate in php community
  - it does not resolve all issues because other tools like static analysis won't understand the fact a final class is mocked/extended.

- Also, `*ServiceClient` classes are the ONLY ones final in the huge google codebase, and this doesn't seems needed/have benefit.

Therefor, I tried to remove the final keyword in the generation.