### PR TITLE
fix: prevent reserved variable names in tests

### DIFF
--- a/src/Generation/TestNameValueProducer.php
+++ b/src/Generation/TestNameValueProducer.php
@@ -94,12 +94,12 @@ class TestNameValueProducer
             });
     }
 
-    public function perFieldRequest(MethodDetails $method): array
+    public function perFieldRequest(MethodDetails $method, array $reservedNames = []): array
     {
         // Handle test request value generation.
         $perField = static::filterFirstOneOf($method->allFields)
-            ->map(fn ($f) => new class($this, $method, $f) {
-                public function __construct($prod, $method, $f)
+            ->map(fn ($f) => new class($this, $method, $f, $reservedNames) {
+                public function __construct($prod, $method, $f, $reservedNames)
                 {
                     // This code is arranged in this way, as a name must not be generated
                     // if this field ends up not being used.
@@ -107,7 +107,8 @@ class TestNameValueProducer
                     // TODO: Consider refactoring this.
                     $this->field = $f;
                     $this->name = ($f->useResourceTestValue ? 'formatted_' : '') . $prod->name($f->name);
-                    $this->var = AST::var(Helpers::toCamelCase($this->name));
+                    $varPrefix = in_array($this->name, $reservedNames) ? 'request_' : '';
+                    $this->var = AST::var(Helpers::toCamelCase($varPrefix . $this->name));
                     $astAcc = Vector::new([]);
                     $prod->fieldInit($method, $f, $this->var, $this->name, null, $astAcc);
                     $this->initCode = $astAcc;

--- a/src/Generation/UnitTestsV2Generator.php
+++ b/src/Generation/UnitTestsV2Generator.php
@@ -309,7 +309,7 @@ class UnitTestsV2Generator
         $client = AST::var(self::CLIENT_VARIABLE);
         $status = AST::var('status');
         $expectedExceptionMessage  = AST::var('expectedExceptionMessage ');
-        [$requestPerField, $requestCallArgs] = $prod->perFieldRequest($method);
+        [$requestPerField, $requestCallArgs] = $prod->perFieldRequest($method, ['status']);
         $ex = AST::var('ex');
         list($initializedFields, $requestAssignment) = $this->initializeRequest($requestPerField, $method->requestType);
         return AST::method($method->testExceptionMethodName)

--- a/tests/Unit/ProtoTests/Basic/basic.proto
+++ b/tests/Unit/ProtoTests/Basic/basic.proto
@@ -48,6 +48,7 @@ message RequestWithArgs {
   repeated PartOfRequestA part_of_request_a = 4 [(google.api.field_behavior) = REQUIRED];
   repeated PartOfRequestB part_of_request_b = 5;
   PartOfRequestC part_of_request_c = 6;
+  int32 status = 7 [(google.api.field_behavior) = REQUIRED]; // reserved variable name
 }
 
 message Response {

--- a/tests/Unit/ProtoTests/Basic/out/samples/BasicClient/method_with_args.php
+++ b/tests/Unit/ProtoTests/Basic/out/samples/BasicClient/method_with_args.php
@@ -33,8 +33,9 @@ use Testing\Basic\Response;
  * Test including method args.
  *
  * @param string $aString A required field...
+ * @param int    $status  reserved variable name
  */
-function method_with_args_sample(string $aString): void
+function method_with_args_sample(string $aString, int $status): void
 {
     // Create a client.
     $basicClient = new BasicClient();
@@ -43,7 +44,8 @@ function method_with_args_sample(string $aString): void
     $partOfRequestA = [new PartOfRequestA()];
     $request = (new RequestWithArgs())
         ->setAString($aString)
-        ->setPartOfRequestA($partOfRequestA);
+        ->setPartOfRequestA($partOfRequestA)
+        ->setStatus($status);
 
     // Call the API and handle any network failures.
     try {
@@ -67,7 +69,8 @@ function method_with_args_sample(string $aString): void
 function callSample(): void
 {
     $aString = '[A_STRING]';
+    $status = 0;
 
-    method_with_args_sample($aString);
+    method_with_args_sample($aString, $status);
 }
 // [END basic_generated_Basic_MethodWithArgs_sync]

--- a/tests/Unit/ProtoTests/Basic/out/tests/Unit/Client/BasicClientTest.php
+++ b/tests/Unit/ProtoTests/Basic/out/tests/Unit/Client/BasicClientTest.php
@@ -129,9 +129,11 @@ class BasicClientTest extends GeneratedTest
         // Mock request
         $aString = 'aString-929604177';
         $partOfRequestA = [];
+        $status = 892481550;
         $request = (new RequestWithArgs())
             ->setAString($aString)
-            ->setPartOfRequestA($partOfRequestA);
+            ->setPartOfRequestA($partOfRequestA)
+            ->setStatus($status);
         $response = $gapicClient->methodWithArgs($request);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
@@ -143,6 +145,8 @@ class BasicClientTest extends GeneratedTest
         $this->assertProtobufEquals($aString, $actualValue);
         $actualValue = $actualRequestObject->getPartOfRequestA();
         $this->assertProtobufEquals($partOfRequestA, $actualValue);
+        $actualValue = $actualRequestObject->getStatus();
+        $this->assertProtobufEquals($status, $actualValue);
         $this->assertTrue($transport->isExhausted());
     }
 
@@ -167,9 +171,11 @@ class BasicClientTest extends GeneratedTest
         // Mock request
         $aString = 'aString-929604177';
         $partOfRequestA = [];
+        $requestStatus = 892481550;
         $request = (new RequestWithArgs())
             ->setAString($aString)
-            ->setPartOfRequestA($partOfRequestA);
+            ->setPartOfRequestA($partOfRequestA)
+            ->setStatus($requestStatus);
         try {
             $gapicClient->methodWithArgs($request);
             // If the $gapicClient method call did not throw, fail the test


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-php/pull/8683

[Tests are failing](https://github.com/googleapis/google-cloud-php/actions/runs/18725681941/job/53409593436?pr=8683#step:8:338) with the following error: 
<img width="942" height="168" alt="Screenshot 2025-10-23 at 3 29 10 PM" src="https://github.com/user-attachments/assets/eba4eb2f-494b-45f7-beae-997897906096" />

This is because [in one of the generated tests](https://github.com/googleapis/google-cloud-php/pull/8683/files#diff-5056250686514826953dd103216e679fbb21f07faa9a2e0b09bc17cb81bbd338R378-R414), the `$status` local variable in the test is being overwritten with a variable named `$status` that is used to populate a required field in the request:

```php
    public function searchAdReviewCenterAdsExceptionTest()
    {
        //...
        $status = new stdClass();
        $status->code = Code::DATA_LOSS;
        $status->details = 'internal error';
        // ...
        $status = AdReviewCenterAdStatus::AD_REVIEW_CENTER_AD_STATUS_UNSPECIFIED;
        $request = (new SearchAdReviewCenterAdsRequest())->setParent($formattedParent)->setStatus($status);
        try {
            $gapicClient->searchAdReviewCenterAds($request);
            // If the $gapicClient method call did not throw, fail the test
            $this->fail('Expected an ApiException, but no exception was thrown.');
        } catch (ApiException $ex) {
            $this->assertEquals($status->code, $ex->getCode());
            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
        }
        //...
    }
```

I've fixed this by passing an array of `$reservedNames` to the code which generates this, and prefixing those names with `request_` before they're converted to camelcased. This will result in the name being `$requestStatus` in this case.