### PR TITLE
fix: include api_version on client class docs

### DIFF
--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -115,6 +115,11 @@ class GapicClientV2Generator
                             'Service Description: ' . ($this->serviceDetails->docLines->firstOrNull() ?? '')
                         )
                 ),
+                !is_null($this->serviceDetails->apiVersion)
+                    ? PhpDoc::text(
+                        'This client uses ' . $this->serviceDetails->shortName . ' version ' . $this->serviceDetails->apiVersion . '.'
+                    )
+                    : null,
                 PhpDoc::preFormattedText(
                     Vector::new([
                         'This class provides the ability to make remote calls to the backing service through method',

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -43,6 +43,8 @@ use Testing\Basic\Response;
 /**
  * Service Description: This is a basic service.
  *
+ * This client uses Basic version v1_20240418.
+ *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods.
  *


### PR DESCRIPTION
Adds simple breadcrumb comment to client class commentary including the `google.api.api_version` value that this client was generated based on and sends in its requests, as per AIP-4236. This breadcrumb will allow client users to reference the API version used by the client in other API artifacts e.g. product documentation.

Fixes internal tracking bug http://b/467139212, child of http://b/467065424.