### PR TITLE
fix: php deprecations for dynamic properties

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
         uses: GoogleCloudPlatform/php-tools/.github/workflows/code-standards.yml@main
         with:
           path: src
+          exclude-patterns: '["src/Protobuf/Internal"]'
 
     static-analysis:
         name: PHPStan Static Analysis

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
             "Google\\PostProcessor\\": "src/PostProcessor",
             "Google\\Generator\\": "src",
             "Google\\Generator\\Tests\\": "tests",
+            "Google\\Protobuf\\Internal\\": "src/Protobuf/Internal",
             "Google\\": "generated/Google",
             "Grpc\\": "generated/Grpc",
             "GPBMetadata\\": "generated/GPBMetadata"

--- a/src/Ast/PhpClass.php
+++ b/src/Ast/PhpClass.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 
+use AllowDynamicProperties;
 use Exception;
 use Google\Generator\Collections\Set;
 use Google\Generator\Collections\Vector;
@@ -26,6 +27,7 @@ use Google\Generator\Utils\Type;
 use RuntimeException;
 
 /** A class definition. */
+#[AllowDynamicProperties]
 final class PhpClass extends AST
 {
     use HasPhpDoc;

--- a/src/Ast/PhpConstant.php
+++ b/src/Ast/PhpConstant.php
@@ -18,7 +18,10 @@ declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 
+use AllowDynamicProperties;
+
 /** A constant within a class. */
+#[AllowDynamicProperties]
 final class PhpConstant extends PhpClassMember
 {
     private mixed $value;

--- a/src/Ast/PhpFunction.php
+++ b/src/Ast/PhpFunction.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 
+use AllowDynamicProperties;
 use Google\Generator\Collections\Vector;
 use Google\Generator\Utils\ResolvedType;
 
@@ -25,6 +26,7 @@ use Google\Generator\Utils\ResolvedType;
  * A function that can be placed in any block of code. Please use
  * {@see PhpMethod} if you intend to add a function to a class.
  */
+#[AllowDynamicProperties]
 final class PhpFunction extends AST implements ShouldNotApplySemicolonInterface
 {
     use HasPhpDoc;

--- a/src/Ast/PhpMethod.php
+++ b/src/Ast/PhpMethod.php
@@ -18,10 +18,12 @@ declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 
+use AllowDynamicProperties;
 use Google\Generator\Collections\Vector;
 use Google\Generator\Utils\ResolvedType;
 
 /** A method within a class. */
+#[AllowDynamicProperties]
 final class PhpMethod extends PhpClassMember
 {
     public function __construct(string $name)

--- a/src/Ast/PhpProperty.php
+++ b/src/Ast/PhpProperty.php
@@ -18,9 +18,11 @@ declare(strict_types=1);
 
 namespace Google\Generator\Ast;
 
+use AllowDynamicProperties;
 use Google\Generator\Utils\ResolvedType;
 
 /** A property within a class. */
+#[AllowDynamicProperties]
 final class PhpProperty extends PhpClassMember
 {
     private ?ResolvedType $type;

--- a/src/Protobuf/Internal/Descriptor.php
+++ b/src/Protobuf/Internal/Descriptor.php
@@ -1,0 +1,216 @@
+<?php
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+namespace Google\Protobuf\Internal;
+
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]
+class Descriptor
+{
+    use HasPublicDescriptorTrait;
+
+    private $full_name;
+    private $field = [];
+    private $json_to_field = [];
+    private $name_to_field = [];
+    private $index_to_field = [];
+    private $nested_type = [];
+    private $enum_type = [];
+    private $klass;
+    private $legacy_klass;
+    private $previous_klass;
+    private $options;
+    private $oneof_decl = [];
+
+    public function __construct()
+    {
+        $this->public_desc = new \Google\Protobuf\Descriptor($this);
+    }
+
+    public function addOneofDecl($oneof)
+    {
+        $this->oneof_decl[] = $oneof;
+    }
+
+    public function getOneofDecl()
+    {
+        return $this->oneof_decl;
+    }
+
+    public function setFullName($full_name)
+    {
+        $this->full_name = $full_name;
+    }
+
+    public function getFullName()
+    {
+        return $this->full_name;
+    }
+
+    public function addField($field)
+    {
+        $this->field[$field->getNumber()] = $field;
+        $this->json_to_field[$field->getJsonName() ?? ''] = $field;
+        $this->name_to_field[$field->getName()] = $field;
+        $this->index_to_field[] = $field;
+    }
+
+    public function getField()
+    {
+        return $this->field;
+    }
+
+    public function addNestedType($desc)
+    {
+        $this->nested_type[] = $desc;
+    }
+
+    public function getNestedType()
+    {
+        return $this->nested_type;
+    }
+
+    public function addEnumType($desc)
+    {
+        $this->enum_type[] = $desc;
+    }
+
+    public function getEnumType()
+    {
+        return $this->enum_type;
+    }
+
+    public function getFieldByNumber($number)
+    {
+        if (!isset($this->field[$number])) {
+          return NULL;
+        } else {
+          return $this->field[$number];
+        }
+    }
+
+    public function getFieldByJsonName($json_name)
+    {
+        if (!isset($this->json_to_field[$json_name])) {
+          return NULL;
+        } else {
+          return $this->json_to_field[$json_name];
+        }
+    }
+
+    public function getFieldByName($name)
+    {
+        if (!isset($this->name_to_field[$name])) {
+          return NULL;
+        } else {
+          return $this->name_to_field[$name];
+        }
+    }
+
+    public function getFieldByIndex($index)
+    {
+        if (count($this->index_to_field) <= $index) {
+            return NULL;
+        } else {
+            return $this->index_to_field[$index];
+        }
+    }
+
+    public function setClass($klass)
+    {
+        $this->klass = $klass;
+    }
+
+    public function getClass()
+    {
+        return $this->klass;
+    }
+
+    public function setLegacyClass($klass)
+    {
+        $this->legacy_klass = $klass;
+    }
+
+    public function getLegacyClass()
+    {
+        return $this->legacy_klass;
+    }
+
+    public function setPreviouslyUnreservedClass($klass)
+    {
+        $this->previous_klass = $klass;
+    }
+
+    public function getPreviouslyUnreservedClass()
+    {
+        return $this->previous_klass;
+    }
+
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public static function buildFromProto($proto, $file_proto, $containing)
+    {
+        $desc = new Descriptor();
+
+        $message_name_without_package  = "";
+        $classname = "";
+        $legacy_classname = "";
+        $previous_classname = "";
+        $fullname = "";
+        GPBUtil::getFullClassName(
+            $proto,
+            $containing,
+            $file_proto,
+            $message_name_without_package,
+            $classname,
+            $legacy_classname,
+            $fullname,
+            $previous_classname);
+        $desc->setFullName($fullname);
+        $desc->setClass($classname);
+        $desc->setLegacyClass($legacy_classname);
+        $desc->setPreviouslyUnreservedClass($previous_classname);
+        $desc->setOptions($proto->getOptions());
+
+        foreach ($proto->getField() as $field_proto) {
+            $desc->addField(FieldDescriptor::buildFromProto($field_proto));
+        }
+
+        // Handle nested types.
+        foreach ($proto->getNestedType() as $nested_proto) {
+            $desc->addNestedType(Descriptor::buildFromProto(
+              $nested_proto, $file_proto, $message_name_without_package));
+        }
+
+        // Handle nested enum.
+        foreach ($proto->getEnumType() as $enum_proto) {
+            $desc->addEnumType(EnumDescriptor::buildFromProto(
+              $enum_proto, $file_proto, $message_name_without_package));
+        }
+
+        // Handle oneof fields.
+        $index = 0;
+        foreach ($proto->getOneofDecl() as $oneof_proto) {
+            $desc->addOneofDecl(
+                OneofDescriptor::buildFromProto($oneof_proto, $desc, $index));
+            $index++;
+        }
+
+        return $desc;
+    }
+}

--- a/src/Protobuf/Internal/EnumDescriptor.php
+++ b/src/Protobuf/Internal/EnumDescriptor.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Google\Protobuf\Internal;
+
+use Google\Protobuf\EnumValueDescriptor;
+
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]
+class EnumDescriptor
+{
+    use HasPublicDescriptorTrait;
+
+    private $klass;
+    private $legacy_klass;
+    private $full_name;
+    private $value;
+    private $name_to_value;
+    private $value_descriptor = [];
+
+    public function __construct()
+    {
+        $this->public_desc = new \Google\Protobuf\EnumDescriptor($this);
+    }
+
+    public function setFullName($full_name)
+    {
+        $this->full_name = $full_name;
+    }
+
+    public function getFullName()
+    {
+        return $this->full_name;
+    }
+
+    public function addValue($number, $value)
+    {
+        $this->value[$number] = $value;
+        $this->name_to_value[$value->getName()] = $value;
+        $this->value_descriptor[] = new EnumValueDescriptor($value->getName(), $number);
+    }
+
+    public function getValueByNumber($number)
+    {
+        if (isset($this->value[$number])) {
+            return $this->value[$number];
+        }
+        return null;
+    }
+
+    public function getValueByName($name)
+    {
+        if (isset($this->name_to_value[$name])) {
+            return $this->name_to_value[$name];
+        }
+        return null;
+    }
+
+    public function getValueDescriptorByIndex($index)
+    {
+        if (isset($this->value_descriptor[$index])) {
+            return $this->value_descriptor[$index];
+        }
+        return null;
+    }
+
+    public function getValueCount()
+    {
+        return count($this->value);
+    }
+
+    public function setClass($klass)
+    {
+        $this->klass = $klass;
+    }
+
+    public function getClass()
+    {
+        return $this->klass;
+    }
+
+    public function setLegacyClass($klass)
+    {
+        $this->legacy_klass = $klass;
+    }
+
+    public function getLegacyClass()
+    {
+        return $this->legacy_klass;
+    }
+
+    public static function buildFromProto($proto, $file_proto, $containing)
+    {
+        $desc = new EnumDescriptor();
+
+        $enum_name_without_package  = "";
+        $classname = "";
+        $legacy_classname = "";
+        $fullname = "";
+        GPBUtil::getFullClassName(
+            $proto,
+            $containing,
+            $file_proto,
+            $enum_name_without_package,
+            $classname,
+            $legacy_classname,
+            $fullname,
+            $unused_previous_classname);
+        $desc->setFullName($fullname);
+        $desc->setClass($classname);
+        $desc->setLegacyClass($legacy_classname);
+        $values = $proto->getValue();
+        foreach ($values as $value) {
+            $desc->addValue($value->getNumber(), $value);
+        }
+
+        return $desc;
+    }
+}

--- a/src/Protobuf/Internal/FieldDescriptor.php
+++ b/src/Protobuf/Internal/FieldDescriptor.php
@@ -1,0 +1,311 @@
+<?php
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+namespace Google\Protobuf\Internal;
+
+use AllowDynamicProperties;
+
+#[AllowDynamicProperties]
+class FieldDescriptor
+{
+    use HasPublicDescriptorTrait;
+
+    private $name;
+    private $json_name;
+    private $setter;
+    private $getter;
+    private $number;
+    private $label;
+    private $type;
+    private $message_type;
+    private $enum_type;
+    private $packed;
+    private $oneof_index = -1;
+    private $proto3_optional;
+
+    /** @var OneofDescriptor $containing_oneof */
+    private $containing_oneof;
+
+    public function __construct()
+    {
+        $this->public_desc = new \Google\Protobuf\FieldDescriptor($this);
+    }
+
+    public function setOneofIndex($index)
+    {
+        $this->oneof_index = $index;
+    }
+
+    public function getOneofIndex()
+    {
+        return $this->oneof_index;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setJsonName($json_name)
+    {
+        $this->json_name = $json_name;
+    }
+
+    public function getJsonName()
+    {
+        return $this->json_name;
+    }
+
+    public function setSetter($setter)
+    {
+        $this->setter = $setter;
+    }
+
+    public function getSetter()
+    {
+        return $this->setter;
+    }
+
+    public function setGetter($getter)
+    {
+        $this->getter = $getter;
+    }
+
+    public function getGetter()
+    {
+        return $this->getter;
+    }
+
+    public function setNumber($number)
+    {
+        $this->number = $number;
+    }
+
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    public function setLabel($label)
+    {
+        $this->label = $label;
+    }
+
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    public function isRequired()
+    {
+        return $this->label === GPBLabel::REQUIRED;
+    }
+
+    public function isRepeated()
+    {
+        return $this->label === GPBLabel::REPEATED;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setMessageType($message_type)
+    {
+        $this->message_type = $message_type;
+    }
+
+    public function getMessageType()
+    {
+        return $this->message_type;
+    }
+
+    public function setEnumType($enum_type)
+    {
+        $this->enum_type = $enum_type;
+    }
+
+    public function getEnumType()
+    {
+        return $this->enum_type;
+    }
+
+    public function setPacked($packed)
+    {
+        $this->packed = $packed;
+    }
+
+    public function getPacked()
+    {
+        return $this->packed;
+    }
+
+    public function getProto3Optional()
+    {
+        return $this->proto3_optional;
+    }
+
+    public function setProto3Optional($proto3_optional)
+    {
+        $this->proto3_optional = $proto3_optional;
+    }
+
+    public function getContainingOneof()
+    {
+        return $this->containing_oneof;
+    }
+
+    public function setContainingOneof($containing_oneof)
+    {
+        $this->containing_oneof = $containing_oneof;
+    }
+
+    public function getRealContainingOneof()
+    {
+        return !is_null($this->containing_oneof) && !$this->containing_oneof->isSynthetic()
+            ? $this->containing_oneof : null;
+    }
+
+    public function isPackable()
+    {
+        return $this->isRepeated() && self::isTypePackable($this->type);
+    }
+
+    public function isMap()
+    {
+        return $this->getType() == GPBType::MESSAGE &&
+               !is_null($this->getMessageType()->getOptions()) &&
+               $this->getMessageType()->getOptions()->getMapEntry();
+    }
+
+    public function isTimestamp()
+    {
+        return $this->getType() == GPBType::MESSAGE &&
+            $this->getMessageType()->getClass() === "Google\Protobuf\Timestamp";
+    }
+
+    public function isWrapperType()
+    {
+        if ($this->getType() == GPBType::MESSAGE) {
+            $class = $this->getMessageType()->getClass();
+            return in_array($class, [
+                "Google\Protobuf\DoubleValue",
+                "Google\Protobuf\FloatValue",
+                "Google\Protobuf\Int64Value",
+                "Google\Protobuf\UInt64Value",
+                "Google\Protobuf\Int32Value",
+                "Google\Protobuf\UInt32Value",
+                "Google\Protobuf\BoolValue",
+                "Google\Protobuf\StringValue",
+                "Google\Protobuf\BytesValue",
+            ]);
+        }
+        return false;
+    }
+
+    private static function isTypePackable($field_type)
+    {
+        return ($field_type !== GPBType::STRING  &&
+            $field_type !== GPBType::GROUP   &&
+            $field_type !== GPBType::MESSAGE &&
+            $field_type !== GPBType::BYTES);
+    }
+
+    /**
+     * @param FieldDescriptorProto $proto
+     * @return FieldDescriptor
+     */
+    public static function getFieldDescriptor($proto)
+    {
+        $type_name = null;
+        $type = $proto->getType();
+        switch ($type) {
+            case GPBType::MESSAGE:
+            case GPBType::GROUP:
+            case GPBType::ENUM:
+                $type_name = $proto->getTypeName();
+                break;
+            default:
+                break;
+        }
+
+        $oneof_index = $proto->hasOneofIndex() ? $proto->getOneofIndex() : -1;
+        // TODO: once proto2 is supported, this default should be false
+        // for proto2.
+        if ($proto->getLabel() === GPBLabel::REPEATED &&
+            $proto->getType() !== GPBType::MESSAGE &&
+            $proto->getType() !== GPBType::GROUP &&
+            $proto->getType() !== GPBType::STRING &&
+            $proto->getType() !== GPBType::BYTES) {
+          $packed = true;
+        } else {
+          $packed = false;
+        }
+        $options = $proto->getOptions();
+        if ($options !== null) {
+            $packed = $options->getPacked();
+        }
+
+        $field = new FieldDescriptor();
+        $field->setName($proto->getName());
+
+        if ($proto->hasJsonName()) {
+            $json_name = $proto->getJsonName();
+        } else {
+            $proto_name = $proto->getName();
+            $json_name = implode('', array_map('ucwords', explode('_', $proto_name)));
+            if ($proto_name[0] !== "_" && !ctype_upper($proto_name[0])) {
+                $json_name = lcfirst($json_name);
+            }
+        }
+        $field->setJsonName($json_name);
+
+        $camel_name = implode('', array_map('ucwords', explode('_', $proto->getName())));
+        $field->setGetter('get' . $camel_name);
+        $field->setSetter('set' . $camel_name);
+        $field->setType($proto->getType());
+        $field->setNumber($proto->getNumber());
+        $field->setLabel($proto->getLabel());
+        $field->setPacked($packed);
+        $field->setOneofIndex($oneof_index);
+        $field->setProto3Optional($proto->getProto3Optional());
+
+        // At this time, the message/enum type may have not been added to pool.
+        // So we use the type name as place holder and will replace it with the
+        // actual descriptor in cross building.
+        switch ($type) {
+            case GPBType::MESSAGE:
+                $field->setMessageType($type_name);
+                break;
+            case GPBType::ENUM:
+                $field->setEnumType($type_name);
+                break;
+            default:
+                break;
+        }
+
+        return $field;
+    }
+
+    public static function buildFromProto($proto)
+    {
+        return FieldDescriptor::getFieldDescriptor($proto);
+    }
+}


### PR DESCRIPTION
This fixes the slew of deprecations we get when updating the protos due to the setting of dynamic properties on PHP objects. Unfortunately this functionality is very critical for this codebase, and removing it would require significant refactoring.

The only solution to suppressing these errors in the core `google/protobuf` library is to create copies of those files and maintain them in this repository, and add the `#[AllowDynamicProperties]` annotation there.

This solution __might__ introduce more technical debt than it's worth to suppress a deprecation message. The best solution may be to try and refactor this library so it does not require setting of dynamic properties in the core protobuf classes. At least this PR identifies the classes which are using dynamic properties, so that we can potentially refactor them in the future!