### PR TITLE
fix: support nested method_signature fields

### DIFF
--- a/src/Generation/BuildMethodFragmentGenerator.php
+++ b/src/Generation/BuildMethodFragmentGenerator.php
@@ -128,11 +128,15 @@ class BuildMethodFragmentGenerator
         };
 
         $methodSignatureArguments = array_map('trim', array_filter(explode(',', $methodSignature)));
+        $methodSignatureTopLevelArguments = array_values(array_unique(array_map(
+            fn ($arg) => explode('.', $arg, 2)[0],
+            $methodSignatureArguments
+        )));
         $requiredFields = $methodDetails->allFields
-            ->filter(fn ($f) => in_array($f->name, $methodSignatureArguments))
-            ->orderBy(fn ($f) => array_search($f->name, $methodSignatureArguments));
+            ->filter(fn ($f) => in_array($f->name, $methodSignatureTopLevelArguments))
+            ->orderBy(fn ($f) => array_search($f->name, $methodSignatureTopLevelArguments));
 
-        if (count($methodSignatureArguments) !== $requiredFields->count()) {
+        if (count($methodSignatureTopLevelArguments) !== $requiredFields->count()) {
             throw new \LogicException(sprintf(
                 'missing method signature arguments (Expected "%s", found %s)',
                 $methodSignature,
@@ -153,7 +157,7 @@ class BuildMethodFragmentGenerator
         $cleanSignature = preg_replace('/\s+/', '', $methodSignature);
         $methodName = $isFirst
             ? 'build'
-            : 'buildFrom' . Helpers::toUpperCamelCase(str_replace(',', '_', $cleanSignature));
+            : 'buildFrom' . Helpers::toUpperCamelCase(str_replace([',', '.'], '_', $cleanSignature));
 
         return AST::method($methodName)
             ->withAccess(Access::PUBLIC, Access::STATIC)

--- a/tests/Unit/Generation/BuildMethodFragmentGeneratorTest.php
+++ b/tests/Unit/Generation/BuildMethodFragmentGeneratorTest.php
@@ -32,7 +32,7 @@ use Google\Generator\Utils\Transport;
 
 final class BuildMethodFragmentGeneratorTest extends TestCase
 {
-    public function testBuildMethodNamesWithSpacesInSignatures(): void
+    public function testBuildMethodNamesWithSpacesAndDotNotationSignatures(): void
     {
         $descBytes = ProtoLoader::loadDescriptorBytes('Utils/example.proto');
         $descSet = new \Google\Protobuf\Internal\FileDescriptorSet();
@@ -62,12 +62,19 @@ final class BuildMethodFragmentGeneratorTest extends TestCase
         $this->assertTrue(isset($fragments[$requestClassName]));
 
         $buildMethods = $fragments[$requestClassName];
-        $this->assertEquals(2, $buildMethods->count());
+        $this->assertEquals(3, $buildMethods->count());
 
         // First builder method should be 'build'
         $this->assertEquals('build', $buildMethods[0]->name);
 
         // Second builder method should be 'buildFromNameNumber' (spaces stripped and camel-cased)
         $this->assertEquals('buildFromNameNumber', $buildMethods[1]->name);
+
+        // Third builder method should be based on the clean original dot-notation signature.
+        $this->assertEquals('buildFromFooAFooB', $buildMethods[2]->name);
+
+        $buildMethodCode = $buildMethods[2]->toCode();
+        $this->assertStringContainsString('function buildFromFooAFooB(\Example\Foo $foo): self', $buildMethodCode);
+        $this->assertStringContainsString('setFoo($foo)', $buildMethodCode);
     }
 }

--- a/tests/Unit/Utils/example.proto
+++ b/tests/Unit/Utils/example.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package example;
 
 import "google/api/client.proto";
+import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/longrunning/operations.proto";
 
@@ -40,6 +41,7 @@ service Example {
   rpc ExampleMethodWithSignatures(Request) returns(Response) {
     option (google.api.method_signature) = "name";
     option (google.api.method_signature) = "name, number";
+    option (google.api.method_signature) = "foo.a, foo.b";
   }
 }
 
@@ -55,6 +57,12 @@ message Request {
   // Required. Percentage of selected conversation to analyze, between
   // [0, 100].
   float analysis_percentage = 3;
+  Foo foo = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+message Foo {
+  string a = 1;
+  string b = 2;
 }
 
 message Response {


### PR DESCRIPTION
## Summary

Fixes #684 by resolving `google.api.method_signature` entries through their top-level request field before matching them against request fields. This lets nested signatures such as `foo.a, foo.b` satisfy the required top-level field `foo` instead of failing the existing "missing method signature arguments" check.

The generated builder method name still follows the declared signature, but dots are treated as separators so the generated PHP identifier remains valid.

## Testing

- `git diff --check`
- `docker run --rm -e USE_TOOLS_PROTOC=true -v "$PWD":/app -w /app php:8.2-cli ./vendor/bin/phpunit --bootstrap tests/Unit/autoload.php --filter BuildMethodFragmentGeneratorTest tests/Unit/Generation/BuildMethodFragmentGeneratorTest.php`
- `docker run --rm -v "$PWD":/app -w /app php:8.2-cli php -l src/Generation/BuildMethodFragmentGenerator.php`
- `docker run --rm -v "$PWD":/app -w /app php:8.2-cli php -l tests/Unit/Generation/BuildMethodFragmentGeneratorTest.php`
