### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/bazel_example.yml
+++ b/.github/workflows/bazel_example.yml
@@ -1,5 +1,8 @@
 name: Bazel Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -9,17 +12,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    container: gcr.io/gapic-images/googleapis:latest
+    container: gcr.io/gapic-images/googleapis:latest # zizmor: ignore[unpinned-images]
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: 'recursive'
+        persist-credentials: false
 
     - name: Bazel File Cache Setup
       id: cache-bazel
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.cache/bazel
         key: ${{ runner.os }}-bazel-20210105-${{ secrets.CACHE_VERSION }}
@@ -81,7 +85,7 @@ jobs:
             tests/Integration:talent \
             tests/Integration:videointelligence --noshow_progress --cache_test_results=no
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       if: ${{ failure() }}
       with:
         name: test-artifacts

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
     push:
         branches:
@@ -11,12 +14,12 @@ on:
 jobs:
     style:
         name: PHP Style Check
-        uses: GoogleCloudPlatform/php-tools/.github/workflows/code-standards.yml@main
+        uses: GoogleCloudPlatform/php-tools/.github/workflows/code-standards.yml@main # zizmor: ignore[unpinned-uses]
         with:
           path: src
 
     static-analysis:
         name: PHPStan Static Analysis
-        uses: GoogleCloudPlatform/php-tools/.github/workflows/static-analysis.yml@main
+        uses: GoogleCloudPlatform/php-tools/.github/workflows/static-analysis.yml@main # zizmor: ignore[unpinned-uses]
         with:
           autoload-file: tests/Unit/autoload.php

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,5 +1,8 @@
 name: PhpUnit tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -12,12 +15,13 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         submodules: 'recursive'
+        persist-credentials: false
 
     - name: Install PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
       with:
         php-version: '8.2'
 

--- a/.github/workflows/release-checks.yaml
+++ b/.github/workflows/release-checks.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
     next-release-label-check:
         name: Check for "next release" label
-        uses: GoogleCloudPlatform/php-tools/.github/workflows/release-checks.yml@main
+        uses: GoogleCloudPlatform/php-tools/.github/workflows/release-checks.yml@main # zizmor: ignore[unpinned-uses]
         if: github.event.pull_request.user.login == 'release-please[bot]'
         with:
             next-release-label-check: false


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
