### PR TITLE
feat: add support for method signatures with a dotted notation.

### DIFF
--- a/src/Generation/BuildMethodFragmentGenerator.php
+++ b/src/Generation/BuildMethodFragmentGenerator.php
@@ -128,11 +128,12 @@ class BuildMethodFragmentGenerator
         };
 
         $methodSignatureArguments = array_map('trim', array_filter(explode(',', $methodSignature)));
+        $topLevelArguments = array_unique(array_map(fn ($arg) => explode('.', $arg)[0], $methodSignatureArguments));
         $requiredFields = $methodDetails->allFields
-            ->filter(fn ($f) => in_array($f->name, $methodSignatureArguments))
-            ->orderBy(fn ($f) => array_search($f->name, $methodSignatureArguments));
+            ->filter(fn ($f) => in_array($f->name, $topLevelArguments))
+            ->orderBy(fn ($f) => array_search($f->name, $topLevelArguments));
 
-        if (count($methodSignatureArguments) !== $requiredFields->count()) {
+        if (count($topLevelArguments) !== $requiredFields->count()) {
             throw new \LogicException(sprintf(
                 'missing method signature arguments (Expected "%s", found %s)',
                 $methodSignature,
@@ -153,7 +154,7 @@ class BuildMethodFragmentGenerator
         $cleanSignature = preg_replace('/\s+/', '', $methodSignature);
         $methodName = $isFirst
             ? 'build'
-            : 'buildFrom' . Helpers::toUpperCamelCase(str_replace(',', '_', $cleanSignature));
+            : 'buildFrom' . Helpers::toUpperCamelCase(str_replace([',', '.'], '_', $cleanSignature));
 
         return AST::method($methodName)
             ->withAccess(Access::PUBLIC, Access::STATIC)

--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -172,7 +172,7 @@ abstract class MethodDetails
                 && $resourceByNumber[0] === $resourceByPosition[0];
         }
 
-        if (is_null($pageSize) || is_null($pageToken) || is_null($nextPageToken) || is_null($resources)) {
+        if (is_null($pageSize) || is_null($pageToken) || is_null($nextPageToken) || is_null($resources) || !$resourceFieldValid) {
             return null;
         }
 

--- a/tests/Unit/Generation/BuildMethodFragmentGeneratorTest.php
+++ b/tests/Unit/Generation/BuildMethodFragmentGeneratorTest.php
@@ -62,12 +62,15 @@ final class BuildMethodFragmentGeneratorTest extends TestCase
         $this->assertTrue(isset($fragments[$requestClassName]));
 
         $buildMethods = $fragments[$requestClassName];
-        $this->assertEquals(2, $buildMethods->count());
+        $this->assertEquals(3, $buildMethods->count());
 
         // First builder method should be 'build'
         $this->assertEquals('build', $buildMethods[0]->name);
 
         // Second builder method should be 'buildFromNameNumber' (spaces stripped and camel-cased)
         $this->assertEquals('buildFromNameNumber', $buildMethods[1]->name);
+
+        // Third builder method should be 'buildFromNameUserDisplayName' (dots replaced and camel-cased)
+        $this->assertEquals('buildFromNameUserDisplayName', $buildMethods[2]->name);
     }
 }

--- a/tests/Unit/Utils/example.proto
+++ b/tests/Unit/Utils/example.proto
@@ -40,6 +40,7 @@ service Example {
   rpc ExampleMethodWithSignatures(Request) returns(Response) {
     option (google.api.method_signature) = "name";
     option (google.api.method_signature) = "name, number";
+    option (google.api.method_signature) = "name, user.display_name";
   }
 }
 
@@ -48,6 +49,10 @@ option (google.api.resource_definition) = {
   pattern: "items/{item}"
 };
 
+message User {
+  string display_name = 1;
+}
+
 message Request {
   string name = 1 [(google.api.resource_reference).type = "example.com/AResource"];
   optional int32 number = 2;
@@ -55,6 +60,7 @@ message Request {
   // Required. Percentage of selected conversation to analyze, between
   // [0, 100].
   float analysis_percentage = 3;
+  User user = 4;
 }
 
 message Response {


### PR DESCRIPTION
Using dotted notations on method signatures is valid for a proto file but our generator does not take into account this. This aims to fix this.