### PR TITLE
feat: Add @internal tag to generated $serviceScopes property to prevent BC breaks

### DIFF
--- a/src/Generation/GapicClientGenerator.php
+++ b/src/Generation/GapicClientGenerator.php
@@ -200,7 +200,10 @@ class GapicClientGenerator
     {
         return AST::property('serviceScopes')
             ->withAccess(Access::PUBLIC, Access::STATIC)
-            ->withPhpDocText('The default scopes required by the service.')
+            ->withPhpDoc(PhpDoc::block(
+                PhpDoc::text('The default scopes required by the service.'),
+                PhpDoc::internal()
+            ))
             ->withValue(AST::array($this->serviceDetails->defaultScopes->toArray()));
     }
 

--- a/src/Generation/GapicClientV2Generator.php
+++ b/src/Generation/GapicClientV2Generator.php
@@ -231,7 +231,10 @@ class GapicClientV2Generator
     {
         return AST::property('serviceScopes')
             ->withAccess(Access::PUBLIC, Access::STATIC)
-            ->withPhpDocText('The default scopes required by the service.')
+            ->withPhpDoc(PhpDoc::block(
+                PhpDoc::text('The default scopes required by the service.'),
+                PhpDoc::internal()
+            ))
             ->withValue(AST::array($this->serviceDetails->defaultScopes->toArray()));
     }
 

--- a/tests/Integration/BUILD.bazel
+++ b/tests/Integration/BUILD.bazel
@@ -595,12 +595,12 @@ php_proto_library(
 # Spanner - Emulator support.
 php_proto_library(
     name = "spanner_php_proto",
-    deps = ["@com_google_googleapis//google/spanner/admin/database/v1:spanner_database_admin_proto"],
+    deps = ["@com_google_googleapis//google/spanner/admin/database/v1:database_proto"],
 )
 
 php_grpc_library(
     name = "spanner_php_grpc",
-    srcs = ["@com_google_googleapis//google/spanner/admin/database/v1:spanner_database_admin_proto"],
+    srcs = ["@com_google_googleapis//google/spanner/admin/database/v1:database_proto"],
     deps = [":spanner_php_proto"],
 )
 

--- a/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Gapic/AssetServiceGapicClient.php
@@ -131,7 +131,11 @@ class AssetServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/AddressesGapicClient.php
@@ -99,7 +99,11 @@ class AddressesGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/compute',
         'https://www.googleapis.com/auth/cloud-platform',

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/RegionOperationsGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/RegionOperationsGapicClient.php
@@ -78,7 +78,11 @@ class RegionOperationsGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/compute.readonly',
         'https://www.googleapis.com/auth/compute',

--- a/tests/Integration/goldens/compute_small/src/V1/Gapic/SubnetworksGapicClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Gapic/SubnetworksGapicClient.php
@@ -88,7 +88,11 @@ class SubnetworksGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/compute',
         'https://www.googleapis.com/auth/cloud-platform',

--- a/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
+++ b/tests/Integration/goldens/container/src/V1/Gapic/ClusterManagerGapicClient.php
@@ -157,7 +157,11 @@ class ClusterManagerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/AutoscalingPolicyServiceGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/AutoscalingPolicyServiceGapicClient.php
@@ -98,7 +98,11 @@ class AutoscalingPolicyServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/BatchControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/BatchControllerGapicClient.php
@@ -124,7 +124,11 @@ class BatchControllerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/ClusterControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/ClusterControllerGapicClient.php
@@ -133,7 +133,11 @@ class ClusterControllerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/JobControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/JobControllerGapicClient.php
@@ -97,7 +97,11 @@ class JobControllerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/NodeGroupControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/NodeGroupControllerGapicClient.php
@@ -124,7 +124,11 @@ class NodeGroupControllerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/SessionControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/SessionControllerGapicClient.php
@@ -125,7 +125,11 @@ class SessionControllerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/SessionTemplateControllerGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/SessionTemplateControllerGapicClient.php
@@ -97,7 +97,11 @@ class SessionTemplateControllerGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/dataproc/src/V1/Gapic/WorkflowTemplateServiceGapicClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Gapic/WorkflowTemplateServiceGapicClient.php
@@ -104,7 +104,11 @@ class WorkflowTemplateServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
@@ -104,7 +104,11 @@ final class CloudFunctionsServiceClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/iam/src/V1/Gapic/IAMPolicyGapicClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Gapic/IAMPolicyGapicClient.php
@@ -105,7 +105,11 @@ class IAMPolicyGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Gapic/KeyManagementServiceGapicClient.php
@@ -143,7 +143,11 @@ class KeyManagementServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/cloudkms',

--- a/tests/Integration/goldens/logging/src/V2/Gapic/ConfigServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/ConfigServiceV2GapicClient.php
@@ -153,7 +153,11 @@ class ConfigServiceV2GapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/cloud-platform.read-only',

--- a/tests/Integration/goldens/logging/src/V2/Gapic/LoggingServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/LoggingServiceV2GapicClient.php
@@ -95,7 +95,11 @@ class LoggingServiceV2GapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/cloud-platform.read-only',

--- a/tests/Integration/goldens/logging/src/V2/Gapic/MetricsServiceV2GapicClient.php
+++ b/tests/Integration/goldens/logging/src/V2/Gapic/MetricsServiceV2GapicClient.php
@@ -89,7 +89,11 @@ class MetricsServiceV2GapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/cloud-platform.read-only',

--- a/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
@@ -119,7 +119,11 @@ final class CloudRedisClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/AnalyticsServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/AnalyticsServiceGapicClient.php
@@ -112,7 +112,11 @@ class AnalyticsServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/BranchServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/BranchServiceGapicClient.php
@@ -95,7 +95,11 @@ class BranchServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/CatalogServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/CatalogServiceGapicClient.php
@@ -106,7 +106,11 @@ class CatalogServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/CompletionServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/CompletionServiceGapicClient.php
@@ -95,7 +95,11 @@ class CompletionServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ControlServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ControlServiceGapicClient.php
@@ -95,7 +95,11 @@ class ControlServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ConversationalSearchServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ConversationalSearchServiceGapicClient.php
@@ -100,7 +100,11 @@ class ConversationalSearchServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/GenerativeQuestionServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/GenerativeQuestionServiceGapicClient.php
@@ -94,7 +94,11 @@ class GenerativeQuestionServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/MerchantCenterAccountLinkServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/MerchantCenterAccountLinkServiceGapicClient.php
@@ -119,7 +119,11 @@ class MerchantCenterAccountLinkServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ModelServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ModelServiceGapicClient.php
@@ -136,7 +136,11 @@ class ModelServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/PredictionServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/PredictionServiceGapicClient.php
@@ -88,7 +88,11 @@ class PredictionServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ProductServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ProductServiceGapicClient.php
@@ -138,7 +138,11 @@ class ProductServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ProjectServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ProjectServiceGapicClient.php
@@ -101,7 +101,11 @@ class ProjectServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/SearchServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/SearchServiceGapicClient.php
@@ -112,7 +112,11 @@ class SearchServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/ServingConfigServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/ServingConfigServiceGapicClient.php
@@ -96,7 +96,11 @@ class ServingConfigServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/retail/src/V2alpha/Gapic/UserEventServiceGapicClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Gapic/UserEventServiceGapicClient.php
@@ -101,7 +101,11 @@ class UserEventServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
@@ -224,7 +224,11 @@ final class SecurityCenterClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/securitycenter/src/V1/Gapic/SecurityCenterGapicClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Gapic/SecurityCenterGapicClient.php
@@ -194,7 +194,11 @@ class SecurityCenterGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
+++ b/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
@@ -152,7 +152,11 @@ final class DatabaseAdminClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/spanner.admin',

--- a/tests/Integration/goldens/spanner/src/V1/Gapic/DatabaseAdminGapicClient.php
+++ b/tests/Integration/goldens/spanner/src/V1/Gapic/DatabaseAdminGapicClient.php
@@ -147,7 +147,11 @@ class DatabaseAdminGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/spanner.admin',

--- a/tests/Integration/goldens/speech/src/V1/Gapic/AdaptationGapicClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Gapic/AdaptationGapicClient.php
@@ -98,7 +98,11 @@ class AdaptationGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/speech/src/V1/Gapic/SpeechGapicClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Gapic/SpeechGapicClient.php
@@ -118,7 +118,11 @@ class SpeechGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompanyServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompanyServiceGapicClient.php
@@ -94,7 +94,11 @@ class CompanyServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/jobs',

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompletionGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/CompletionGapicClient.php
@@ -90,7 +90,11 @@ class CompletionGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/jobs',

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/EventServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/EventServiceGapicClient.php
@@ -87,7 +87,11 @@ class EventServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/jobs',

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/JobServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/JobServiceGapicClient.php
@@ -136,7 +136,11 @@ class JobServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/jobs',

--- a/tests/Integration/goldens/talent/src/V4beta1/Gapic/TenantServiceGapicClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Gapic/TenantServiceGapicClient.php
@@ -94,7 +94,11 @@ class TenantServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/jobs',

--- a/tests/Integration/goldens/videointelligence/src/V1/Gapic/VideoIntelligenceServiceGapicClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Gapic/VideoIntelligenceServiceGapicClient.php
@@ -105,7 +105,11 @@ class VideoIntelligenceServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -70,7 +70,11 @@ final class BasicClient
     /** The api version of the service */
     private string $apiVersion = 'v1_20240418';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/Gapic/BasicAutoPopulationGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/Gapic/BasicAutoPopulationGapicClient.php
@@ -68,7 +68,11 @@ class BasicAutoPopulationGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Gapic/BasicBidiStreamingGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Gapic/BasicBidiStreamingGapicClient.php
@@ -100,7 +100,11 @@ class BasicBidiStreamingGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Gapic/BasicClientStreamingGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Gapic/BasicClientStreamingGapicClient.php
@@ -88,7 +88,11 @@ class BasicClientStreamingGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Gapic/LibraryGapicClient.php
@@ -160,7 +160,11 @@ class LibraryGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/library',
         'https://www.googleapis.com/auth/cloud-platform',

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Client/BasicExplicitPaginatedClient.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Client/BasicExplicitPaginatedClient.php
@@ -61,7 +61,11 @@ final class BasicExplicitPaginatedClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Gapic/BasicExplicitPaginatedGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Gapic/BasicExplicitPaginatedGapicClient.php
@@ -85,7 +85,11 @@ class BasicExplicitPaginatedGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/Client/BasicGrpcOnlyClient.php
+++ b/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/Client/BasicGrpcOnlyClient.php
@@ -54,7 +54,11 @@ final class BasicGrpcOnlyClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Gapic/BasicLroGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Gapic/BasicLroGapicClient.php
@@ -94,7 +94,11 @@ class BasicLroGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Gapic/BasicOneofGapicClient.php
@@ -73,7 +73,11 @@ class BasicOneofGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicOneofNew/out/src/Client/BasicOneofNewClient.php
+++ b/tests/Unit/ProtoTests/BasicOneofNew/out/src/Client/BasicOneofNewClient.php
@@ -61,7 +61,11 @@ final class BasicOneofNewClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Gapic/BasicPaginatedGapicClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Gapic/BasicPaginatedGapicClient.php
@@ -85,7 +85,11 @@ class BasicPaginatedGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
@@ -59,7 +59,11 @@ final class BasicServerStreamingClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroGapicClient.php
@@ -94,7 +94,11 @@ class CustomLroGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Gapic/CustomLroOperationsGapicClient.php
@@ -71,7 +71,11 @@ class CustomLroOperationsGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroClient.php
+++ b/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroClient.php
@@ -61,7 +61,11 @@ final class CustomLroClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroOperationsClient.php
+++ b/tests/Unit/ProtoTests/CustomLroNew/out/src/Client/CustomLroOperationsClient.php
@@ -65,7 +65,11 @@ final class CustomLroOperationsClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Gapic/DeprecatedServiceGapicClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Gapic/DeprecatedServiceGapicClient.php
@@ -68,7 +68,11 @@ class DeprecatedServiceGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'https://www.googleapis.com/auth/cloud-platform',
     ];

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Client/HeuristicPaginationClientClient.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Client/HeuristicPaginationClientClient.php
@@ -70,7 +70,11 @@ final class HeuristicPaginationClientClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Gapic/HeuristicPaginationClientGapicClient.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Gapic/HeuristicPaginationClientGapicClient.php
@@ -87,7 +87,11 @@ class HeuristicPaginationClientGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [
         'scope1',
         'scope2',

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Gapic/DisableSnippetsGapicClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Gapic/DisableSnippetsGapicClient.php
@@ -68,7 +68,11 @@ class DisableSnippetsGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Gapic/GrpcServiceConfigWithRetry1GapicClient.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Gapic/GrpcServiceConfigWithRetry1GapicClient.php
@@ -71,7 +71,11 @@ class GrpcServiceConfigWithRetry1GapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private $operationsClient;

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
@@ -84,7 +84,11 @@ final class ResourceNamesClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Gapic/ResourceNamesGapicClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Gapic/ResourceNamesGapicClient.php
@@ -88,7 +88,11 @@ class ResourceNamesGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static $deeplyNestedNameTemplate;

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
@@ -74,7 +74,11 @@ final class RoutingHeadersClient
     /** The name of the code generator, to be included in the agent header. */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Gapic/RoutingHeadersGapicClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Gapic/RoutingHeadersGapicClient.php
@@ -71,7 +71,11 @@ class RoutingHeadersGapicClient
     /** The name of the code generator, to be included in the agent header. */
     const CODEGEN_NAME = 'gapic';
 
-    /** The default scopes required by the service. */
+    /**
+     * The default scopes required by the service.
+     *
+     * @internal
+     */
     public static $serviceScopes = [];
 
     private static function getClientDefaults()


### PR DESCRIPTION
Goes with: https://github.com/googleapis/google-cloud-php/pull/9372
Addresses [googleapis/google-cloud-php#9358](https://github.com/googleapis/google-cloud-php/issues/9358)

### Description
This PR modifies the PHP code generators to include the `@internal` PHPDoc tag on the generated `public static $serviceScopes` property. 

By marking this property as `@internal`, we signal to tools like `roave/backward-compatibility-check` that this property should be ignored during backward compatibility checks. This prevents the pipeline from failing when new scopes are introduced in an API update. Users are instead encouraged to use the newly added `getServiceScopes()` method (implemented in `google-cloud-php`).

### Changes
* Added `PhpDoc::internal()` to `$serviceScopes` property generation in `src/Generation/GapicClientGenerator.php`.
* Added `PhpDoc::internal()` to `$serviceScopes` property generation in `src/Generation/GapicClientV2Generator.php`.
* Updated test goldens to reflect the newly generated `@internal` tags.

### Validation
* **Golden Generation**: Ran `composer update-all-tests` successfully. Verified that the output goldens for the unit tests correctly generate the `@internal` tag in the docblock for `public static $serviceScopes`.
  ```php
      /**
       * The default scopes required by the service.
       *
       * @internal
       */
      public static $serviceScopes = [
  ```

* **BC Checker Validation**: The `roave/backward-compatibility-check` tool specifically validates backward compatibility and explicitly ignores properties marked with `@internal`. The golden generation above guarantees that the tool will automatically ignore modifications to `$serviceScopes` moving forward on CI environments.