### PR TITLE
fix: Update the FixYaml to handle valid YAML files with extra spaces

### DIFF
--- a/src/Utils/ServiceYamlConfig.php
+++ b/src/Utils/ServiceYamlConfig.php
@@ -37,6 +37,10 @@ class ServiceYamlConfig
         $result = '';
         $fixNextLine = false;
         foreach (explode("\n", $yaml) as $line) {
+            $trimmed = trim($line);
+            if ($trimmed === '' || preg_match('/^[a-zA-Z0-9_.-]+\s*:/', $line)) {
+                $fixNextLine = false;
+            }
             if ($fixNextLine) {
                 if (strlen($line) > 0 && !static::isWhitespace(substr($line, 0, 1))) {
                     $result .= '  ' . $line . "\n";

--- a/tests/Unit/Utils/ServiceYamlConfigTest.php
+++ b/tests/Unit/Utils/ServiceYamlConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Generator\Tests\Unit\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Google\Generator\Utils\ServiceYamlConfig;
+
+final class ServiceYamlConfigTest extends TestCase
+{
+    public function testParsesServiceYamlWithTrailingWhitespaceAndMultipleRuleBlocks(): void
+    {
+        // YAML with trailing whitespace on blank line between blocks containing 'rules' keys
+        $yaml = "type: google.api.Service\n" .
+            "name: test.googleapis.com\n" .
+            "backend:\n" .
+            "  rules:\n" .
+            "  - selector: 'google.test.Service.*'\n" .
+            "    deadline: 60.0\n" .
+            "    \n" .
+            "http:\n" .
+            "  rules:\n" .
+            "  - selector: google.test.Service.TestMethod\n" .
+            "    get: '/v1/test'\n";
+
+        $config = new ServiceYamlConfig($yaml);
+
+        $this->assertCount(1, $config->httpRules);
+        $this->assertEquals('google.test.Service.TestMethod', $config->httpRules[0]->getSelector());
+        $this->assertCount(1, $config->backendRules);
+        $this->assertEquals('google.test.Service.*', $config->backendRules[0]->getSelector());
+    }
+
+    public function testParsesUnindentedMultiLineStringContinuations(): void
+    {
+        // Legacy Cloud Functions style YAML with unindented string continuation
+        $yaml = "type: google.api.Service\n" .
+            "name: cloudfunctions.googleapis.com\n" .
+            "documentation:\n" .
+            "  summary: 'Manages lightweight user-provided functions executed in response to events.'\n" .
+            "  overview: 'Manages lightweight user-provided functions executed in response to\n" .
+            "events.'\n" .
+            "http:\n" .
+            "  rules:\n" .
+            "  - selector: google.cloud.functions.v1.CloudFunctionsService.ListFunctions\n" .
+            "    get: '/v1/{parent=projects/*/locations/*}/functions'\n";
+
+        $config = new ServiceYamlConfig($yaml);
+
+        $this->assertCount(1, $config->httpRules);
+        $this->assertEquals('google.cloud.functions.v1.CloudFunctionsService.ListFunctions', $config->httpRules[0]->getSelector());
+    }
+}


### PR DESCRIPTION
Closes: #837 

Currently we are having issues with valid Yaml files that have white spaces. The `fixYaml` function was interpreting this as a line that needed to be fix, this has been changed to take into consideration files like this:
```
...
backend:
  rules:
  - selector: 'google.cloud.location.Locations.*'
    deadline: 60.0
  - selector: 'google.iam.v1.IAMPolicy.*'
    deadline: 60.0
  - selector: 'google.longrunning.Operations.*'
    deadline: 60.0
    //<- Here are 4 empty spaces. This is a valid yaml file but fixYaml handles this incorrectly
http:
  rules:
 ```