### PR TITLE
chore: Update symfony/yaml to version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": "^8.2",
         "google/protobuf": "^5.0",
         "friendsofphp/php-cs-fixer": "^3",
-        "symfony/yaml": "^5.2",
+        "symfony/yaml": "^6.0",
         "microsoft/tolerant-php-parser": "^0.1.2",
         "symplify/coding-standard": "13.0.1"
     },


### PR DESCRIPTION
We decided to upgrade symfony/yaml version to version 6. google cloud PHP uses version 6 so using the generator as a dependency for dev scripts causes these to clash, so updating this is the best solution for our google cloud libraries.