### PR TITLE
fix: include mismatched PHP namespaces in package error

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -152,12 +152,20 @@ class CodeGenerator
         $mixinRpcNames = [];
         $serviceYamlConfig = new ServiceYamlConfig($serviceYaml);
         $transportType = Transport::parseTransport($transport);
-        foreach ($byPackage as [$_, $singlePackageFileDescs]) {
+        foreach ($byPackage as [$package, $singlePackageFileDescs]) {
+            $fileNamespaces = $singlePackageFileDescs
+              ->map(fn ($x) => sprintf('%s (%s)', $x->getName(), ProtoHelpers::getNamespace($x)));
             $namespaces = $singlePackageFileDescs
               ->map(fn ($x) => ProtoHelpers::getNamespace($x))
               ->distinct();
             if (count($namespaces) > 1) {
-                throw new Exception('All files in the same package must have the same PHP namespace');
+                throw new Exception(sprintf(
+                    'All files in the same package must have the same PHP namespace; ' .
+                    'package "%s" has mismatched namespaces [%s] from files: %s',
+                    $package,
+                    $namespaces->join(', '),
+                    $fileNamespaces->join(', ')
+                ));
             }
 
             // Full protobuf names, e.g. google.cloud.foo.Bar.

--- a/tests/Unit/CodeGeneratorNamespaceTest.php
+++ b/tests/Unit/CodeGeneratorNamespaceTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Generator\Tests\Unit;
+
+use Exception;
+use Google\Generator\CodeGenerator;
+use Google\Generator\Collections\Vector;
+use Google\Protobuf\Internal\FileDescriptorProto;
+use Google\Protobuf\Internal\FileOptions;
+use Google\Protobuf\Internal\SourceCodeInfo;
+use PHPUnit\Framework\TestCase;
+
+final class CodeGeneratorNamespaceTest extends TestCase
+{
+    public function testMismatchedPhpNamespacesIncludeDetailsInError(): void
+    {
+        $fileA = $this->fileDesc('tests/Unit/a.proto', 'testing.ns_mismatch', 'Testing\\NsMismatchA');
+        $fileB = $this->fileDesc('tests/Unit/b.proto', 'testing.ns_mismatch', 'Testing\\NsMismatchB');
+
+        try {
+            iterator_to_array(CodeGenerator::generate(
+                Vector::new([$fileA, $fileB]),
+                Vector::new([$fileA->getName(), $fileB->getName()]),
+                null,
+                false,
+                null,
+                null,
+                null,
+            ));
+            $this->fail('Expected Exception was not thrown');
+        } catch (Exception $e) {
+            $this->assertStringContainsString(
+                'All files in the same package must have the same PHP namespace',
+                $e->getMessage()
+            );
+            $this->assertStringContainsString('package "testing.ns_mismatch"', $e->getMessage());
+            $this->assertStringContainsString('Testing\\NsMismatchA', $e->getMessage());
+            $this->assertStringContainsString('Testing\\NsMismatchB', $e->getMessage());
+            $this->assertStringContainsString('tests/Unit/a.proto', $e->getMessage());
+            $this->assertStringContainsString('tests/Unit/b.proto', $e->getMessage());
+        }
+    }
+
+    private function fileDesc(string $name, string $package, string $phpNamespace): FileDescriptorProto
+    {
+        $opts = new FileOptions();
+        $opts->setPhpNamespace($phpNamespace);
+
+        $file = new FileDescriptorProto();
+        $file->setName($name);
+        $file->setPackage($package);
+        $file->setSyntax('proto3');
+        $file->setOptions($opts);
+        $file->setSourceCodeInfo(new SourceCodeInfo());
+        return $file;
+    }
+}


### PR DESCRIPTION
## Summary
- Improve the package PHP namespace mismatch error to include the package name, distinct namespaces, and per-file namespace mapping.
- Add a unit test covering the richer error details.

Fixes #668

## Notes
- Contributor will sign the Google CLA if required for this repository.

## Test plan
- [ ] Review updated exception text in `CodeGenerator`
- [ ] Run `tests/Unit/CodeGeneratorNamespaceTest.php` (or full unit suite) in CI