### PR TITLE
fix: remove empty fragments directories from packaged output

### DIFF
--- a/rules_php_gapic/php_gapic_pkg.bzl
+++ b/rules_php_gapic/php_gapic_pkg.bzl
@@ -70,6 +70,8 @@ def _php_gapic_src_pkg_impl(ctx):
         fi
     done
     {post_processor} --input {package_dir_path}
+    # Drop any leftover empty fragments/ tree from the package tarball.
+    rm -rf {package_dir_path}/fragments
     cd {package_dir_path}/{tar_cd_suffix}
     tar --exclude=*.build.txt  -zchpf {tar_prefix}/{package_dir}.tar.gz {tar_prefix}/*
     cd -

--- a/src/PostProcessor/FragmentInjectionProcessor.php
+++ b/src/PostProcessor/FragmentInjectionProcessor.php
@@ -41,6 +41,32 @@ class FragmentInjectionProcessor implements ProcessorInterface
 
             self::inject($fragmentPath, $protoPath);
         }
+
+        // Remove fragment sources after injection so packaging does not ship
+        // empty fragments/ directory trees (see googleapis/gapic-generator-php#621).
+        self::removeFragmentsDirectory($inputDir);
+    }
+
+    private static function removeFragmentsDirectory(string $inputDir): void
+    {
+        $fragmentsDir = rtrim($inputDir, '/').'/fragments';
+        if (!is_dir($fragmentsDir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($fragmentsDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($files as $fileinfo) {
+            $pathname = $fileinfo->getPathname();
+            if ($fileinfo->isDir()) {
+                rmdir($pathname);
+            } else {
+                unlink($pathname);
+            }
+        }
+        rmdir($fragmentsDir);
     }
 
     private static function inject(string $fragmentFile, string $classFile): void

--- a/tests/Unit/PostProcessor/FragmentInjectionProcessorTest.php
+++ b/tests/Unit/PostProcessor/FragmentInjectionProcessorTest.php
@@ -140,6 +140,8 @@ EOL;
 
         // If we've gotten here, the PHP code is valid. Just assert that the contents have changed.
         $this->expectOutputString('Fragment written to ' . $toFile . PHP_EOL);
+        $this->assertFileDoesNotExist($tmpDir . '/fragments/Bar.build.txt');
+        $this->assertDirectoryDoesNotExist($tmpDir . '/fragments');
     }
 
     public function provideWriteMethodToClassScript()


### PR DESCRIPTION
## Summary
- Delete `fragments/` after fragment injection in the post-processor.
- Also prune any leftover `fragments/` tree in `php_gapic_pkg.bzl` before creating the package tarball.
- Update the fragment injection unit test to assert the directory is removed.

Fixes #621

## Notes
- Contributor will sign the Google CLA if required for this repository.

## Test plan
- [ ] Run `FragmentInjectionProcessorTest`
- [ ] Build a PHP GAPIC package and confirm the tarball has no empty `fragments/` directories