### PR TITLE
fix: gracefully handle missing proto/src directories in ProtobufNoCheckInHeaderProcessor

### DIFF
--- a/src/PostProcessor/ProtobufNoCheckInHeaderProcessor.php
+++ b/src/PostProcessor/ProtobufNoCheckInHeaderProcessor.php
@@ -22,7 +22,11 @@ class ProtobufNoCheckInHeaderProcessor implements ProcessorInterface
 {
     public static function run(string $inputDir): void
     {
-        $protoDir = new \RecursiveDirectoryIterator($inputDir . '/proto/src');
+        $protoSrcDir = $inputDir . '/proto/src';
+        if (!is_dir($protoSrcDir)) {
+            return;
+        }
+        $protoDir = new \RecursiveDirectoryIterator($protoSrcDir);
         $protoDirItr = new \RecursiveIteratorIterator($protoDir);
         $protoItr = new \RegexIterator($protoDirItr, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH);
         foreach ($protoItr as $finding) {

--- a/tests/Unit/PostProcessor/ProtobufNoCheckInHeaderProcessorTest.php
+++ b/tests/Unit/PostProcessor/ProtobufNoCheckInHeaderProcessorTest.php
@@ -98,6 +98,20 @@ EOL;
         $this->expectOutputString('No Check-In Header removed in ' . $toFile . PHP_EOL);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRunDoesNotFailWhenProtoSrcDirectoryIsMissing()
+    {
+        $tmpDir = sys_get_temp_dir() . '/test-missing-proto-src-' . rand();
+        mkdir($tmpDir, 0777, true);
+
+        // This should not throw an exception.
+        ProtobufNoCheckInHeaderProcessor::run($tmpDir);
+
+        $this->assertTrue(true); // If we reach here, no exception was thrown.
+    }
+
     private function classContainsNoCheckInHeader(string $classContents): bool
     {
         $tokens = token_get_all($classContents);


### PR DESCRIPTION
This PR adds a safety check to ProtobufNoCheckInHeaderProcessor to ensure the proto/src directory actually exists before attempting to traverse it. Previously, if a library did not contain a proto/src directory (which is common for certain Google Cloud packages like accessapproval), the post-processor would crash with a fatal error: Uncaught UnexpectedValueException: RecursiveDirectoryIterator::__construct(././proto/src): Failed to open directory.

Fixes https://github.com/googleapis/librarian/issues/7260