### PR TITLE
fix: restore dropped code fixers and dead pagination checks

### DIFF
--- a/src/Collections/Map.php
+++ b/src/Collections/Map.php
@@ -63,7 +63,7 @@ class Map implements \IteratorAggregate, \Countable, \ArrayAccess
         $data = [];
         foreach ($pairs as [$k, $v]) {
             if (static::apply($data, $k, 1, $v)[0]) {
-                throw new Exception("Cannot add two items with the same key $k");
+                throw new Exception('Cannot add two items with the same key ' . static::keyToString($k));
             }
         }
         return new Map($data, count($pairs));
@@ -155,7 +155,25 @@ class Map implements \IteratorAggregate, \Countable, \ArrayAccess
         }
         $dbt = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         $caller = isset($dbt[1]['function']) ? $dbt[1]['function'] : null;
-        throw new Exception("Key $key does not exist, called from $caller");
+        throw new Exception('Key ' . static::keyToString($key) . " does not exist, called from $caller");
+    }
+
+    /**
+     * Render a key for use in an exception message. Keys may be any type that supports
+     * equality, which does not imply they are convertible to string; interpolating such a
+     * key directly would raise an "object could not be converted to string" error, masking
+     * the diagnostic being reported.
+     *
+     * @param mixed $key The key to render.
+     *
+     * @return string
+     */
+    private static function keyToString($key): string
+    {
+        if (is_object($key)) {
+            return method_exists($key, '__toString') ? (string) $key : '<' . get_class($key) . '>';
+        }
+        return (string) $key;
     }
 
     /** @inheritDoc */

--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -203,9 +203,7 @@ abstract class MethodDetails
                 && $resourceByNumber[0] === $resourceByPosition[0];
         }
 
-        // A method missing any of the pagination fields is simply not paginated. A method that
-        // has them all but whose resource field is unusable is malformed, and is reported below.
-        if (is_null($pageSize) || is_null($pageToken) || is_null($nextPageToken) || is_null($resources)) {
+        if (is_null($pageSize) || is_null($pageToken) || is_null($nextPageToken) || is_null($resources) || !$resourceFieldValid) {
             return null;
         }
 
@@ -224,12 +222,6 @@ abstract class MethodDetails
         }
         if ($nextPageToken->isRepeated() || $nextPageToken->getType() !== GPBType::STRING) {
             throw new Exception('next_page_token field must be of type string.');
-        }
-        if (!$resourceFieldValid) {
-            if ($isDireGapic) {
-                throw new Exception('Item resources field must a map or repeated field.');
-            }
-            throw new Exception('Item resources field must be the first repeated field by number and position.');
         }
         return new class($svc, $desc, $outputMsg, $pageSize, $pageToken, $nextPageToken, $resources) extends MethodDetails {
             public function __construct($svc, $desc, $outputMsg, $pageSize, $pageToken, $nextPageToken, $resources)

--- a/src/Generation/MethodDetails.php
+++ b/src/Generation/MethodDetails.php
@@ -199,19 +199,22 @@ abstract class MethodDetails
 
         // Leverage short-circuting.
         if ($resourceFieldValid && !$isDireGapic) {
-            $resourceFieldValid &= !ProtoHelpers::isMap($catalog, $resources)
+            $resourceFieldValid = !ProtoHelpers::isMap($catalog, $resources)
                 && $resourceByNumber[0] === $resourceByPosition[0];
         }
 
-        if (is_null($pageSize) || is_null($pageToken) || is_null($nextPageToken) || is_null($resources) || !$resourceFieldValid) {
+        // A method missing any of the pagination fields is simply not paginated. A method that
+        // has them all but whose resource field is unusable is malformed, and is reported below.
+        if (is_null($pageSize) || is_null($pageToken) || is_null($nextPageToken) || is_null($resources)) {
             return null;
         }
 
         $isValidPageSize = !$pageSize->isRepeated();
         if ($isDireGapic) {
-            $isValidPageSize = $pageSize->getType() === GPBType::UINT32 || $pageSize->getType() === GPBType::INT32;
+            $isValidPageSize = $isValidPageSize
+                && ($pageSize->getType() === GPBType::UINT32 || $pageSize->getType() === GPBType::INT32);
         } else {
-            $isValidPageSize = $pageSize->getType() === GPBType::INT32;
+            $isValidPageSize = $isValidPageSize && $pageSize->getType() === GPBType::INT32;
         }
         if (!$isValidPageSize) {
             throw new Exception('page_size field must be of type ' . ($isDireGapic ? 'uint32 or int32' : 'int32') . '.');

--- a/src/Utils/Formatter.php
+++ b/src/Utils/Formatter.php
@@ -72,7 +72,7 @@ class Formatter
             $fixers[] = self::buildLineLengthFixer($lineLength);
         }
 
-        $fixers += [
+        $fixers = array_merge($fixers, [
             new Fixer\FunctionNotation\NoSpacesAfterFunctionNameFixer(), // 2, PSR2
             new Fixer\Comment\NoEmptyCommentFixer(), // 2
             new Fixer\Whitespace\NoSpacesInsideParenthesisFixer(), // 2, PSR2
@@ -98,7 +98,7 @@ class Formatter
             new Fixer\Whitespace\ArrayIndentationFixer(), // -31
             new Fixer\Whitespace\MethodChainingIndentationFixer(), // -34
             new Fixer\Whitespace\SingleBlankLineAtEofFixer(), // -50, PSR2 (must run last)
-        ];
+        ]);
 
         // Fixer temporarily removed:
         // new Fixer\Whitespace\BlankLineBeforeStatementFixer(), // -21

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_iam_policy_longrunning.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_move.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_move.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_org_policies.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_org_policies.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_containers.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/analyze_org_policy_governed_containers.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/batch_get_assets_history.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/batch_get_assets_history.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/batch_get_effective_iam_policies.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/batch_get_effective_iam_policies.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/create_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/create_feed.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/create_saved_query.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/create_saved_query.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/delete_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/delete_feed.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/delete_saved_query.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/delete_saved_query.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/export_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/export_assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/get_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/get_feed.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/get_saved_query.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/get_saved_query.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_feeds.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_feeds.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_saved_queries.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/list_saved_queries.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/query_assets.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/query_assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_iam_policies.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_iam_policies.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_resources.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/search_all_resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/update_feed.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/update_feed.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/update_saved_query.php
+++ b/tests/Integration/goldens/asset/samples/V1/AssetServiceClient/update_saved_query.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/src/V1/Client/AssetServiceClient.php
+++ b/tests/Integration/goldens/asset/src/V1/Client/AssetServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -113,7 +114,9 @@ final class AssetServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.asset.v1.AssetService';
 
     /**
@@ -123,13 +126,19 @@ final class AssetServiceClient
      */
     private const SERVICE_ADDRESS = 'cloudasset.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'cloudasset.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -500,7 +509,9 @@ final class AssetServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/asset/src/V1/resources/asset_service_descriptor_config.php
+++ b/tests/Integration/goldens/asset/src/V1/resources/asset_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/src/V1/resources/asset_service_rest_client_config.php
+++ b/tests/Integration/goldens/asset/src/V1/resources/asset_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/asset/tests/Unit/V1/Client/AssetServiceClientTest.php
+++ b/tests/Integration/goldens/asset/tests/Unit/V1/Client/AssetServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -95,19 +96,25 @@ use stdClass;
  */
 class AssetServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return AssetServiceClient */
+    /**
+     * @return AssetServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -116,7 +123,9 @@ class AssetServiceClientTest extends GeneratedTest
         return new AssetServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -147,7 +156,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -184,7 +195,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeIamPolicyLongrunningTest()
     {
         $operationsTransport = $this->createTransport();
@@ -254,7 +267,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeIamPolicyLongrunningExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -315,7 +330,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeMoveTest()
     {
         $transport = $this->createTransport();
@@ -346,7 +363,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeMoveExceptionTest()
     {
         $transport = $this->createTransport();
@@ -383,7 +402,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeOrgPoliciesTest()
     {
         $transport = $this->createTransport();
@@ -424,7 +445,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeOrgPoliciesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -461,7 +484,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeOrgPolicyGovernedAssetsTest()
     {
         $transport = $this->createTransport();
@@ -502,7 +527,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeOrgPolicyGovernedAssetsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -539,7 +566,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeOrgPolicyGovernedContainersTest()
     {
         $transport = $this->createTransport();
@@ -580,7 +609,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeOrgPolicyGovernedContainersExceptionTest()
     {
         $transport = $this->createTransport();
@@ -617,7 +648,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchGetAssetsHistoryTest()
     {
         $transport = $this->createTransport();
@@ -652,7 +685,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchGetAssetsHistoryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -691,7 +726,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchGetEffectiveIamPoliciesTest()
     {
         $transport = $this->createTransport();
@@ -722,7 +759,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchGetEffectiveIamPoliciesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -759,7 +798,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFeedTest()
     {
         $transport = $this->createTransport();
@@ -800,7 +841,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFeedExceptionTest()
     {
         $transport = $this->createTransport();
@@ -843,7 +886,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSavedQueryTest()
     {
         $transport = $this->createTransport();
@@ -886,7 +931,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSavedQueryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -925,7 +972,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteFeedTest()
     {
         $transport = $this->createTransport();
@@ -951,7 +1000,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteFeedExceptionTest()
     {
         $transport = $this->createTransport();
@@ -986,7 +1037,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSavedQueryTest()
     {
         $transport = $this->createTransport();
@@ -1012,7 +1065,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSavedQueryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1047,7 +1102,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportAssetsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1115,7 +1172,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportAssetsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1174,7 +1233,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getFeedTest()
     {
         $transport = $this->createTransport();
@@ -1203,7 +1264,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getFeedExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1238,7 +1301,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSavedQueryTest()
     {
         $transport = $this->createTransport();
@@ -1273,7 +1338,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSavedQueryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1308,7 +1375,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAssetsTest()
     {
         $transport = $this->createTransport();
@@ -1345,7 +1414,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAssetsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1380,7 +1451,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listFeedsTest()
     {
         $transport = $this->createTransport();
@@ -1407,7 +1480,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listFeedsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1442,7 +1517,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSavedQueriesTest()
     {
         $transport = $this->createTransport();
@@ -1479,7 +1556,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSavedQueriesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1514,7 +1593,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function queryAssetsTest()
     {
         $transport = $this->createTransport();
@@ -1545,7 +1626,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function queryAssetsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1580,7 +1663,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchAllIamPoliciesTest()
     {
         $transport = $this->createTransport();
@@ -1617,7 +1702,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchAllIamPoliciesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1652,7 +1739,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchAllResourcesTest()
     {
         $transport = $this->createTransport();
@@ -1689,7 +1778,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchAllResourcesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1724,7 +1815,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateFeedTest()
     {
         $transport = $this->createTransport();
@@ -1761,7 +1854,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateFeedExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1802,7 +1897,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSavedQueryTest()
     {
         $transport = $this->createTransport();
@@ -1841,7 +1938,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSavedQueryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1878,7 +1977,9 @@ class AssetServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function analyzeIamPolicyAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/aggregated_list.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/aggregated_list.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/delete.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/delete.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/insert.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/insert.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/list.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/AddressesClient/list.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/samples/V1/RegionOperationsClient/get.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/RegionOperationsClient/get.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/samples/V1/SubnetworksClient/list_usable.php
+++ b/tests/Integration/goldens/compute_small/samples/V1/SubnetworksClient/list_usable.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/src/V1/Client/AddressesClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/AddressesClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -59,7 +60,9 @@ final class AddressesClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.compute.v1.Addresses';
 
     /**
@@ -69,13 +72,19 @@ final class AddressesClient
      */
     private const SERVICE_ADDRESS = 'compute.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'compute.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -109,13 +118,17 @@ final class AddressesClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -133,7 +146,9 @@ final class AddressesClient
         return $this->operationsClient;
     }
 
-    /** Return the default longrunning operation descriptor config. */
+    /**
+     * Return the default longrunning operation descriptor config.
+     */
     private function getDefaultOperationDescriptor()
     {
         return [
@@ -265,7 +280,9 @@ final class AddressesClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/compute_small/src/V1/Client/RegionOperationsClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/RegionOperationsClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -49,7 +50,9 @@ final class RegionOperationsClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.compute.v1.RegionOperations';
 
     /**
@@ -59,13 +62,19 @@ final class RegionOperationsClient
      */
     private const SERVICE_ADDRESS = 'compute.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'compute.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -98,13 +107,17 @@ final class RegionOperationsClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -183,7 +196,9 @@ final class RegionOperationsClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/compute_small/src/V1/Client/SubnetworksClient.php
+++ b/tests/Integration/goldens/compute_small/src/V1/Client/SubnetworksClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -49,7 +50,9 @@ final class SubnetworksClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.compute.v1.Subnetworks';
 
     /**
@@ -59,13 +62,19 @@ final class SubnetworksClient
      */
     private const SERVICE_ADDRESS = 'compute.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'compute.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -97,13 +106,17 @@ final class SubnetworksClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -182,7 +195,9 @@ final class SubnetworksClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/compute_small/src/V1/resources/addresses_descriptor_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/addresses_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/src/V1/resources/addresses_rest_client_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/addresses_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/src/V1/resources/region_operations_descriptor_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/region_operations_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/src/V1/resources/region_operations_rest_client_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/region_operations_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/src/V1/resources/subnetworks_descriptor_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/subnetworks_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/src/V1/resources/subnetworks_rest_client_config.php
+++ b/tests/Integration/goldens/compute_small/src/V1/resources/subnetworks_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/Client/AddressesClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/Client/AddressesClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -49,19 +50,25 @@ use stdClass;
  */
 class AddressesClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return AddressesClient */
+    /**
+     * @return AddressesClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -70,7 +77,9 @@ class AddressesClientTest extends GeneratedTest
         return new AddressesClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aggregatedListTest()
     {
         $transport = $this->createTransport();
@@ -114,7 +123,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aggregatedListExceptionTest()
     {
         $transport = $this->createTransport();
@@ -149,7 +160,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteTest()
     {
         $operationsTransport = $this->createTransport();
@@ -217,7 +230,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -276,7 +291,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function insertTest()
     {
         $operationsTransport = $this->createTransport();
@@ -344,7 +361,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function insertExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -403,7 +422,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listTest()
     {
         $transport = $this->createTransport();
@@ -454,7 +475,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listExceptionTest()
     {
         $transport = $this->createTransport();
@@ -493,7 +516,9 @@ class AddressesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aggregatedListAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/Client/RegionOperationsClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/Client/RegionOperationsClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class RegionOperationsClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return RegionOperationsClient */
+    /**
+     * @return RegionOperationsClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class RegionOperationsClientTest extends GeneratedTest
         return new RegionOperationsClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getTest()
     {
         $transport = $this->createTransport();
@@ -135,7 +144,9 @@ class RegionOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getExceptionTest()
     {
         $transport = $this->createTransport();
@@ -174,7 +185,9 @@ class RegionOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/compute_small/tests/Unit/V1/Client/SubnetworksClientTest.php
+++ b/tests/Integration/goldens/compute_small/tests/Unit/V1/Client/SubnetworksClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class SubnetworksClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return SubnetworksClient */
+    /**
+     * @return SubnetworksClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class SubnetworksClientTest extends GeneratedTest
         return new SubnetworksClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listUsableTest()
     {
         $transport = $this->createTransport();
@@ -104,7 +113,9 @@ class SubnetworksClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listUsableExceptionTest()
     {
         $transport = $this->createTransport();
@@ -139,7 +150,9 @@ class SubnetworksClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listUsableAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/cancel_operation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/cancel_operation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/check_autopilot_compatibility.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/check_autopilot_compatibility.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/complete_ip_rotation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/complete_ip_rotation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/complete_node_pool_upgrade.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/complete_node_pool_upgrade.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/create_node_pool.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/delete_node_pool.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/fetch_cluster_upgrade_info.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/fetch_cluster_upgrade_info.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/fetch_node_pool_upgrade_info.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/fetch_node_pool_upgrade_info.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_json_web_keys.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_json_web_keys.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_node_pool.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_operation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_operation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_server_config.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/get_server_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_clusters.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_clusters.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_node_pools.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_node_pools.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_operations.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_operations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_usable_subnetworks.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/list_usable_subnetworks.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/rollback_node_pool_upgrade.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/rollback_node_pool_upgrade.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_addons_config.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_addons_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_labels.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_labels.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_legacy_abac.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_legacy_abac.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_locations.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_locations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_logging_service.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_logging_service.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_maintenance_policy.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_maintenance_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_master_auth.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_master_auth.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_monitoring_service.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_monitoring_service.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_network_policy.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_network_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_autoscaling.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_autoscaling.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_management.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_management.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_size.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/set_node_pool_size.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/start_ip_rotation.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/start_ip_rotation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_cluster.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_master.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_master.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_node_pool.php
+++ b/tests/Integration/goldens/container/samples/V1/ClusterManagerClient/update_node_pool.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/src/V1/Client/ClusterManagerClient.php
+++ b/tests/Integration/goldens/container/src/V1/Client/ClusterManagerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -137,7 +138,9 @@ final class ClusterManagerClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.container.v1.ClusterManager';
 
     /**
@@ -147,13 +150,19 @@ final class ClusterManagerClient
      */
     private const SERVICE_ADDRESS = 'container.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'container.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -343,7 +352,9 @@ final class ClusterManagerClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/container/src/V1/resources/cluster_manager_descriptor_config.php
+++ b/tests/Integration/goldens/container/src/V1/resources/cluster_manager_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/src/V1/resources/cluster_manager_rest_client_config.php
+++ b/tests/Integration/goldens/container/src/V1/resources/cluster_manager_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/container/tests/Unit/V1/Client/ClusterManagerClientTest.php
+++ b/tests/Integration/goldens/container/tests/Unit/V1/Client/ClusterManagerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -94,19 +95,25 @@ use stdClass;
  */
 class ClusterManagerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ClusterManagerClient */
+    /**
+     * @return ClusterManagerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -115,7 +122,9 @@ class ClusterManagerClientTest extends GeneratedTest
         return new ClusterManagerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelOperationTest()
     {
         $transport = $this->createTransport();
@@ -136,7 +145,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelOperationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -168,7 +179,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function checkAutopilotCompatibilityTest()
     {
         $transport = $this->createTransport();
@@ -192,7 +205,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function checkAutopilotCompatibilityExceptionTest()
     {
         $transport = $this->createTransport();
@@ -224,7 +239,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeIPRotationTest()
     {
         $transport = $this->createTransport();
@@ -264,7 +281,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeIPRotationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -296,7 +315,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeNodePoolUpgradeTest()
     {
         $transport = $this->createTransport();
@@ -317,7 +338,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeNodePoolUpgradeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -349,7 +372,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClusterTest()
     {
         $transport = $this->createTransport();
@@ -394,7 +419,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClusterExceptionTest()
     {
         $transport = $this->createTransport();
@@ -429,7 +456,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNodePoolTest()
     {
         $transport = $this->createTransport();
@@ -474,7 +503,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNodePoolExceptionTest()
     {
         $transport = $this->createTransport();
@@ -509,7 +540,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteClusterTest()
     {
         $transport = $this->createTransport();
@@ -549,7 +582,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteClusterExceptionTest()
     {
         $transport = $this->createTransport();
@@ -581,7 +616,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteNodePoolTest()
     {
         $transport = $this->createTransport();
@@ -621,7 +658,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteNodePoolExceptionTest()
     {
         $transport = $this->createTransport();
@@ -653,7 +692,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fetchClusterUpgradeInfoTest()
     {
         $transport = $this->createTransport();
@@ -688,7 +729,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fetchClusterUpgradeInfoExceptionTest()
     {
         $transport = $this->createTransport();
@@ -723,7 +766,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fetchNodePoolUpgradeInfoTest()
     {
         $transport = $this->createTransport();
@@ -758,7 +803,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fetchNodePoolUpgradeInfoExceptionTest()
     {
         $transport = $this->createTransport();
@@ -793,7 +840,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getClusterTest()
     {
         $transport = $this->createTransport();
@@ -873,7 +922,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getClusterExceptionTest()
     {
         $transport = $this->createTransport();
@@ -905,7 +956,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getJSONWebKeysTest()
     {
         $transport = $this->createTransport();
@@ -927,7 +980,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getJSONWebKeysExceptionTest()
     {
         $transport = $this->createTransport();
@@ -959,7 +1014,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNodePoolTest()
     {
         $transport = $this->createTransport();
@@ -995,7 +1052,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNodePoolExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1027,7 +1086,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getOperationTest()
     {
         $transport = $this->createTransport();
@@ -1067,7 +1128,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getOperationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1099,7 +1162,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getServerConfigTest()
     {
         $transport = $this->createTransport();
@@ -1125,7 +1190,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getServerConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1157,7 +1224,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listClustersTest()
     {
         $transport = $this->createTransport();
@@ -1179,7 +1248,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listClustersExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1211,7 +1282,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listNodePoolsTest()
     {
         $transport = $this->createTransport();
@@ -1233,7 +1306,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listNodePoolsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1265,7 +1340,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listOperationsTest()
     {
         $transport = $this->createTransport();
@@ -1287,7 +1364,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listOperationsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1319,7 +1398,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listUsableSubnetworksTest()
     {
         $transport = $this->createTransport();
@@ -1351,7 +1432,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listUsableSubnetworksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1383,7 +1466,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function rollbackNodePoolUpgradeTest()
     {
         $transport = $this->createTransport();
@@ -1423,7 +1508,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function rollbackNodePoolUpgradeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1455,7 +1542,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setAddonsConfigTest()
     {
         $transport = $this->createTransport();
@@ -1500,7 +1589,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setAddonsConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1535,7 +1626,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLabelsTest()
     {
         $transport = $this->createTransport();
@@ -1587,7 +1680,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLabelsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1627,7 +1722,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLegacyAbacTest()
     {
         $transport = $this->createTransport();
@@ -1672,7 +1769,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLegacyAbacExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1707,7 +1806,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLocationsTest()
     {
         $transport = $this->createTransport();
@@ -1752,7 +1853,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLocationsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1787,7 +1890,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLoggingServiceTest()
     {
         $transport = $this->createTransport();
@@ -1832,7 +1937,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setLoggingServiceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1867,7 +1974,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMaintenancePolicyTest()
     {
         $transport = $this->createTransport();
@@ -1924,7 +2033,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMaintenancePolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1965,7 +2076,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMasterAuthTest()
     {
         $transport = $this->createTransport();
@@ -2014,7 +2127,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMasterAuthExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2051,7 +2166,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMonitoringServiceTest()
     {
         $transport = $this->createTransport();
@@ -2096,7 +2213,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMonitoringServiceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2131,7 +2250,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNetworkPolicyTest()
     {
         $transport = $this->createTransport();
@@ -2176,7 +2297,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNetworkPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2211,7 +2334,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNodePoolAutoscalingTest()
     {
         $transport = $this->createTransport();
@@ -2256,7 +2381,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNodePoolAutoscalingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2291,7 +2418,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNodePoolManagementTest()
     {
         $transport = $this->createTransport();
@@ -2336,7 +2465,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNodePoolManagementExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2371,7 +2502,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNodePoolSizeTest()
     {
         $transport = $this->createTransport();
@@ -2416,7 +2549,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setNodePoolSizeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2451,7 +2586,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function startIPRotationTest()
     {
         $transport = $this->createTransport();
@@ -2491,7 +2628,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function startIPRotationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2523,7 +2662,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateClusterTest()
     {
         $transport = $this->createTransport();
@@ -2568,7 +2709,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateClusterExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2603,7 +2746,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateMasterTest()
     {
         $transport = $this->createTransport();
@@ -2648,7 +2793,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateMasterExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2683,7 +2830,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateNodePoolTest()
     {
         $transport = $this->createTransport();
@@ -2732,7 +2881,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateNodePoolExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2769,7 +2920,9 @@ class ClusterManagerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelOperationAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/create_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/create_autoscaling_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/delete_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/delete_autoscaling_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/get_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/get_autoscaling_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/list_autoscaling_policies.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/list_autoscaling_policies.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/update_autoscaling_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/AutoscalingPolicyServiceClient/update_autoscaling_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/create_batch.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/create_batch.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/delete_batch.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/delete_batch.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/get_batch.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/get_batch.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/list_batches.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/list_batches.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/BatchControllerClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/create_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/create_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/delete_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/delete_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/diagnose_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/diagnose_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/get_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/get_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/list_clusters.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/list_clusters.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/start_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/start_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/stop_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/stop_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/update_cluster.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/ClusterControllerClient/update_cluster.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/cancel_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/cancel_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/delete_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/delete_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/get_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/get_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/list_jobs.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/list_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job_as_operation.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/submit_job_as_operation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/update_job.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/JobControllerClient/update_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/create_node_group.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/create_node_group.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/get_node_group.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/get_node_group.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/resize_node_group.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/resize_node_group.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/NodeGroupControllerClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/create_session.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/create_session.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/delete_session.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/delete_session.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/get_session.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/get_session.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/list_sessions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/list_sessions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/terminate_session.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/terminate_session.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionControllerClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/create_session_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/create_session_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/delete_session_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/delete_session_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/get_session_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/get_session_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/list_session_templates.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/list_session_templates.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/update_session_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/SessionTemplateControllerClient/update_session_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/create_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/create_workflow_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/delete_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/delete_workflow_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/get_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/get_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/get_workflow_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_inline_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_inline_workflow_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/instantiate_workflow_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/list_workflow_templates.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/list_workflow_templates.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/set_iam_policy.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/update_workflow_template.php
+++ b/tests/Integration/goldens/dataproc/samples/V1/WorkflowTemplateServiceClient/update_workflow_template.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/Client/AutoscalingPolicyServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/AutoscalingPolicyServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -74,7 +75,9 @@ final class AutoscalingPolicyServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.AutoscalingPolicyService';
 
     /**
@@ -84,13 +87,19 @@ final class AutoscalingPolicyServiceClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -314,7 +323,9 @@ final class AutoscalingPolicyServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/BatchControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/BatchControllerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -74,7 +75,9 @@ final class BatchControllerClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.BatchController';
 
     /**
@@ -84,13 +87,19 @@ final class BatchControllerClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -327,7 +336,9 @@ final class BatchControllerClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/ClusterControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/ClusterControllerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -85,7 +86,9 @@ final class ClusterControllerClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.ClusterController';
 
     /**
@@ -95,13 +98,19 @@ final class ClusterControllerClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -384,7 +393,9 @@ final class ClusterControllerClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/JobControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/JobControllerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -72,7 +73,9 @@ final class JobControllerClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.JobController';
 
     /**
@@ -82,13 +85,19 @@ final class JobControllerClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -244,7 +253,9 @@ final class JobControllerClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/NodeGroupControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/NodeGroupControllerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -73,7 +74,9 @@ final class NodeGroupControllerClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.NodeGroupController';
 
     /**
@@ -83,13 +86,19 @@ final class NodeGroupControllerClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -310,7 +319,9 @@ final class NodeGroupControllerClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/SessionControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/SessionControllerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -76,7 +77,9 @@ final class SessionControllerClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.SessionController';
 
     /**
@@ -86,13 +89,19 @@ final class SessionControllerClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -349,7 +358,9 @@ final class SessionControllerClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/SessionTemplateControllerClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/SessionTemplateControllerClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -73,7 +74,9 @@ final class SessionTemplateControllerClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.SessionTemplateController';
 
     /**
@@ -83,13 +86,19 @@ final class SessionTemplateControllerClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -275,7 +284,9 @@ final class SessionTemplateControllerClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/Client/WorkflowTemplateServiceClient.php
+++ b/tests/Integration/goldens/dataproc/src/V1/Client/WorkflowTemplateServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -82,7 +83,9 @@ final class WorkflowTemplateServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.dataproc.v1.WorkflowTemplateService';
 
     /**
@@ -92,13 +95,19 @@ final class WorkflowTemplateServiceClient
      */
     private const SERVICE_ADDRESS = 'dataproc.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'dataproc.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -457,7 +466,9 @@ final class WorkflowTemplateServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/dataproc/src/V1/resources/autoscaling_policy_service_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/autoscaling_policy_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/autoscaling_policy_service_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/autoscaling_policy_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/batch_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/batch_controller_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/batch_controller_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/batch_controller_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/cluster_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/cluster_controller_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/cluster_controller_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/cluster_controller_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/job_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/job_controller_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/job_controller_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/job_controller_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/node_group_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/node_group_controller_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/node_group_controller_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/node_group_controller_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/session_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/session_controller_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/session_controller_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/session_controller_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/session_template_controller_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/session_template_controller_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/session_template_controller_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/session_template_controller_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/workflow_template_service_descriptor_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/workflow_template_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/src/V1/resources/workflow_template_service_rest_client_config.php
+++ b/tests/Integration/goldens/dataproc/src/V1/resources/workflow_template_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/AutoscalingPolicyServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/AutoscalingPolicyServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -54,19 +55,25 @@ use stdClass;
  */
 class AutoscalingPolicyServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return AutoscalingPolicyServiceClient */
+    /**
+     * @return AutoscalingPolicyServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -75,7 +82,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         return new AutoscalingPolicyServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createAutoscalingPolicyTest()
     {
         $transport = $this->createTransport();
@@ -124,7 +133,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createAutoscalingPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -175,7 +186,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteAutoscalingPolicyTest()
     {
         $transport = $this->createTransport();
@@ -201,7 +214,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteAutoscalingPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -236,7 +251,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAutoscalingPolicyTest()
     {
         $transport = $this->createTransport();
@@ -267,7 +284,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAutoscalingPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -302,7 +321,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAutoscalingPoliciesTest()
     {
         $transport = $this->createTransport();
@@ -339,7 +360,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAutoscalingPoliciesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -374,7 +397,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateAutoscalingPolicyTest()
     {
         $transport = $this->createTransport();
@@ -419,7 +444,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateAutoscalingPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -468,7 +495,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -499,7 +528,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -534,7 +565,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -569,7 +602,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -606,7 +641,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -637,7 +674,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -674,7 +713,9 @@ class AutoscalingPolicyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createAutoscalingPolicyAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/BatchControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/BatchControllerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -53,19 +54,25 @@ use stdClass;
  */
 class BatchControllerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BatchControllerClient */
+    /**
+     * @return BatchControllerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -74,7 +81,9 @@ class BatchControllerClientTest extends GeneratedTest
         return new BatchControllerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBatchTest()
     {
         $operationsTransport = $this->createTransport();
@@ -152,7 +161,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBatchExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -211,7 +222,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBatchTest()
     {
         $transport = $this->createTransport();
@@ -237,7 +250,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBatchExceptionTest()
     {
         $transport = $this->createTransport();
@@ -272,7 +287,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBatchTest()
     {
         $transport = $this->createTransport();
@@ -309,7 +326,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBatchExceptionTest()
     {
         $transport = $this->createTransport();
@@ -344,7 +363,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBatchesTest()
     {
         $transport = $this->createTransport();
@@ -381,7 +402,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBatchesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -416,7 +439,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -447,7 +472,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -482,7 +509,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -517,7 +546,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -554,7 +585,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -585,7 +618,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -622,7 +657,9 @@ class BatchControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBatchAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/ClusterControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/ClusterControllerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -59,19 +60,25 @@ use stdClass;
  */
 class ClusterControllerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ClusterControllerClient */
+    /**
+     * @return ClusterControllerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -80,7 +87,9 @@ class ClusterControllerClientTest extends GeneratedTest
         return new ClusterControllerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClusterTest()
     {
         $operationsTransport = $this->createTransport();
@@ -162,7 +171,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClusterExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -227,7 +238,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteClusterTest()
     {
         $operationsTransport = $this->createTransport();
@@ -299,7 +312,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteClusterExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -360,7 +375,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function diagnoseClusterTest()
     {
         $operationsTransport = $this->createTransport();
@@ -434,7 +451,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function diagnoseClusterExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -495,7 +514,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getClusterTest()
     {
         $transport = $this->createTransport();
@@ -536,7 +557,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getClusterExceptionTest()
     {
         $transport = $this->createTransport();
@@ -575,7 +598,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listClustersTest()
     {
         $transport = $this->createTransport();
@@ -616,7 +641,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listClustersExceptionTest()
     {
         $transport = $this->createTransport();
@@ -653,7 +680,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function startClusterTest()
     {
         $operationsTransport = $this->createTransport();
@@ -731,7 +760,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function startClusterExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -792,7 +823,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function stopClusterTest()
     {
         $operationsTransport = $this->createTransport();
@@ -870,7 +903,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function stopClusterExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -931,7 +966,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateClusterTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1021,7 +1058,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateClusterExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1090,7 +1129,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -1121,7 +1162,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1156,7 +1199,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -1191,7 +1236,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1228,7 +1275,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -1259,7 +1308,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1296,7 +1347,9 @@ class ClusterControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClusterAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/JobControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/JobControllerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -57,19 +58,25 @@ use stdClass;
  */
 class JobControllerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return JobControllerClient */
+    /**
+     * @return JobControllerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -78,7 +85,9 @@ class JobControllerClientTest extends GeneratedTest
         return new JobControllerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelJobTest()
     {
         $transport = $this->createTransport();
@@ -121,7 +130,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -160,7 +171,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteJobTest()
     {
         $transport = $this->createTransport();
@@ -194,7 +207,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -233,7 +248,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getJobTest()
     {
         $transport = $this->createTransport();
@@ -276,7 +293,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -315,7 +334,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listJobsTest()
     {
         $transport = $this->createTransport();
@@ -356,7 +377,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listJobsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -393,7 +416,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function submitJobTest()
     {
         $transport = $this->createTransport();
@@ -440,7 +465,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function submitJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -483,7 +510,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function submitJobAsOperationTest()
     {
         $operationsTransport = $this->createTransport();
@@ -567,7 +596,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function submitJobAsOperationExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -632,7 +663,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateJobTest()
     {
         $transport = $this->createTransport();
@@ -687,7 +720,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -734,7 +769,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -765,7 +802,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -800,7 +839,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -835,7 +876,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -872,7 +915,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -903,7 +948,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -940,7 +987,9 @@ class JobControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelJobAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/NodeGroupControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/NodeGroupControllerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -50,19 +51,25 @@ use stdClass;
  */
 class NodeGroupControllerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return NodeGroupControllerClient */
+    /**
+     * @return NodeGroupControllerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -71,7 +78,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         return new NodeGroupControllerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNodeGroupTest()
     {
         $operationsTransport = $this->createTransport();
@@ -143,7 +152,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNodeGroupExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -204,7 +215,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNodeGroupTest()
     {
         $transport = $this->createTransport();
@@ -233,7 +246,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNodeGroupExceptionTest()
     {
         $transport = $this->createTransport();
@@ -268,7 +283,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function resizeNodeGroupTest()
     {
         $operationsTransport = $this->createTransport();
@@ -338,7 +355,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function resizeNodeGroupExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -397,7 +416,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -428,7 +449,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -463,7 +486,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -498,7 +523,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -535,7 +562,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -566,7 +595,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -603,7 +634,9 @@ class NodeGroupControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNodeGroupAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/SessionControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/SessionControllerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -53,19 +54,25 @@ use stdClass;
  */
 class SessionControllerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return SessionControllerClient */
+    /**
+     * @return SessionControllerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -74,7 +81,9 @@ class SessionControllerClientTest extends GeneratedTest
         return new SessionControllerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSessionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -160,7 +169,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSessionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -223,7 +234,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSessionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -299,7 +312,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSessionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -356,7 +371,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSessionTest()
     {
         $transport = $this->createTransport();
@@ -395,7 +412,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSessionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -430,7 +449,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSessionsTest()
     {
         $transport = $this->createTransport();
@@ -467,7 +488,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSessionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -502,7 +525,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function terminateSessionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -578,7 +603,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function terminateSessionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -635,7 +662,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -666,7 +695,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -701,7 +732,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -736,7 +769,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -773,7 +808,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -804,7 +841,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -841,7 +880,9 @@ class SessionControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSessionAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/SessionTemplateControllerClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/SessionTemplateControllerClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -50,19 +51,25 @@ use stdClass;
  */
 class SessionTemplateControllerClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return SessionTemplateControllerClient */
+    /**
+     * @return SessionTemplateControllerClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -71,7 +78,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         return new SessionTemplateControllerClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSessionTemplateTest()
     {
         $transport = $this->createTransport();
@@ -112,7 +121,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSessionTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -151,7 +162,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSessionTemplateTest()
     {
         $transport = $this->createTransport();
@@ -177,7 +190,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSessionTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -212,7 +227,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSessionTemplateTest()
     {
         $transport = $this->createTransport();
@@ -247,7 +264,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSessionTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -282,7 +301,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSessionTemplatesTest()
     {
         $transport = $this->createTransport();
@@ -319,7 +340,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSessionTemplatesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -354,7 +377,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSessionTemplateTest()
     {
         $transport = $this->createTransport();
@@ -391,7 +416,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSessionTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -428,7 +455,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -459,7 +488,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -494,7 +525,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -529,7 +562,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -566,7 +601,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -597,7 +634,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -634,7 +673,9 @@ class SessionTemplateControllerClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSessionTemplateAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/WorkflowTemplateServiceClientTest.php
+++ b/tests/Integration/goldens/dataproc/tests/Unit/V1/Client/WorkflowTemplateServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -57,19 +58,25 @@ use stdClass;
  */
 class WorkflowTemplateServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return WorkflowTemplateServiceClient */
+    /**
+     * @return WorkflowTemplateServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -78,7 +85,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         return new WorkflowTemplateServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createWorkflowTemplateTest()
     {
         $transport = $this->createTransport();
@@ -121,7 +130,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createWorkflowTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -164,7 +175,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteWorkflowTemplateTest()
     {
         $transport = $this->createTransport();
@@ -190,7 +203,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteWorkflowTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -225,7 +240,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getWorkflowTemplateTest()
     {
         $transport = $this->createTransport();
@@ -258,7 +275,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getWorkflowTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -293,7 +312,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function instantiateInlineWorkflowTemplateTest()
     {
         $operationsTransport = $this->createTransport();
@@ -367,7 +388,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function instantiateInlineWorkflowTemplateExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -432,7 +455,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function instantiateWorkflowTemplateTest()
     {
         $operationsTransport = $this->createTransport();
@@ -496,7 +521,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function instantiateWorkflowTemplateExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -553,7 +580,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listWorkflowTemplatesTest()
     {
         $transport = $this->createTransport();
@@ -590,7 +619,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listWorkflowTemplatesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -625,7 +656,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateWorkflowTemplateTest()
     {
         $transport = $this->createTransport();
@@ -664,7 +697,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateWorkflowTemplateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -705,7 +740,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -736,7 +773,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -771,7 +810,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -806,7 +847,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -843,7 +886,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -874,7 +919,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -911,7 +958,9 @@ class WorkflowTemplateServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createWorkflowTemplateAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/call_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/call_function.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/create_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/create_function.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/delete_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/delete_function.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_download_url.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_download_url.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_upload_url.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/generate_upload_url.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_function.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_iam_policy.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/list_functions.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/list_functions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/set_iam_policy.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/update_function.php
+++ b/tests/Integration/goldens/functions/samples/V1/CloudFunctionsServiceClient/update_function.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
+++ b/tests/Integration/goldens/functions/src/V1/Client/CloudFunctionsServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -85,7 +86,9 @@ final class CloudFunctionsServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.functions.v1.CloudFunctionsService';
 
     /**
@@ -95,13 +98,19 @@ final class CloudFunctionsServiceClient
      */
     private const SERVICE_ADDRESS = 'cloudfunctions.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'cloudfunctions.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -360,7 +369,9 @@ final class CloudFunctionsServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/functions/src/V1/resources/cloud_functions_service_descriptor_config.php
+++ b/tests/Integration/goldens/functions/src/V1/resources/cloud_functions_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/src/V1/resources/cloud_functions_service_rest_client_config.php
+++ b/tests/Integration/goldens/functions/src/V1/resources/cloud_functions_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/functions/tests/Unit/V1/Client/CloudFunctionsServiceClientTest.php
+++ b/tests/Integration/goldens/functions/tests/Unit/V1/Client/CloudFunctionsServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -60,19 +61,25 @@ use stdClass;
  */
 class CloudFunctionsServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CloudFunctionsServiceClient */
+    /**
+     * @return CloudFunctionsServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -81,7 +88,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         return new CloudFunctionsServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function callFunctionTest()
     {
         $transport = $this->createTransport();
@@ -118,7 +127,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function callFunctionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -155,7 +166,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFunctionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -261,7 +274,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFunctionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -320,7 +335,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteFunctionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -384,7 +401,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteFunctionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -441,7 +460,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function generateDownloadUrlTest()
     {
         $transport = $this->createTransport();
@@ -465,7 +486,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function generateDownloadUrlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -497,7 +520,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function generateUploadUrlTest()
     {
         $transport = $this->createTransport();
@@ -521,7 +546,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function generateUploadUrlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -553,7 +580,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getFunctionTest()
     {
         $transport = $this->createTransport();
@@ -618,7 +647,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getFunctionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -653,7 +684,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -684,7 +717,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -719,7 +754,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listFunctionsTest()
     {
         $transport = $this->createTransport();
@@ -751,7 +788,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listFunctionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -783,7 +822,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -818,7 +859,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -855,7 +898,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -886,7 +931,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -923,7 +970,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateFunctionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1025,7 +1074,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateFunctionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1082,7 +1133,9 @@ class CloudFunctionsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function callFunctionAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/get_iam_policy.php
+++ b/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/set_iam_policy.php
+++ b/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/iam/samples/V1/IAMPolicyClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/iam/src/V1/Client/IAMPolicyClient.php
+++ b/tests/Integration/goldens/iam/src/V1/Client/IAMPolicyClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -78,7 +79,9 @@ final class IAMPolicyClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.iam.v1.IAMPolicy';
 
     /**
@@ -88,13 +91,19 @@ final class IAMPolicyClient
      */
     private const SERVICE_ADDRESS = 'iam-meta-api.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'iam-meta-api.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -197,7 +206,9 @@ final class IAMPolicyClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/iam/src/V1/resources/iam_policy_descriptor_config.php
+++ b/tests/Integration/goldens/iam/src/V1/resources/iam_policy_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/iam/src/V1/resources/iam_policy_rest_client_config.php
+++ b/tests/Integration/goldens/iam/src/V1/resources/iam_policy_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/iam/tests/Unit/V1/Client/IAMPolicyClientTest.php
+++ b/tests/Integration/goldens/iam/tests/Unit/V1/Client/IAMPolicyClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -42,19 +43,25 @@ use stdClass;
  */
 class IAMPolicyClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return IAMPolicyClient */
+    /**
+     * @return IAMPolicyClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -63,7 +70,9 @@ class IAMPolicyClientTest extends GeneratedTest
         return new IAMPolicyClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -94,7 +103,9 @@ class IAMPolicyClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -129,7 +140,9 @@ class IAMPolicyClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -164,7 +177,9 @@ class IAMPolicyClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -201,7 +216,9 @@ class IAMPolicyClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -232,7 +249,9 @@ class IAMPolicyClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -269,7 +288,9 @@ class IAMPolicyClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_decrypt.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_decrypt.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_sign.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/asymmetric_sign.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_crypto_key_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_import_job.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_import_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_key_ring.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/create_key_ring.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/decrypt.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/decrypt.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/destroy_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/destroy_crypto_key_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/encrypt.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/encrypt.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_crypto_key_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_iam_policy.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_import_job.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_import_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_key_ring.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_key_ring.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_location.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_location.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_public_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/get_public_key.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/import_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/import_crypto_key_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_key_versions.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_key_versions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_keys.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_crypto_keys.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_import_jobs.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_import_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_key_rings.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_key_rings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_locations.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/list_locations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/restore_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/restore_crypto_key_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/set_iam_policy.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_primary_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_primary_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_version.php
+++ b/tests/Integration/goldens/kms/samples/V1/KeyManagementServiceClient/update_crypto_key_version.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/src/V1/Client/KeyManagementServiceClient.php
+++ b/tests/Integration/goldens/kms/src/V1/Client/KeyManagementServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -133,7 +134,9 @@ final class KeyManagementServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.kms.v1.KeyManagementService';
 
     /**
@@ -143,13 +146,19 @@ final class KeyManagementServiceClient
      */
     private const SERVICE_ADDRESS = 'cloudkms.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'cloudkms.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -384,7 +393,9 @@ final class KeyManagementServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/kms/src/V1/resources/key_management_service_descriptor_config.php
+++ b/tests/Integration/goldens/kms/src/V1/resources/key_management_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/src/V1/resources/key_management_service_rest_client_config.php
+++ b/tests/Integration/goldens/kms/src/V1/resources/key_management_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/kms/tests/Unit/V1/Client/KeyManagementServiceClientTest.php
+++ b/tests/Integration/goldens/kms/tests/Unit/V1/Client/KeyManagementServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -87,19 +88,25 @@ use stdClass;
  */
 class KeyManagementServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return KeyManagementServiceClient */
+    /**
+     * @return KeyManagementServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -108,7 +115,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         return new KeyManagementServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function asymmetricDecryptTest()
     {
         $transport = $this->createTransport();
@@ -143,7 +152,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function asymmetricDecryptExceptionTest()
     {
         $transport = $this->createTransport();
@@ -180,7 +191,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function asymmetricSignTest()
     {
         $transport = $this->createTransport();
@@ -217,7 +230,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function asymmetricSignExceptionTest()
     {
         $transport = $this->createTransport();
@@ -254,7 +269,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCryptoKeyTest()
     {
         $transport = $this->createTransport();
@@ -291,7 +308,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCryptoKeyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -330,7 +349,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCryptoKeyVersionTest()
     {
         $transport = $this->createTransport();
@@ -367,7 +388,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCryptoKeyVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -404,7 +427,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createImportJobTest()
     {
         $transport = $this->createTransport();
@@ -445,7 +470,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createImportJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -488,7 +515,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createKeyRingTest()
     {
         $transport = $this->createTransport();
@@ -525,7 +554,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createKeyRingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -564,7 +595,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function decryptTest()
     {
         $transport = $this->createTransport();
@@ -597,7 +630,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function decryptExceptionTest()
     {
         $transport = $this->createTransport();
@@ -634,7 +669,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function destroyCryptoKeyVersionTest()
     {
         $transport = $this->createTransport();
@@ -667,7 +704,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function destroyCryptoKeyVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -702,7 +741,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function encryptTest()
     {
         $transport = $this->createTransport();
@@ -741,7 +782,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function encryptExceptionTest()
     {
         $transport = $this->createTransport();
@@ -778,7 +821,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCryptoKeyTest()
     {
         $transport = $this->createTransport();
@@ -807,7 +852,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCryptoKeyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -842,7 +889,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCryptoKeyVersionTest()
     {
         $transport = $this->createTransport();
@@ -875,7 +924,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCryptoKeyVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -910,7 +961,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -941,7 +994,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -976,7 +1031,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getImportJobTest()
     {
         $transport = $this->createTransport();
@@ -1005,7 +1062,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getImportJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1040,7 +1099,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getKeyRingTest()
     {
         $transport = $this->createTransport();
@@ -1069,7 +1130,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getKeyRingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1104,7 +1167,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getPublicKeyTest()
     {
         $transport = $this->createTransport();
@@ -1135,7 +1200,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getPublicKeyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1170,7 +1237,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importCryptoKeyVersionTest()
     {
         $transport = $this->createTransport();
@@ -1211,7 +1280,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importCryptoKeyVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1250,7 +1321,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCryptoKeyVersionsTest()
     {
         $transport = $this->createTransport();
@@ -1289,7 +1362,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCryptoKeyVersionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1324,7 +1399,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCryptoKeysTest()
     {
         $transport = $this->createTransport();
@@ -1363,7 +1440,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCryptoKeysExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1398,7 +1477,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listImportJobsTest()
     {
         $transport = $this->createTransport();
@@ -1437,7 +1518,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listImportJobsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1472,7 +1555,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listKeyRingsTest()
     {
         $transport = $this->createTransport();
@@ -1511,7 +1596,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listKeyRingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1546,7 +1633,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function restoreCryptoKeyVersionTest()
     {
         $transport = $this->createTransport();
@@ -1579,7 +1668,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function restoreCryptoKeyVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1614,7 +1705,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCryptoKeyTest()
     {
         $transport = $this->createTransport();
@@ -1647,7 +1740,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCryptoKeyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1684,7 +1779,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCryptoKeyPrimaryVersionTest()
     {
         $transport = $this->createTransport();
@@ -1717,7 +1814,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCryptoKeyPrimaryVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1754,7 +1853,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCryptoKeyVersionTest()
     {
         $transport = $this->createTransport();
@@ -1791,7 +1892,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCryptoKeyVersionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1828,7 +1931,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -1863,7 +1968,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1900,7 +2007,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -1931,7 +2040,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1968,7 +2079,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLocationTest()
     {
         $transport = $this->createTransport();
@@ -1996,7 +2109,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLocationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2028,7 +2143,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLocationsTest()
     {
         $transport = $this->createTransport();
@@ -2060,7 +2177,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLocationsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2092,7 +2211,9 @@ class KeyManagementServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function asymmetricDecryptAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/copy_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/copy_log_entries.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_bucket.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_bucket_async.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_bucket_async.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_exclusion.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_link.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_link.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_sink.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/create_view.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_bucket.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_exclusion.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_link.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_link.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_sink.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/delete_view.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_bucket.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_cmek_settings.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_cmek_settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_exclusion.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_link.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_link.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_settings.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_sink.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/get_view.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_buckets.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_buckets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_exclusions.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_exclusions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_links.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_links.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_sinks.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_sinks.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_views.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/list_views.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/undelete_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/undelete_bucket.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_bucket.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_bucket.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_bucket_async.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_bucket_async.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_cmek_settings.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_cmek_settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_exclusion.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_exclusion.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_settings.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_sink.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_sink.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_view.php
+++ b/tests/Integration/goldens/logging/samples/V2/ConfigServiceV2Client/update_view.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/delete_log.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/delete_log.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_log_entries.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_logs.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_logs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_monitored_resource_descriptors.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/list_monitored_resource_descriptors.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/tail_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/tail_log_entries.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/write_log_entries.php
+++ b/tests/Integration/goldens/logging/samples/V2/LoggingServiceV2Client/write_log_entries.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/create_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/create_log_metric.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/delete_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/delete_log_metric.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/get_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/get_log_metric.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/list_log_metrics.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/list_log_metrics.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/update_log_metric.php
+++ b/tests/Integration/goldens/logging/samples/V2/MetricsServiceV2Client/update_log_metric.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/src/V2/Client/ConfigServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/ConfigServiceV2Client.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -127,7 +128,9 @@ final class ConfigServiceV2Client
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.logging.v2.ConfigServiceV2';
 
     /**
@@ -137,13 +140,19 @@ final class ConfigServiceV2Client
      */
     private const SERVICE_ADDRESS = 'logging.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'logging.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -1121,7 +1130,9 @@ final class ConfigServiceV2Client
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/logging/src/V2/Client/LoggingServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/LoggingServiceV2Client.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -66,7 +67,9 @@ final class LoggingServiceV2Client
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.logging.v2.LoggingServiceV2';
 
     /**
@@ -76,13 +79,19 @@ final class LoggingServiceV2Client
      */
     private const SERVICE_ADDRESS = 'logging.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'logging.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -368,7 +377,9 @@ final class LoggingServiceV2Client
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/logging/src/V2/Client/MetricsServiceV2Client.php
+++ b/tests/Integration/goldens/logging/src/V2/Client/MetricsServiceV2Client.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -65,7 +66,9 @@ final class MetricsServiceV2Client
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.logging.v2.MetricsServiceV2';
 
     /**
@@ -75,13 +78,19 @@ final class MetricsServiceV2Client
      */
     private const SERVICE_ADDRESS = 'logging.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'logging.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -247,7 +256,9 @@ final class MetricsServiceV2Client
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/logging/src/V2/resources/config_service_v2_descriptor_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/config_service_v2_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/src/V2/resources/config_service_v2_rest_client_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/config_service_v2_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/src/V2/resources/logging_service_v2_descriptor_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/logging_service_v2_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/src/V2/resources/logging_service_v2_rest_client_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/logging_service_v2_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/src/V2/resources/metrics_service_v2_descriptor_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/metrics_service_v2_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/src/V2/resources/metrics_service_v2_rest_client_config.php
+++ b/tests/Integration/goldens/logging/src/V2/resources/metrics_service_v2_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/logging/tests/Unit/V2/Client/ConfigServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/Client/ConfigServiceV2ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -86,19 +87,25 @@ use stdClass;
  */
 class ConfigServiceV2ClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ConfigServiceV2Client */
+    /**
+     * @return ConfigServiceV2Client
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -107,7 +114,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         return new ConfigServiceV2Client($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function copyLogEntriesTest()
     {
         $operationsTransport = $this->createTransport();
@@ -177,7 +186,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function copyLogEntriesExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -236,7 +247,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBucketTest()
     {
         $transport = $this->createTransport();
@@ -281,7 +294,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBucketExceptionTest()
     {
         $transport = $this->createTransport();
@@ -320,7 +335,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBucketAsyncTest()
     {
         $operationsTransport = $this->createTransport();
@@ -402,7 +419,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBucketAsyncExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -463,7 +482,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createExclusionTest()
     {
         $transport = $this->createTransport();
@@ -506,7 +527,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createExclusionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -547,7 +570,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createLinkTest()
     {
         $operationsTransport = $this->createTransport();
@@ -623,7 +648,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createLinkExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -684,7 +711,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSinkTest()
     {
         $transport = $this->createTransport();
@@ -733,7 +762,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSinkExceptionTest()
     {
         $transport = $this->createTransport();
@@ -774,7 +805,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createViewTest()
     {
         $transport = $this->createTransport();
@@ -815,7 +848,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createViewExceptionTest()
     {
         $transport = $this->createTransport();
@@ -854,7 +889,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBucketTest()
     {
         $transport = $this->createTransport();
@@ -880,7 +917,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBucketExceptionTest()
     {
         $transport = $this->createTransport();
@@ -915,7 +954,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteExclusionTest()
     {
         $transport = $this->createTransport();
@@ -941,7 +982,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteExclusionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -976,7 +1019,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLinkTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1040,7 +1085,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLinkExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1097,7 +1144,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSinkTest()
     {
         $transport = $this->createTransport();
@@ -1123,7 +1172,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSinkExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1158,7 +1209,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteViewTest()
     {
         $transport = $this->createTransport();
@@ -1184,7 +1237,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteViewExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1219,7 +1274,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBucketTest()
     {
         $transport = $this->createTransport();
@@ -1256,7 +1313,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBucketExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1291,7 +1350,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCmekSettingsTest()
     {
         $transport = $this->createTransport();
@@ -1321,7 +1382,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCmekSettingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1353,7 +1416,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getExclusionTest()
     {
         $transport = $this->createTransport();
@@ -1388,7 +1453,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getExclusionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1423,7 +1490,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLinkTest()
     {
         $transport = $this->createTransport();
@@ -1454,7 +1523,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLinkExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1489,7 +1560,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSettingsTest()
     {
         $transport = $this->createTransport();
@@ -1526,7 +1599,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSettingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1561,7 +1636,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSinkTest()
     {
         $transport = $this->createTransport();
@@ -1602,7 +1679,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSinkExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1637,7 +1716,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getViewTest()
     {
         $transport = $this->createTransport();
@@ -1670,7 +1751,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getViewExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1705,7 +1788,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBucketsTest()
     {
         $transport = $this->createTransport();
@@ -1742,7 +1827,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBucketsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1777,7 +1864,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listExclusionsTest()
     {
         $transport = $this->createTransport();
@@ -1814,7 +1903,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listExclusionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1849,7 +1940,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLinksTest()
     {
         $transport = $this->createTransport();
@@ -1886,7 +1979,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLinksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1921,7 +2016,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSinksTest()
     {
         $transport = $this->createTransport();
@@ -1958,7 +2055,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSinksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1993,7 +2092,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listViewsTest()
     {
         $transport = $this->createTransport();
@@ -2030,7 +2131,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listViewsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2065,7 +2168,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function undeleteBucketTest()
     {
         $transport = $this->createTransport();
@@ -2091,7 +2196,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function undeleteBucketExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2126,7 +2233,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBucketTest()
     {
         $transport = $this->createTransport();
@@ -2171,7 +2280,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBucketExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2210,7 +2321,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBucketAsyncTest()
     {
         $operationsTransport = $this->createTransport();
@@ -2292,7 +2405,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBucketAsyncExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -2353,7 +2468,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCmekSettingsTest()
     {
         $transport = $this->createTransport();
@@ -2383,7 +2500,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCmekSettingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2415,7 +2534,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateExclusionTest()
     {
         $transport = $this->createTransport();
@@ -2462,7 +2583,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateExclusionExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2505,7 +2628,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSettingsTest()
     {
         $transport = $this->createTransport();
@@ -2546,7 +2671,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSettingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2583,7 +2710,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSinkTest()
     {
         $transport = $this->createTransport();
@@ -2632,7 +2761,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSinkExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2673,7 +2804,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateViewTest()
     {
         $transport = $this->createTransport();
@@ -2710,7 +2843,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateViewExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2747,7 +2882,9 @@ class ConfigServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function copyLogEntriesAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/logging/tests/Unit/V2/Client/LoggingServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/Client/LoggingServiceV2ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -52,19 +53,25 @@ use stdClass;
  */
 class LoggingServiceV2ClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return LoggingServiceV2Client */
+    /**
+     * @return LoggingServiceV2Client
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -73,7 +80,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         return new LoggingServiceV2Client($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLogTest()
     {
         $transport = $this->createTransport();
@@ -99,7 +108,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLogExceptionTest()
     {
         $transport = $this->createTransport();
@@ -134,7 +145,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLogEntriesTest()
     {
         $transport = $this->createTransport();
@@ -173,7 +186,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLogEntriesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -210,7 +225,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLogsTest()
     {
         $transport = $this->createTransport();
@@ -247,7 +264,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLogsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -282,7 +301,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMonitoredResourceDescriptorsTest()
     {
         $transport = $this->createTransport();
@@ -314,7 +335,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMonitoredResourceDescriptorsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -346,7 +369,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function tailLogEntriesTest()
     {
         $transport = $this->createTransport();
@@ -407,7 +432,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function tailLogEntriesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -440,7 +467,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function writeLogEntriesTest()
     {
         $transport = $this->createTransport();
@@ -467,7 +496,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function writeLogEntriesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -502,7 +533,9 @@ class LoggingServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLogAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/logging/tests/Unit/V2/Client/MetricsServiceV2ClientTest.php
+++ b/tests/Integration/goldens/logging/tests/Unit/V2/Client/MetricsServiceV2ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -45,19 +46,25 @@ use stdClass;
  */
 class MetricsServiceV2ClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return MetricsServiceV2Client */
+    /**
+     * @return MetricsServiceV2Client
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -66,7 +73,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         return new MetricsServiceV2Client($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createLogMetricTest()
     {
         $transport = $this->createTransport();
@@ -113,7 +122,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createLogMetricExceptionTest()
     {
         $transport = $this->createTransport();
@@ -154,7 +165,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLogMetricTest()
     {
         $transport = $this->createTransport();
@@ -180,7 +193,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteLogMetricExceptionTest()
     {
         $transport = $this->createTransport();
@@ -215,7 +230,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLogMetricTest()
     {
         $transport = $this->createTransport();
@@ -254,7 +271,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLogMetricExceptionTest()
     {
         $transport = $this->createTransport();
@@ -289,7 +308,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLogMetricsTest()
     {
         $transport = $this->createTransport();
@@ -326,7 +347,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLogMetricsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -361,7 +384,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateLogMetricTest()
     {
         $transport = $this->createTransport();
@@ -408,7 +433,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateLogMetricExceptionTest()
     {
         $transport = $this->createTransport();
@@ -449,7 +476,9 @@ class MetricsServiceV2ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createLogMetricAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/create_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/create_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/delete_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/delete_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/export_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/export_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/failover_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/failover_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_instance_auth_string.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_instance_auth_string.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_location.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/get_location.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/import_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/import_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/list_instances.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/list_instances.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/list_locations.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/list_locations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/reschedule_maintenance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/reschedule_maintenance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/update_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/update_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/upgrade_instance.php
+++ b/tests/Integration/goldens/redis/samples/V1/CloudRedisClient/upgrade_instance.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
+++ b/tests/Integration/goldens/redis/src/V1/Client/CloudRedisClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -100,7 +101,9 @@ final class CloudRedisClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.redis.v1.CloudRedis';
 
     /**
@@ -110,13 +113,19 @@ final class CloudRedisClient
      */
     private const SERVICE_ADDRESS = 'redis.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'redis.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -144,7 +153,9 @@ final class CloudRedisClient
         ];
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -334,7 +345,9 @@ final class CloudRedisClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/redis/src/V1/resources/cloud_redis_descriptor_config.php
+++ b/tests/Integration/goldens/redis/src/V1/resources/cloud_redis_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/redis/tests/Unit/V1/Client/CloudRedisClientTest.php
+++ b/tests/Integration/goldens/redis/tests/Unit/V1/Client/CloudRedisClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -65,19 +66,25 @@ use stdClass;
  */
 class CloudRedisClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CloudRedisClient */
+    /**
+     * @return CloudRedisClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -86,7 +93,9 @@ class CloudRedisClientTest extends GeneratedTest
         return new CloudRedisClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -204,7 +213,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -271,7 +282,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -335,7 +348,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -392,7 +407,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -500,7 +517,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -559,7 +578,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function failoverInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -663,7 +684,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function failoverInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -720,7 +743,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getInstanceTest()
     {
         $transport = $this->createTransport();
@@ -787,7 +812,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getInstanceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -822,7 +849,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getInstanceAuthStringTest()
     {
         $transport = $this->createTransport();
@@ -851,7 +880,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getInstanceAuthStringExceptionTest()
     {
         $transport = $this->createTransport();
@@ -886,7 +917,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -994,7 +1027,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1053,7 +1088,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listInstancesTest()
     {
         $transport = $this->createTransport();
@@ -1090,7 +1127,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listInstancesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1125,7 +1164,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function rescheduleMaintenanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1233,7 +1274,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function rescheduleMaintenanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1292,7 +1335,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1406,7 +1451,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1471,7 +1518,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function upgradeInstanceTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1579,7 +1628,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function upgradeInstanceExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1638,7 +1689,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLocationTest()
     {
         $transport = $this->createTransport();
@@ -1666,7 +1719,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLocationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1698,7 +1753,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLocationsTest()
     {
         $transport = $this->createTransport();
@@ -1730,7 +1787,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listLocationsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1762,7 +1821,9 @@ class CloudRedisClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createInstanceAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/retail/samples/V2alpha/AnalyticsServiceClient/export_analytics_metrics.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/AnalyticsServiceClient/export_analytics_metrics.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/BranchServiceClient/get_branch.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/BranchServiceClient/get_branch.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/BranchServiceClient/list_branches.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/BranchServiceClient/list_branches.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/add_catalog_attribute.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/add_catalog_attribute.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/batch_remove_catalog_attributes.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/batch_remove_catalog_attributes.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_attributes_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_attributes_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_completion_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_completion_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_default_branch.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/get_default_branch.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/list_catalogs.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/list_catalogs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/remove_catalog_attribute.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/remove_catalog_attribute.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/replace_catalog_attribute.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/replace_catalog_attribute.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/set_default_branch.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/set_default_branch.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_attributes_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_attributes_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_catalog.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_catalog.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_completion_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CatalogServiceClient/update_completion_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/complete_query.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/complete_query.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/import_completion_data.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/CompletionServiceClient/import_completion_data.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/create_control.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/create_control.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/delete_control.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/delete_control.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/get_control.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/get_control.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/list_controls.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/list_controls.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/update_control.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ControlServiceClient/update_control.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ConversationalSearchServiceClient/conversational_search.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ConversationalSearchServiceClient/conversational_search.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/batch_update_generative_question_configs.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/batch_update_generative_question_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/get_generative_questions_feature_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/get_generative_questions_feature_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/list_generative_question_configs.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/list_generative_question_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/update_generative_question_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/update_generative_question_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/update_generative_questions_feature_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/GenerativeQuestionServiceClient/update_generative_questions_feature_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/MerchantCenterAccountLinkServiceClient/create_merchant_center_account_link.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/MerchantCenterAccountLinkServiceClient/create_merchant_center_account_link.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/MerchantCenterAccountLinkServiceClient/delete_merchant_center_account_link.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/MerchantCenterAccountLinkServiceClient/delete_merchant_center_account_link.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/MerchantCenterAccountLinkServiceClient/list_merchant_center_account_links.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/MerchantCenterAccountLinkServiceClient/list_merchant_center_account_links.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/create_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/create_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/delete_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/delete_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/get_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/get_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/list_models.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/list_models.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/pause_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/pause_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/resume_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/resume_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/tune_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/tune_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/update_model.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ModelServiceClient/update_model.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/PredictionServiceClient/predict.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/PredictionServiceClient/predict.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_fulfillment_places.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_fulfillment_places.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_local_inventories.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/add_local_inventories.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/create_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/create_product.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/delete_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/delete_product.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/export_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/export_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/get_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/get_product.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/import_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/import_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/list_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/list_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/purge_products.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/purge_products.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_fulfillment_places.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_fulfillment_places.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_local_inventories.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/remove_local_inventories.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/set_inventory.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/set_inventory.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/update_product.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProductServiceClient/update_product.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/accept_terms.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/accept_terms.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/enroll_solution.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/enroll_solution.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/get_alert_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/get_alert_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/get_logging_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/get_logging_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/get_project.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/get_project.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/list_enrolled_solutions.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/list_enrolled_solutions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/update_alert_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/update_alert_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/update_logging_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ProjectServiceClient/update_logging_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/SearchServiceClient/search.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/SearchServiceClient/search.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/add_control.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/add_control.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/create_serving_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/create_serving_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/delete_serving_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/delete_serving_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/get_serving_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/get_serving_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/list_serving_configs.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/list_serving_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/remove_control.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/remove_control.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/update_serving_config.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/ServingConfigServiceClient/update_serving_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/collect_user_event.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/collect_user_event.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/export_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/export_user_events.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/import_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/import_user_events.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/purge_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/purge_user_events.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/rejoin_user_events.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/rejoin_user_events.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/write_user_event.php
+++ b/tests/Integration/goldens/retail/samples/V2alpha/UserEventServiceClient/write_user_event.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/AnalyticsServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/AnalyticsServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -58,7 +59,9 @@ final class AnalyticsServiceClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.AnalyticsService';
 
     /**
@@ -68,13 +71,19 @@ final class AnalyticsServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -236,7 +245,9 @@ final class AnalyticsServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/BranchServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/BranchServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -69,7 +70,9 @@ final class BranchServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.BranchService';
 
     /**
@@ -79,13 +82,19 @@ final class BranchServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -263,7 +272,9 @@ final class BranchServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/CatalogServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/CatalogServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -87,7 +88,9 @@ final class CatalogServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.CatalogService';
 
     /**
@@ -97,13 +100,19 @@ final class CatalogServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -345,7 +354,9 @@ final class CatalogServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/CompletionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/CompletionServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -69,7 +70,9 @@ final class CompletionServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.CompletionService';
 
     /**
@@ -79,13 +82,19 @@ final class CompletionServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -294,7 +303,9 @@ final class CompletionServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ControlServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ControlServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -69,7 +70,9 @@ final class ControlServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ControlService';
 
     /**
@@ -79,13 +82,19 @@ final class ControlServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -263,7 +272,9 @@ final class ControlServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ConversationalSearchServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ConversationalSearchServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -61,7 +62,9 @@ final class ConversationalSearchServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ConversationalSearchService';
 
     /**
@@ -71,13 +74,19 @@ final class ConversationalSearchServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/GenerativeQuestionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/GenerativeQuestionServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -71,7 +72,9 @@ final class GenerativeQuestionServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.GenerativeQuestionService';
 
     /**
@@ -81,13 +84,19 @@ final class GenerativeQuestionServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -241,7 +250,9 @@ final class GenerativeQuestionServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/MerchantCenterAccountLinkServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/MerchantCenterAccountLinkServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -68,7 +69,9 @@ final class MerchantCenterAccountLinkServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.MerchantCenterAccountLinkService';
 
     /**
@@ -78,13 +81,19 @@ final class MerchantCenterAccountLinkServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -318,7 +327,9 @@ final class MerchantCenterAccountLinkServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ModelServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ModelServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -90,7 +91,9 @@ final class ModelServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ModelService';
 
     /**
@@ -100,13 +103,19 @@ final class ModelServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -339,7 +348,9 @@ final class ModelServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/PredictionServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/PredictionServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -60,7 +61,9 @@ final class PredictionServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.PredictionService';
 
     /**
@@ -70,13 +73,19 @@ final class PredictionServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -234,7 +243,9 @@ final class PredictionServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ProductServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ProductServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -97,7 +98,9 @@ final class ProductServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ProductService';
 
     /**
@@ -107,13 +110,19 @@ final class ProductServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -350,7 +359,9 @@ final class ProductServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ProjectServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ProjectServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -81,7 +82,9 @@ final class ProjectServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ProjectService';
 
     /**
@@ -91,13 +94,19 @@ final class ProjectServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -356,7 +365,9 @@ final class ProjectServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/SearchServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/SearchServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -63,7 +64,9 @@ final class SearchServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.SearchService';
 
     /**
@@ -73,13 +76,19 @@ final class SearchServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -235,7 +244,9 @@ final class SearchServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/ServingConfigServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/ServingConfigServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -73,7 +74,9 @@ final class ServingConfigServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.ServingConfigService';
 
     /**
@@ -83,13 +86,19 @@ final class ServingConfigServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -267,7 +276,9 @@ final class ServingConfigServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/Client/UserEventServiceClient.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/Client/UserEventServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -80,7 +81,9 @@ final class UserEventServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.retail.v2alpha.UserEventService';
 
     /**
@@ -90,13 +93,19 @@ final class UserEventServiceClient
      */
     private const SERVICE_ADDRESS = 'retail.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'retail.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -331,7 +340,9 @@ final class UserEventServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/analytics_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/analytics_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/analytics_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/analytics_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/branch_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/branch_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/branch_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/branch_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/catalog_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/catalog_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/catalog_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/catalog_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/completion_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/completion_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/completion_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/completion_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/control_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/control_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/control_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/control_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/conversational_search_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/conversational_search_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/conversational_search_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/conversational_search_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/generative_question_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/generative_question_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/generative_question_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/generative_question_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/merchant_center_account_link_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/merchant_center_account_link_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/merchant_center_account_link_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/merchant_center_account_link_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/model_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/model_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/model_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/model_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/prediction_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/prediction_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/prediction_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/prediction_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/product_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/product_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/product_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/product_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/project_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/project_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/project_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/project_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/search_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/search_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/search_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/search_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/serving_config_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/serving_config_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/serving_config_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/serving_config_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/user_event_service_descriptor_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/user_event_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/src/V2alpha/resources/user_event_service_rest_client_config.php
+++ b/tests/Integration/goldens/retail/src/V2alpha/resources/user_event_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/AnalyticsServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/AnalyticsServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -44,19 +45,25 @@ use stdClass;
  */
 class AnalyticsServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return AnalyticsServiceClient */
+    /**
+     * @return AnalyticsServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -65,7 +72,9 @@ class AnalyticsServiceClientTest extends GeneratedTest
         return new AnalyticsServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportAnalyticsMetricsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -133,7 +142,9 @@ class AnalyticsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportAnalyticsMetricsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -192,7 +203,9 @@ class AnalyticsServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportAnalyticsMetricsAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/BranchServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/BranchServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -41,19 +42,25 @@ use stdClass;
  */
 class BranchServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BranchServiceClient */
+    /**
+     * @return BranchServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -62,7 +69,9 @@ class BranchServiceClientTest extends GeneratedTest
         return new BranchServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBranchTest()
     {
         $transport = $this->createTransport();
@@ -95,7 +104,9 @@ class BranchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBranchExceptionTest()
     {
         $transport = $this->createTransport();
@@ -130,7 +141,9 @@ class BranchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBranchesTest()
     {
         $transport = $this->createTransport();
@@ -157,7 +170,9 @@ class BranchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBranchesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -192,7 +207,9 @@ class BranchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBranchAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/CatalogServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/CatalogServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -58,19 +59,25 @@ use stdClass;
  */
 class CatalogServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CatalogServiceClient */
+    /**
+     * @return CatalogServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -79,7 +86,9 @@ class CatalogServiceClientTest extends GeneratedTest
         return new CatalogServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addCatalogAttributeTest()
     {
         $transport = $this->createTransport();
@@ -114,7 +123,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addCatalogAttributeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -153,7 +164,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchRemoveCatalogAttributesTest()
     {
         $transport = $this->createTransport();
@@ -184,7 +197,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchRemoveCatalogAttributesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -221,7 +236,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAttributesConfigTest()
     {
         $transport = $this->createTransport();
@@ -250,7 +267,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAttributesConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -285,7 +304,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCompletionConfigTest()
     {
         $transport = $this->createTransport();
@@ -328,7 +349,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCompletionConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -363,7 +386,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getDefaultBranchTest()
     {
         $transport = $this->createTransport();
@@ -389,7 +414,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getDefaultBranchExceptionTest()
     {
         $transport = $this->createTransport();
@@ -421,7 +448,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCatalogsTest()
     {
         $transport = $this->createTransport();
@@ -458,7 +487,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCatalogsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -493,7 +524,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeCatalogAttributeTest()
     {
         $transport = $this->createTransport();
@@ -526,7 +559,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeCatalogAttributeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -563,7 +598,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function replaceCatalogAttributeTest()
     {
         $transport = $this->createTransport();
@@ -598,7 +635,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function replaceCatalogAttributeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -637,7 +676,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setDefaultBranchTest()
     {
         $transport = $this->createTransport();
@@ -658,7 +699,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setDefaultBranchExceptionTest()
     {
         $transport = $this->createTransport();
@@ -690,7 +733,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateAttributesConfigTest()
     {
         $transport = $this->createTransport();
@@ -721,7 +766,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateAttributesConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -758,7 +805,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCatalogTest()
     {
         $transport = $this->createTransport();
@@ -795,7 +844,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCatalogExceptionTest()
     {
         $transport = $this->createTransport();
@@ -836,7 +887,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCompletionConfigTest()
     {
         $transport = $this->createTransport();
@@ -881,7 +934,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCompletionConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -918,7 +973,9 @@ class CatalogServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addCatalogAttributeAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/CompletionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/CompletionServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -47,19 +48,25 @@ use stdClass;
  */
 class CompletionServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CompletionServiceClient */
+    /**
+     * @return CompletionServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -68,7 +75,9 @@ class CompletionServiceClientTest extends GeneratedTest
         return new CompletionServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeQueryTest()
     {
         $transport = $this->createTransport();
@@ -101,7 +110,9 @@ class CompletionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeQueryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -138,7 +149,9 @@ class CompletionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importCompletionDataTest()
     {
         $operationsTransport = $this->createTransport();
@@ -212,7 +225,9 @@ class CompletionServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importCompletionDataExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -277,7 +292,9 @@ class CompletionServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeQueryAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ControlServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ControlServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -45,19 +46,25 @@ use stdClass;
  */
 class ControlServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ControlServiceClient */
+    /**
+     * @return ControlServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -66,7 +73,9 @@ class ControlServiceClientTest extends GeneratedTest
         return new ControlServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createControlTest()
     {
         $transport = $this->createTransport();
@@ -109,7 +118,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createControlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -152,7 +163,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteControlTest()
     {
         $transport = $this->createTransport();
@@ -178,7 +191,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteControlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -213,7 +228,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getControlTest()
     {
         $transport = $this->createTransport();
@@ -244,7 +261,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getControlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -279,7 +298,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listControlsTest()
     {
         $transport = $this->createTransport();
@@ -316,7 +337,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listControlsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -351,7 +374,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateControlTest()
     {
         $transport = $this->createTransport();
@@ -386,7 +411,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateControlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -425,7 +452,9 @@ class ControlServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createControlAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ConversationalSearchServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ConversationalSearchServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class ConversationalSearchServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ConversationalSearchServiceClient */
+    /**
+     * @return ConversationalSearchServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class ConversationalSearchServiceClientTest extends GeneratedTest
         return new ConversationalSearchServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function conversationalSearchTest()
     {
         $transport = $this->createTransport();
@@ -118,7 +127,9 @@ class ConversationalSearchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function conversationalSearchExceptionTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/GenerativeQuestionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/GenerativeQuestionServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -46,19 +47,25 @@ use stdClass;
  */
 class GenerativeQuestionServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return GenerativeQuestionServiceClient */
+    /**
+     * @return GenerativeQuestionServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -67,7 +74,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         return new GenerativeQuestionServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchUpdateGenerativeQuestionConfigsTest()
     {
         $transport = $this->createTransport();
@@ -94,7 +103,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchUpdateGenerativeQuestionConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -129,7 +140,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getGenerativeQuestionsFeatureConfigTest()
     {
         $transport = $this->createTransport();
@@ -162,7 +175,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getGenerativeQuestionsFeatureConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -197,7 +212,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listGenerativeQuestionConfigsTest()
     {
         $transport = $this->createTransport();
@@ -224,7 +241,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listGenerativeQuestionConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -259,7 +278,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateGenerativeQuestionConfigTest()
     {
         $transport = $this->createTransport();
@@ -302,7 +323,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateGenerativeQuestionConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -341,7 +364,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateGenerativeQuestionsFeatureConfigTest()
     {
         $transport = $this->createTransport();
@@ -376,7 +401,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateGenerativeQuestionsFeatureConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -413,7 +440,9 @@ class GenerativeQuestionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchUpdateGenerativeQuestionConfigsAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/MerchantCenterAccountLinkServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/MerchantCenterAccountLinkServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -47,19 +48,25 @@ use stdClass;
  */
 class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return MerchantCenterAccountLinkServiceClient */
+    /**
+     * @return MerchantCenterAccountLinkServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -68,7 +75,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         return new MerchantCenterAccountLinkServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createMerchantCenterAccountLinkTest()
     {
         $operationsTransport = $this->createTransport();
@@ -156,7 +165,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createMerchantCenterAccountLinkExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -219,7 +230,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMerchantCenterAccountLinkTest()
     {
         $transport = $this->createTransport();
@@ -245,7 +258,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMerchantCenterAccountLinkExceptionTest()
     {
         $transport = $this->createTransport();
@@ -280,7 +295,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMerchantCenterAccountLinksTest()
     {
         $transport = $this->createTransport();
@@ -307,7 +324,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMerchantCenterAccountLinksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -342,7 +361,9 @@ class MerchantCenterAccountLinkServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createMerchantCenterAccountLinkAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ModelServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ModelServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -53,19 +54,25 @@ use stdClass;
  */
 class ModelServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ModelServiceClient */
+    /**
+     * @return ModelServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -74,7 +81,9 @@ class ModelServiceClientTest extends GeneratedTest
         return new ModelServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createModelTest()
     {
         $operationsTransport = $this->createTransport();
@@ -158,7 +167,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createModelExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -223,7 +234,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteModelTest()
     {
         $transport = $this->createTransport();
@@ -249,7 +262,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteModelExceptionTest()
     {
         $transport = $this->createTransport();
@@ -284,7 +299,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getModelTest()
     {
         $transport = $this->createTransport();
@@ -321,7 +338,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getModelExceptionTest()
     {
         $transport = $this->createTransport();
@@ -356,7 +375,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listModelsTest()
     {
         $transport = $this->createTransport();
@@ -393,7 +414,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listModelsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -428,7 +451,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function pauseModelTest()
     {
         $transport = $this->createTransport();
@@ -465,7 +490,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function pauseModelExceptionTest()
     {
         $transport = $this->createTransport();
@@ -500,7 +527,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function resumeModelTest()
     {
         $transport = $this->createTransport();
@@ -537,7 +566,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function resumeModelExceptionTest()
     {
         $transport = $this->createTransport();
@@ -572,7 +603,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function tuneModelTest()
     {
         $operationsTransport = $this->createTransport();
@@ -636,7 +669,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function tuneModelExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -693,7 +728,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateModelTest()
     {
         $transport = $this->createTransport();
@@ -736,7 +773,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateModelExceptionTest()
     {
         $transport = $this->createTransport();
@@ -777,7 +816,9 @@ class ModelServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createModelAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/PredictionServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/PredictionServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class PredictionServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return PredictionServiceClient */
+    /**
+     * @return PredictionServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class PredictionServiceClientTest extends GeneratedTest
         return new PredictionServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function predictTest()
     {
         $transport = $this->createTransport();
@@ -100,7 +109,9 @@ class PredictionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function predictExceptionTest()
     {
         $transport = $this->createTransport();
@@ -141,7 +152,9 @@ class PredictionServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function predictAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ProductServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ProductServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -67,19 +68,25 @@ use stdClass;
  */
 class ProductServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ProductServiceClient */
+    /**
+     * @return ProductServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -88,7 +95,9 @@ class ProductServiceClientTest extends GeneratedTest
         return new ProductServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addFulfillmentPlacesTest()
     {
         $operationsTransport = $this->createTransport();
@@ -160,7 +169,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addFulfillmentPlacesExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -221,7 +232,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addLocalInventoriesTest()
     {
         $operationsTransport = $this->createTransport();
@@ -289,7 +302,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addLocalInventoriesExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -348,7 +363,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createProductTest()
     {
         $transport = $this->createTransport();
@@ -401,7 +418,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createProductExceptionTest()
     {
         $transport = $this->createTransport();
@@ -442,7 +461,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteProductTest()
     {
         $transport = $this->createTransport();
@@ -468,7 +489,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteProductExceptionTest()
     {
         $transport = $this->createTransport();
@@ -503,7 +526,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportProductsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -571,7 +596,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportProductsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -630,7 +657,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getProductTest()
     {
         $transport = $this->createTransport();
@@ -673,7 +702,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getProductExceptionTest()
     {
         $transport = $this->createTransport();
@@ -708,7 +739,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importProductsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -776,7 +809,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importProductsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -835,7 +870,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listProductsTest()
     {
         $transport = $this->createTransport();
@@ -874,7 +911,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listProductsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -909,7 +948,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function purgeProductsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -979,7 +1020,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function purgeProductsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1038,7 +1081,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeFulfillmentPlacesTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1110,7 +1155,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeFulfillmentPlacesExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1171,7 +1218,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeLocalInventoriesTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1239,7 +1288,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeLocalInventoriesExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1298,7 +1349,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setInventoryTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1364,7 +1417,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setInventoryExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1423,7 +1478,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateProductTest()
     {
         $transport = $this->createTransport();
@@ -1468,7 +1525,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateProductExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1505,7 +1564,9 @@ class ProductServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addFulfillmentPlacesAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ProjectServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ProjectServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -55,19 +56,25 @@ use stdClass;
  */
 class ProjectServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ProjectServiceClient */
+    /**
+     * @return ProjectServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -76,7 +83,9 @@ class ProjectServiceClientTest extends GeneratedTest
         return new ProjectServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function acceptTermsTest()
     {
         $transport = $this->createTransport();
@@ -105,7 +114,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function acceptTermsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -140,7 +151,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function enrollSolutionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -208,7 +221,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function enrollSolutionExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -267,7 +282,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAlertConfigTest()
     {
         $transport = $this->createTransport();
@@ -296,7 +313,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getAlertConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -331,7 +350,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLoggingConfigTest()
     {
         $transport = $this->createTransport();
@@ -360,7 +381,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getLoggingConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -395,7 +418,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getProjectTest()
     {
         $transport = $this->createTransport();
@@ -424,7 +449,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getProjectExceptionTest()
     {
         $transport = $this->createTransport();
@@ -459,7 +486,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEnrolledSolutionsTest()
     {
         $transport = $this->createTransport();
@@ -486,7 +515,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEnrolledSolutionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -521,7 +552,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateAlertConfigTest()
     {
         $transport = $this->createTransport();
@@ -552,7 +585,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateAlertConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -589,7 +624,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateLoggingConfigTest()
     {
         $transport = $this->createTransport();
@@ -620,7 +657,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateLoggingConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -657,7 +696,9 @@ class ProjectServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function acceptTermsAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/SearchServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/SearchServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class SearchServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return SearchServiceClient */
+    /**
+     * @return SearchServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class SearchServiceClientTest extends GeneratedTest
         return new SearchServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchTest()
     {
         $transport = $this->createTransport();
@@ -110,7 +119,9 @@ class SearchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchExceptionTest()
     {
         $transport = $this->createTransport();
@@ -147,7 +158,9 @@ class SearchServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ServingConfigServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/ServingConfigServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -47,19 +48,25 @@ use stdClass;
  */
 class ServingConfigServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ServingConfigServiceClient */
+    /**
+     * @return ServingConfigServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -68,7 +75,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         return new ServingConfigServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addControlTest()
     {
         $transport = $this->createTransport();
@@ -113,7 +122,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addControlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -150,7 +161,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createServingConfigTest()
     {
         $transport = $this->createTransport();
@@ -203,7 +216,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createServingConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -246,7 +261,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteServingConfigTest()
     {
         $transport = $this->createTransport();
@@ -272,7 +289,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteServingConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -307,7 +326,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getServingConfigTest()
     {
         $transport = $this->createTransport();
@@ -348,7 +369,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getServingConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -383,7 +406,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listServingConfigsTest()
     {
         $transport = $this->createTransport();
@@ -420,7 +445,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listServingConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -455,7 +482,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeControlTest()
     {
         $transport = $this->createTransport();
@@ -500,7 +529,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function removeControlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -537,7 +568,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateServingConfigTest()
     {
         $transport = $this->createTransport();
@@ -582,7 +615,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateServingConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -621,7 +656,9 @@ class ServingConfigServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addControlAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/UserEventServiceClientTest.php
+++ b/tests/Integration/goldens/retail/tests/Unit/V2alpha/Client/UserEventServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -56,19 +57,25 @@ use stdClass;
  */
 class UserEventServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return UserEventServiceClient */
+    /**
+     * @return UserEventServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -77,7 +84,9 @@ class UserEventServiceClientTest extends GeneratedTest
         return new UserEventServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function collectUserEventTest()
     {
         $transport = $this->createTransport();
@@ -112,7 +121,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function collectUserEventExceptionTest()
     {
         $transport = $this->createTransport();
@@ -149,7 +160,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportUserEventsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -217,7 +230,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function exportUserEventsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -276,7 +291,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importUserEventsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -348,7 +365,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function importUserEventsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -411,7 +430,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function purgeUserEventsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -481,7 +502,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function purgeUserEventsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -540,7 +563,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function rejoinUserEventsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -606,7 +631,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function rejoinUserEventsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -663,7 +690,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function writeUserEventTest()
     {
         $transport = $this->createTransport();
@@ -724,7 +753,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function writeUserEventExceptionTest()
     {
         $transport = $this->createTransport();
@@ -765,7 +796,9 @@ class UserEventServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function collectUserEventAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/batch_create_resource_value_configs.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/batch_create_resource_value_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/bulk_mute_findings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/bulk_mute_findings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_big_query_export.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_big_query_export.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_event_threat_detection_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_event_threat_detection_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_finding.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_finding.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_mute_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_mute_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_notification_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_security_health_analytics_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_security_health_analytics_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_source.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/create_source.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_big_query_export.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_big_query_export.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_event_threat_detection_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_event_threat_detection_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_mute_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_mute_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_notification_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_resource_value_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_resource_value_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_security_health_analytics_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/delete_security_health_analytics_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_big_query_export.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_big_query_export.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_effective_event_threat_detection_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_effective_event_threat_detection_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_effective_security_health_analytics_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_effective_security_health_analytics_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_event_threat_detection_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_event_threat_detection_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_iam_policy.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_mute_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_mute_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_notification_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_organization_settings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_organization_settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_resource_value_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_resource_value_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_security_health_analytics_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_security_health_analytics_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_simulation.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_simulation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_source.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_source.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_valued_resource.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/get_valued_resource.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_assets.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_findings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/group_findings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_assets.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_attack_paths.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_attack_paths.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_big_query_exports.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_big_query_exports.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_descendant_event_threat_detection_custom_modules.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_descendant_event_threat_detection_custom_modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_descendant_security_health_analytics_custom_modules.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_descendant_security_health_analytics_custom_modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_effective_event_threat_detection_custom_modules.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_effective_event_threat_detection_custom_modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_effective_security_health_analytics_custom_modules.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_effective_security_health_analytics_custom_modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_event_threat_detection_custom_modules.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_event_threat_detection_custom_modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_findings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_findings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_mute_configs.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_mute_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_notification_configs.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_notification_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_resource_value_configs.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_resource_value_configs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_security_health_analytics_custom_modules.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_security_health_analytics_custom_modules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_sources.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_sources.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_valued_resources.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/list_valued_resources.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/run_asset_discovery.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_finding_state.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_finding_state.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_iam_policy.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_mute.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/set_mute.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/simulate_security_health_analytics_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/simulate_security_health_analytics_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_big_query_export.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_big_query_export.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_event_threat_detection_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_event_threat_detection_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_external_system.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_external_system.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_finding.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_finding.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_mute_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_mute_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_notification_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_notification_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_organization_settings.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_organization_settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_resource_value_config.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_resource_value_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_security_health_analytics_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_security_health_analytics_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_security_marks.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_security_marks.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_source.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/update_source.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/validate_event_threat_detection_custom_module.php
+++ b/tests/Integration/goldens/securitycenter/samples/V1/SecurityCenterClient/validate_event_threat_detection_custom_module.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/Client/SecurityCenterClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -205,7 +206,9 @@ final class SecurityCenterClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.securitycenter.v1.SecurityCenter';
 
     /**
@@ -215,13 +218,19 @@ final class SecurityCenterClient
      */
     private const SERVICE_ADDRESS = 'securitycenter.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'securitycenter.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -1786,7 +1795,9 @@ final class SecurityCenterClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/securitycenter/src/V1/resources/security_center_descriptor_config.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/resources/security_center_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/src/V1/resources/security_center_rest_client_config.php
+++ b/tests/Integration/goldens/securitycenter/src/V1/resources/security_center_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/securitycenter/tests/Unit/V1/Client/SecurityCenterClientTest.php
+++ b/tests/Integration/goldens/securitycenter/tests/Unit/V1/Client/SecurityCenterClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -154,19 +155,25 @@ use stdClass;
  */
 class SecurityCenterClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return SecurityCenterClient */
+    /**
+     * @return SecurityCenterClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -175,7 +182,9 @@ class SecurityCenterClientTest extends GeneratedTest
         return new SecurityCenterClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchCreateResourceValueConfigsTest()
     {
         $transport = $this->createTransport();
@@ -206,7 +215,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchCreateResourceValueConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -243,7 +254,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function bulkMuteFindingsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -307,7 +320,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function bulkMuteFindingsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -364,7 +379,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBigQueryExportTest()
     {
         $transport = $this->createTransport();
@@ -411,7 +428,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBigQueryExportExceptionTest()
     {
         $transport = $this->createTransport();
@@ -450,7 +469,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createEventThreatDetectionCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -493,7 +514,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createEventThreatDetectionCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -530,7 +553,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFindingTest()
     {
         $transport = $this->createTransport();
@@ -587,7 +612,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFindingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -626,7 +653,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createMuteConfigTest()
     {
         $transport = $this->createTransport();
@@ -673,7 +702,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createMuteConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -714,7 +745,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNotificationConfigTest()
     {
         $transport = $this->createTransport();
@@ -757,7 +790,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createNotificationConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -796,7 +831,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSecurityHealthAnalyticsCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -835,7 +872,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSecurityHealthAnalyticsCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -872,7 +911,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSourceTest()
     {
         $transport = $this->createTransport();
@@ -911,7 +952,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createSourceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -948,7 +991,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBigQueryExportTest()
     {
         $transport = $this->createTransport();
@@ -974,7 +1019,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBigQueryExportExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1009,7 +1056,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteEventThreatDetectionCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -1035,7 +1084,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteEventThreatDetectionCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1070,7 +1121,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMuteConfigTest()
     {
         $transport = $this->createTransport();
@@ -1096,7 +1149,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMuteConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1131,7 +1186,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteNotificationConfigTest()
     {
         $transport = $this->createTransport();
@@ -1157,7 +1214,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteNotificationConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1192,7 +1251,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteResourceValueConfigTest()
     {
         $transport = $this->createTransport();
@@ -1218,7 +1279,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteResourceValueConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1253,7 +1316,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSecurityHealthAnalyticsCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -1279,7 +1344,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteSecurityHealthAnalyticsCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1314,7 +1381,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBigQueryExportTest()
     {
         $transport = $this->createTransport();
@@ -1353,7 +1422,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBigQueryExportExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1388,7 +1459,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getEffectiveEventThreatDetectionCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -1423,7 +1496,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getEffectiveEventThreatDetectionCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1458,7 +1533,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getEffectiveSecurityHealthAnalyticsCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -1489,7 +1566,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getEffectiveSecurityHealthAnalyticsCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1524,7 +1603,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getEventThreatDetectionCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -1563,7 +1644,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getEventThreatDetectionCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1598,7 +1681,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -1629,7 +1714,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1664,7 +1751,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getMuteConfigTest()
     {
         $transport = $this->createTransport();
@@ -1701,7 +1790,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getMuteConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1736,7 +1827,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNotificationConfigTest()
     {
         $transport = $this->createTransport();
@@ -1771,7 +1864,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNotificationConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1806,7 +1901,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getOrganizationSettingsTest()
     {
         $transport = $this->createTransport();
@@ -1837,7 +1934,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getOrganizationSettingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1872,7 +1971,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getResourceValueConfigTest()
     {
         $transport = $this->createTransport();
@@ -1907,7 +2008,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getResourceValueConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1942,7 +2045,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSecurityHealthAnalyticsCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -1977,7 +2082,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSecurityHealthAnalyticsCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2012,7 +2119,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSimulationTest()
     {
         $transport = $this->createTransport();
@@ -2041,7 +2150,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSimulationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2076,7 +2187,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSourceTest()
     {
         $transport = $this->createTransport();
@@ -2111,7 +2224,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getSourceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2146,7 +2261,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getValuedResourceTest()
     {
         $transport = $this->createTransport();
@@ -2183,7 +2300,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getValuedResourceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2218,7 +2337,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function groupAssetsTest()
     {
         $transport = $this->createTransport();
@@ -2261,7 +2382,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function groupAssetsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2298,7 +2421,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function groupFindingsTest()
     {
         $transport = $this->createTransport();
@@ -2341,7 +2466,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function groupFindingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2378,7 +2505,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAssetsTest()
     {
         $transport = $this->createTransport();
@@ -2417,7 +2546,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAssetsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2452,7 +2583,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAttackPathsTest()
     {
         $transport = $this->createTransport();
@@ -2489,7 +2622,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAttackPathsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2524,7 +2659,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBigQueryExportsTest()
     {
         $transport = $this->createTransport();
@@ -2561,7 +2698,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBigQueryExportsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2596,7 +2735,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDescendantEventThreatDetectionCustomModulesTest()
     {
         $transport = $this->createTransport();
@@ -2633,7 +2774,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDescendantEventThreatDetectionCustomModulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2668,7 +2811,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDescendantSecurityHealthAnalyticsCustomModulesTest()
     {
         $transport = $this->createTransport();
@@ -2705,7 +2850,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDescendantSecurityHealthAnalyticsCustomModulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2740,7 +2887,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEffectiveEventThreatDetectionCustomModulesTest()
     {
         $transport = $this->createTransport();
@@ -2777,7 +2926,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEffectiveEventThreatDetectionCustomModulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2812,7 +2963,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEffectiveSecurityHealthAnalyticsCustomModulesTest()
     {
         $transport = $this->createTransport();
@@ -2849,7 +3002,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEffectiveSecurityHealthAnalyticsCustomModulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2884,7 +3039,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEventThreatDetectionCustomModulesTest()
     {
         $transport = $this->createTransport();
@@ -2921,7 +3078,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listEventThreatDetectionCustomModulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2956,7 +3115,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listFindingsTest()
     {
         $transport = $this->createTransport();
@@ -2995,7 +3156,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listFindingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3030,7 +3193,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMuteConfigsTest()
     {
         $transport = $this->createTransport();
@@ -3067,7 +3232,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMuteConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3102,7 +3269,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listNotificationConfigsTest()
     {
         $transport = $this->createTransport();
@@ -3139,7 +3308,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listNotificationConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3174,7 +3345,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listResourceValueConfigsTest()
     {
         $transport = $this->createTransport();
@@ -3211,7 +3384,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listResourceValueConfigsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3246,7 +3421,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSecurityHealthAnalyticsCustomModulesTest()
     {
         $transport = $this->createTransport();
@@ -3283,7 +3460,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSecurityHealthAnalyticsCustomModulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3318,7 +3497,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSourcesTest()
     {
         $transport = $this->createTransport();
@@ -3355,7 +3536,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listSourcesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3390,7 +3573,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listValuedResourcesTest()
     {
         $transport = $this->createTransport();
@@ -3429,7 +3614,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listValuedResourcesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3464,7 +3651,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function runAssetDiscoveryTest()
     {
         $operationsTransport = $this->createTransport();
@@ -3528,7 +3717,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function runAssetDiscoveryExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -3585,7 +3776,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setFindingStateTest()
     {
         $transport = $this->createTransport();
@@ -3642,7 +3835,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setFindingStateExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3681,7 +3876,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -3716,7 +3913,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3753,7 +3952,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMuteTest()
     {
         $transport = $this->createTransport();
@@ -3806,7 +4007,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setMuteExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3843,7 +4046,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function simulateSecurityHealthAnalyticsCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -3880,7 +4085,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function simulateSecurityHealthAnalyticsCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3921,7 +4128,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -3952,7 +4161,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -3989,7 +4200,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBigQueryExportTest()
     {
         $transport = $this->createTransport();
@@ -4028,7 +4241,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBigQueryExportExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4063,7 +4278,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateEventThreatDetectionCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -4102,7 +4319,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateEventThreatDetectionCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4137,7 +4356,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateExternalSystemTest()
     {
         $transport = $this->createTransport();
@@ -4174,7 +4395,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateExternalSystemExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4209,7 +4432,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateFindingTest()
     {
         $transport = $this->createTransport();
@@ -4258,7 +4483,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateFindingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4293,7 +4520,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateMuteConfigTest()
     {
         $transport = $this->createTransport();
@@ -4332,7 +4561,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateMuteConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4369,7 +4600,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateNotificationConfigTest()
     {
         $transport = $this->createTransport();
@@ -4404,7 +4637,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateNotificationConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4439,7 +4674,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateOrganizationSettingsTest()
     {
         $transport = $this->createTransport();
@@ -4470,7 +4707,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateOrganizationSettingsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4505,7 +4744,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateResourceValueConfigTest()
     {
         $transport = $this->createTransport();
@@ -4544,7 +4785,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateResourceValueConfigExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4583,7 +4826,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSecurityHealthAnalyticsCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -4618,7 +4863,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSecurityHealthAnalyticsCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4653,7 +4900,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSecurityMarksTest()
     {
         $transport = $this->createTransport();
@@ -4684,7 +4933,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSecurityMarksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4719,7 +4970,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSourceTest()
     {
         $transport = $this->createTransport();
@@ -4754,7 +5007,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateSourceExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4789,7 +5044,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function validateEventThreatDetectionCustomModuleTest()
     {
         $transport = $this->createTransport();
@@ -4824,7 +5081,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function validateEventThreatDetectionCustomModuleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -4863,7 +5122,9 @@ class SecurityCenterClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchCreateResourceValueConfigsAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/add_split_points.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/add_split_points.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/copy_backup.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/copy_backup.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/create_backup.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/create_backup.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/create_backup_schedule.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/create_backup_schedule.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/create_database.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/create_database.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/delete_backup.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/delete_backup.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/delete_backup_schedule.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/delete_backup_schedule.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/drop_database.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/drop_database.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_backup.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_backup.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_backup_schedule.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_backup_schedule.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_database.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_database.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_database_ddl.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_database_ddl.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_iam_policy.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/get_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/internal_update_graph_operation.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/internal_update_graph_operation.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_backup_operations.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_backup_operations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_backup_schedules.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_backup_schedules.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_backups.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_backups.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_database_operations.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_database_operations.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_database_roles.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_database_roles.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_databases.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/list_databases.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/restore_database.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/restore_database.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/set_iam_policy.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/set_iam_policy.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/test_iam_permissions.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/test_iam_permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_backup.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_backup.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_backup_schedule.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_backup_schedule.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_database.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_database.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_database_ddl.php
+++ b/tests/Integration/goldens/spanner/samples/V1/DatabaseAdminClient/update_database_ddl.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
+++ b/tests/Integration/goldens/spanner/src/V1/Client/DatabaseAdminClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -133,7 +134,9 @@ final class DatabaseAdminClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.spanner.admin.database.v1.DatabaseAdmin';
 
     /**
@@ -143,13 +146,19 @@ final class DatabaseAdminClient
      */
     private const SERVICE_ADDRESS = 'spanner.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'spanner.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -480,7 +489,9 @@ final class DatabaseAdminClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
@@ -1326,7 +1337,9 @@ final class DatabaseAdminClient
         return $this->startApiCall('UpdateDatabaseDdl', $request, $callOptions)->wait();
     }
 
-    /** Configure the gapic configuration to use a service emulator. */
+    /**
+     * Configure the gapic configuration to use a service emulator.
+     */
     private function setDefaultEmulatorConfig(array $options): array
     {
         $emulatorHost = getenv('SPANNER_EMULATOR_HOST');

--- a/tests/Integration/goldens/spanner/src/V1/resources/database_admin_descriptor_config.php
+++ b/tests/Integration/goldens/spanner/src/V1/resources/database_admin_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/src/V1/resources/database_admin_rest_client_config.php
+++ b/tests/Integration/goldens/spanner/src/V1/resources/database_admin_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/spanner/tests/Unit/V1/Client/DatabaseAdminClientTest.php
+++ b/tests/Integration/goldens/spanner/tests/Unit/V1/Client/DatabaseAdminClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -86,19 +87,25 @@ use stdClass;
  */
 class DatabaseAdminClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return DatabaseAdminClient */
+    /**
+     * @return DatabaseAdminClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -107,7 +114,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         return new DatabaseAdminClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addSplitPointsTest()
     {
         $transport = $this->createTransport();
@@ -138,7 +147,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addSplitPointsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -175,7 +186,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function copyBackupTest()
     {
         $operationsTransport = $this->createTransport();
@@ -263,7 +276,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function copyBackupExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -326,7 +341,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBackupTest()
     {
         $operationsTransport = $this->createTransport();
@@ -410,7 +427,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBackupExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -471,7 +490,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBackupScheduleTest()
     {
         $transport = $this->createTransport();
@@ -508,7 +529,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBackupScheduleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -547,7 +570,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createDatabaseTest()
     {
         $operationsTransport = $this->createTransport();
@@ -625,7 +650,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createDatabaseExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -684,7 +711,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBackupTest()
     {
         $transport = $this->createTransport();
@@ -710,7 +739,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBackupExceptionTest()
     {
         $transport = $this->createTransport();
@@ -745,7 +776,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBackupScheduleTest()
     {
         $transport = $this->createTransport();
@@ -771,7 +804,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBackupScheduleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -806,7 +841,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function dropDatabaseTest()
     {
         $transport = $this->createTransport();
@@ -832,7 +869,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function dropDatabaseExceptionTest()
     {
         $transport = $this->createTransport();
@@ -867,7 +906,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBackupTest()
     {
         $transport = $this->createTransport();
@@ -906,7 +947,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBackupExceptionTest()
     {
         $transport = $this->createTransport();
@@ -941,7 +984,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBackupScheduleTest()
     {
         $transport = $this->createTransport();
@@ -970,7 +1015,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBackupScheduleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1005,7 +1052,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getDatabaseTest()
     {
         $transport = $this->createTransport();
@@ -1042,7 +1091,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getDatabaseExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1077,7 +1128,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getDatabaseDdlTest()
     {
         $transport = $this->createTransport();
@@ -1106,7 +1159,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getDatabaseDdlExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1141,7 +1196,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -1172,7 +1229,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1207,7 +1266,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function internalUpdateGraphOperationTest()
     {
         $transport = $this->createTransport();
@@ -1242,7 +1303,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function internalUpdateGraphOperationExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1281,7 +1344,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBackupOperationsTest()
     {
         $transport = $this->createTransport();
@@ -1318,7 +1383,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBackupOperationsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1353,7 +1420,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBackupSchedulesTest()
     {
         $transport = $this->createTransport();
@@ -1390,7 +1459,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBackupSchedulesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1425,7 +1496,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBackupsTest()
     {
         $transport = $this->createTransport();
@@ -1462,7 +1535,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBackupsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1497,7 +1572,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDatabaseOperationsTest()
     {
         $transport = $this->createTransport();
@@ -1534,7 +1611,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDatabaseOperationsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1569,7 +1648,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDatabaseRolesTest()
     {
         $transport = $this->createTransport();
@@ -1606,7 +1687,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDatabaseRolesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1641,7 +1724,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDatabasesTest()
     {
         $transport = $this->createTransport();
@@ -1678,7 +1763,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listDatabasesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1713,7 +1800,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function restoreDatabaseTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1791,7 +1880,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function restoreDatabaseExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1850,7 +1941,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyTest()
     {
         $transport = $this->createTransport();
@@ -1885,7 +1978,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function setIamPolicyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1922,7 +2017,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsTest()
     {
         $transport = $this->createTransport();
@@ -1953,7 +2050,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function testIamPermissionsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1990,7 +2089,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBackupTest()
     {
         $transport = $this->createTransport();
@@ -2033,7 +2134,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBackupExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2070,7 +2173,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBackupScheduleTest()
     {
         $transport = $this->createTransport();
@@ -2103,7 +2208,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBackupScheduleExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2140,7 +2247,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateDatabaseTest()
     {
         $operationsTransport = $this->createTransport();
@@ -2220,7 +2329,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateDatabaseExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -2281,7 +2392,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateDatabaseDdlTest()
     {
         $operationsTransport = $this->createTransport();
@@ -2349,7 +2462,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateDatabaseDdlExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -2408,7 +2523,9 @@ class DatabaseAdminClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addSplitPointsAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/create_custom_class.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/create_custom_class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/create_phrase_set.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/create_phrase_set.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/delete_custom_class.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/delete_custom_class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/delete_phrase_set.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/delete_phrase_set.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/get_custom_class.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/get_custom_class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/get_phrase_set.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/get_phrase_set.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/list_custom_classes.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/list_custom_classes.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/list_phrase_set.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/list_phrase_set.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/update_custom_class.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/update_custom_class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/AdaptationClient/update_phrase_set.php
+++ b/tests/Integration/goldens/speech/samples/V1/AdaptationClient/update_phrase_set.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/long_running_recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/long_running_recognize.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/recognize.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/samples/V1/SpeechClient/streaming_recognize.php
+++ b/tests/Integration/goldens/speech/samples/V1/SpeechClient/streaming_recognize.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/src/V1/Client/AdaptationClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/AdaptationClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -76,7 +77,9 @@ final class AdaptationClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.speech.v1.Adaptation';
 
     /**
@@ -86,13 +89,19 @@ final class AdaptationClient
      */
     private const SERVICE_ADDRESS = 'speech.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'speech.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -278,7 +287,9 @@ final class AdaptationClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/speech/src/V1/Client/SpeechClient.php
+++ b/tests/Integration/goldens/speech/src/V1/Client/SpeechClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -63,7 +64,9 @@ final class SpeechClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.speech.v1.Speech';
 
     /**
@@ -73,13 +76,19 @@ final class SpeechClient
      */
     private const SERVICE_ADDRESS = 'speech.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'speech.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -316,7 +325,9 @@ final class SpeechClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/speech/src/V1/resources/adaptation_descriptor_config.php
+++ b/tests/Integration/goldens/speech/src/V1/resources/adaptation_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/src/V1/resources/adaptation_rest_client_config.php
+++ b/tests/Integration/goldens/speech/src/V1/resources/adaptation_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/src/V1/resources/speech_descriptor_config.php
+++ b/tests/Integration/goldens/speech/src/V1/resources/speech_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/src/V1/resources/speech_rest_client_config.php
+++ b/tests/Integration/goldens/speech/src/V1/resources/speech_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/speech/tests/Unit/V1/Client/AdaptationClientTest.php
+++ b/tests/Integration/goldens/speech/tests/Unit/V1/Client/AdaptationClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -52,19 +53,25 @@ use stdClass;
  */
 class AdaptationClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return AdaptationClient */
+    /**
+     * @return AdaptationClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -73,7 +80,9 @@ class AdaptationClientTest extends GeneratedTest
         return new AdaptationClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCustomClassTest()
     {
         $transport = $this->createTransport();
@@ -112,7 +121,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCustomClassExceptionTest()
     {
         $transport = $this->createTransport();
@@ -151,7 +162,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createPhraseSetTest()
     {
         $transport = $this->createTransport();
@@ -190,7 +203,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createPhraseSetExceptionTest()
     {
         $transport = $this->createTransport();
@@ -229,7 +244,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteCustomClassTest()
     {
         $transport = $this->createTransport();
@@ -255,7 +272,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteCustomClassExceptionTest()
     {
         $transport = $this->createTransport();
@@ -290,7 +309,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deletePhraseSetTest()
     {
         $transport = $this->createTransport();
@@ -316,7 +337,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deletePhraseSetExceptionTest()
     {
         $transport = $this->createTransport();
@@ -351,7 +374,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCustomClassTest()
     {
         $transport = $this->createTransport();
@@ -382,7 +407,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCustomClassExceptionTest()
     {
         $transport = $this->createTransport();
@@ -417,7 +444,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getPhraseSetTest()
     {
         $transport = $this->createTransport();
@@ -448,7 +477,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getPhraseSetExceptionTest()
     {
         $transport = $this->createTransport();
@@ -483,7 +514,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCustomClassesTest()
     {
         $transport = $this->createTransport();
@@ -520,7 +553,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCustomClassesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -555,7 +590,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listPhraseSetTest()
     {
         $transport = $this->createTransport();
@@ -592,7 +629,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listPhraseSetExceptionTest()
     {
         $transport = $this->createTransport();
@@ -627,7 +666,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCustomClassTest()
     {
         $transport = $this->createTransport();
@@ -658,7 +699,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCustomClassExceptionTest()
     {
         $transport = $this->createTransport();
@@ -693,7 +736,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updatePhraseSetTest()
     {
         $transport = $this->createTransport();
@@ -724,7 +769,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updatePhraseSetExceptionTest()
     {
         $transport = $this->createTransport();
@@ -759,7 +806,9 @@ class AdaptationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCustomClassAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/speech/tests/Unit/V1/Client/SpeechClientTest.php
+++ b/tests/Integration/goldens/speech/tests/Unit/V1/Client/SpeechClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -50,19 +51,25 @@ use stdClass;
  */
 class SpeechClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return SpeechClient */
+    /**
+     * @return SpeechClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -71,7 +78,9 @@ class SpeechClientTest extends GeneratedTest
         return new SpeechClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function longRunningRecognizeTest()
     {
         $operationsTransport = $this->createTransport();
@@ -143,7 +152,9 @@ class SpeechClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function longRunningRecognizeExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -204,7 +215,9 @@ class SpeechClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function recognizeTest()
     {
         $transport = $this->createTransport();
@@ -239,7 +252,9 @@ class SpeechClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function recognizeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -278,7 +293,9 @@ class SpeechClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function streamingRecognizeTest()
     {
         $transport = $this->createTransport();
@@ -339,7 +356,9 @@ class SpeechClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function streamingRecognizeExceptionTest()
     {
         $transport = $this->createTransport();
@@ -372,7 +391,9 @@ class SpeechClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function longRunningRecognizeAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/create_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/create_company.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/delete_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/delete_company.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/get_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/get_company.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/list_companies.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/list_companies.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/update_company.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompanyServiceClient/update_company.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/CompletionClient/complete_query.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/CompletionClient/complete_query.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/EventServiceClient/create_client_event.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/EventServiceClient/create_client_event.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_create_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_create_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_delete_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_delete_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_update_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/batch_update_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/create_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/create_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/delete_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/delete_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/get_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/get_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/list_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/list_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs_for_alert.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/search_jobs_for_alert.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/update_job.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/JobServiceClient/update_job.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/create_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/create_tenant.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/delete_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/delete_tenant.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/get_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/get_tenant.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/list_tenants.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/list_tenants.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/update_tenant.php
+++ b/tests/Integration/goldens/talent/samples/V4beta1/TenantServiceClient/update_tenant.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/CompanyServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/CompanyServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -69,7 +70,9 @@ final class CompanyServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.talent.v4beta1.CompanyService';
 
     /**
@@ -79,13 +82,19 @@ final class CompanyServiceClient
      */
     private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'jobs.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -320,7 +329,9 @@ final class CompanyServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/CompletionClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/CompletionClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -60,7 +61,9 @@ final class CompletionClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.talent.v4beta1.Completion';
 
     /**
@@ -70,13 +73,19 @@ final class CompletionClient
      */
     private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'jobs.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -311,7 +320,9 @@ final class CompletionClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/EventServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/EventServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -60,7 +61,9 @@ final class EventServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.talent.v4beta1.EventService';
 
     /**
@@ -70,13 +73,19 @@ final class EventServiceClient
      */
     private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'jobs.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -247,7 +256,9 @@ final class EventServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/JobServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/JobServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -82,7 +83,9 @@ final class JobServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.talent.v4beta1.JobService';
 
     /**
@@ -92,13 +95,19 @@ final class JobServiceClient
      */
     private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'jobs.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -452,7 +461,9 @@ final class JobServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/talent/src/V4beta1/Client/TenantServiceClient.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/Client/TenantServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -69,7 +70,9 @@ final class TenantServiceClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.talent.v4beta1.TenantService';
 
     /**
@@ -79,13 +82,19 @@ final class TenantServiceClient
      */
     private const SERVICE_ADDRESS = 'jobs.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'jobs.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -256,7 +265,9 @@ final class TenantServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/company_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/company_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/company_service_rest_client_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/company_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/completion_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/completion_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/completion_rest_client_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/completion_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/event_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/event_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/event_service_rest_client_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/event_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/job_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/job_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/job_service_rest_client_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/job_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/tenant_service_descriptor_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/tenant_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/src/V4beta1/resources/tenant_service_rest_client_config.php
+++ b/tests/Integration/goldens/talent/src/V4beta1/resources/tenant_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/CompanyServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/CompanyServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -45,19 +46,25 @@ use stdClass;
  */
 class CompanyServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CompanyServiceClient */
+    /**
+     * @return CompanyServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -66,7 +73,9 @@ class CompanyServiceClientTest extends GeneratedTest
         return new CompanyServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCompanyTest()
     {
         $transport = $this->createTransport();
@@ -121,7 +130,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCompanyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -162,7 +173,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteCompanyTest()
     {
         $transport = $this->createTransport();
@@ -188,7 +201,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteCompanyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -223,7 +238,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCompanyTest()
     {
         $transport = $this->createTransport();
@@ -270,7 +287,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getCompanyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -305,7 +324,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCompaniesTest()
     {
         $transport = $this->createTransport();
@@ -342,7 +363,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listCompaniesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -377,7 +400,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCompanyTest()
     {
         $transport = $this->createTransport();
@@ -428,7 +453,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateCompanyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -467,7 +494,9 @@ class CompanyServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createCompanyAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/CompletionClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/CompletionClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class CompletionClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CompletionClient */
+    /**
+     * @return CompletionClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class CompletionClientTest extends GeneratedTest
         return new CompletionClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeQueryTest()
     {
         $transport = $this->createTransport();
@@ -95,7 +104,9 @@ class CompletionClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeQueryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -134,7 +145,9 @@ class CompletionClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function completeQueryAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/EventServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/EventServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class EventServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return EventServiceClient */
+    /**
+     * @return EventServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class EventServiceClientTest extends GeneratedTest
         return new EventServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClientEventTest()
     {
         $transport = $this->createTransport();
@@ -102,7 +111,9 @@ class EventServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClientEventExceptionTest()
     {
         $transport = $this->createTransport();
@@ -143,7 +154,9 @@ class EventServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createClientEventAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/JobServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/JobServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -57,19 +58,25 @@ use stdClass;
  */
 class JobServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return JobServiceClient */
+    /**
+     * @return JobServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -78,7 +85,9 @@ class JobServiceClientTest extends GeneratedTest
         return new JobServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchCreateJobsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -146,7 +155,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchCreateJobsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -205,7 +216,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchDeleteJobsTest()
     {
         $transport = $this->createTransport();
@@ -235,7 +248,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchDeleteJobsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -272,7 +287,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchUpdateJobsTest()
     {
         $operationsTransport = $this->createTransport();
@@ -340,7 +357,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchUpdateJobsExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -399,7 +418,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createJobTest()
     {
         $transport = $this->createTransport();
@@ -462,7 +483,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -507,7 +530,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteJobTest()
     {
         $transport = $this->createTransport();
@@ -533,7 +558,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -568,7 +595,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getJobTest()
     {
         $transport = $this->createTransport();
@@ -619,7 +648,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -654,7 +685,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listJobsTest()
     {
         $transport = $this->createTransport();
@@ -695,7 +728,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listJobsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -732,7 +767,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchJobsTest()
     {
         $transport = $this->createTransport();
@@ -779,7 +816,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchJobsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -816,7 +855,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchJobsForAlertTest()
     {
         $transport = $this->createTransport();
@@ -863,7 +904,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function searchJobsForAlertExceptionTest()
     {
         $transport = $this->createTransport();
@@ -900,7 +943,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateJobTest()
     {
         $transport = $this->createTransport();
@@ -959,7 +1004,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateJobExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1002,7 +1049,9 @@ class JobServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function batchCreateJobsAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/TenantServiceClientTest.php
+++ b/tests/Integration/goldens/talent/tests/Unit/V4beta1/Client/TenantServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -45,19 +46,25 @@ use stdClass;
  */
 class TenantServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return TenantServiceClient */
+    /**
+     * @return TenantServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -66,7 +73,9 @@ class TenantServiceClientTest extends GeneratedTest
         return new TenantServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createTenantTest()
     {
         $transport = $this->createTransport();
@@ -103,7 +112,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createTenantExceptionTest()
     {
         $transport = $this->createTransport();
@@ -142,7 +153,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteTenantTest()
     {
         $transport = $this->createTransport();
@@ -168,7 +181,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteTenantExceptionTest()
     {
         $transport = $this->createTransport();
@@ -203,7 +218,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getTenantTest()
     {
         $transport = $this->createTransport();
@@ -234,7 +251,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getTenantExceptionTest()
     {
         $transport = $this->createTransport();
@@ -269,7 +288,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listTenantsTest()
     {
         $transport = $this->createTransport();
@@ -306,7 +327,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listTenantsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -341,7 +364,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateTenantTest()
     {
         $transport = $this->createTransport();
@@ -374,7 +399,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateTenantExceptionTest()
     {
         $transport = $this->createTransport();
@@ -411,7 +438,9 @@ class TenantServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createTenantAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Integration/goldens/videointelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
+++ b/tests/Integration/goldens/videointelligence/samples/V1/VideoIntelligenceServiceClient/annotate_video.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/videointelligence/src/V1/Client/VideoIntelligenceServiceClient.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/Client/VideoIntelligenceServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -53,7 +54,9 @@ final class VideoIntelligenceServiceClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.cloud.videointelligence.v1.VideoIntelligenceService';
 
     /**
@@ -63,13 +66,19 @@ final class VideoIntelligenceServiceClient
      */
     private const SERVICE_ADDRESS = 'videointelligence.googleapis.com';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'videointelligence.UNIVERSE_DOMAIN';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -225,7 +234,9 @@ final class VideoIntelligenceServiceClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Integration/goldens/videointelligence/src/V1/resources/video_intelligence_service_descriptor_config.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/resources/video_intelligence_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/videointelligence/src/V1/resources/video_intelligence_service_rest_client_config.php
+++ b/tests/Integration/goldens/videointelligence/src/V1/resources/video_intelligence_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Integration/goldens/videointelligence/tests/Unit/V1/Client/VideoIntelligenceServiceClientTest.php
+++ b/tests/Integration/goldens/videointelligence/tests/Unit/V1/Client/VideoIntelligenceServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *
@@ -43,19 +44,25 @@ use stdClass;
  */
 class VideoIntelligenceServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return VideoIntelligenceServiceClient */
+    /**
+     * @return VideoIntelligenceServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -64,7 +71,9 @@ class VideoIntelligenceServiceClientTest extends GeneratedTest
         return new VideoIntelligenceServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function annotateVideoTest()
     {
         $operationsTransport = $this->createTransport();
@@ -123,7 +132,9 @@ class VideoIntelligenceServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function annotateVideoExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -177,7 +188,9 @@ class VideoIntelligenceServiceClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function annotateVideoAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Unit/Collections/MapTest.php
+++ b/tests/Unit/Collections/MapTest.php
@@ -44,6 +44,14 @@ class ObjEq implements Equality
     }
 }
 
+class ObjEqStringable extends ObjEq
+{
+    public function __toString(): string
+    {
+        return "ObjEq({$this->id})";
+    }
+}
+
 final class MapTest extends TestCase
 {
     public function testNew(): void
@@ -147,6 +155,46 @@ final class MapTest extends TestCase
         $this->assertCount(2, $v);
         $this->assertContains('one', $v);
         $this->assertContains('two', $v);
+    }
+
+    public function testMissingObjectKeyExceptionMessage(): void
+    {
+        // Keys need only support equality, not string conversion. Interpolating the key
+        // directly raised "object could not be converted to string", masking this message.
+        $m = Map::new();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Key <' . Obj::class . '> does not exist');
+        $m[new Obj()];
+    }
+
+    public function testMissingStringableObjectKeyExceptionMessage(): void
+    {
+        $m = Map::new();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Key ObjEq(7) does not exist');
+        $m[new ObjEqStringable(7)];
+    }
+
+    public function testMissingScalarKeyExceptionMessage(): void
+    {
+        $m = Map::new();
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Key 3 does not exist');
+        $m[3];
+    }
+
+    public function testDuplicateObjectKeyExceptionMessage(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot add two items with the same key <' . ObjEq::class . '>');
+        Map::fromPairs([[new ObjEq(1), 'one'], [new ObjEq(1), 'uno']]);
+    }
+
+    public function testDuplicateScalarKeyExceptionMessage(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Cannot add two items with the same key 1');
+        Map::fromPairs([[1, 'one'], [1, 'uno']]);
     }
 
     public function testToAssociativeArray(): void

--- a/tests/Unit/Generation/MethodDetailsTest.php
+++ b/tests/Unit/Generation/MethodDetailsTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Generator\Tests\Unit\Generation;
+
+use PHPUnit\Framework\TestCase;
+use Google\Generator\CodeGenerator;
+use Google\Generator\Tests\Tools\ProtoLoader;
+
+final class MethodDetailsTest extends TestCase
+{
+    private static function generate(string $protoPath, string $package): void
+    {
+        $descBytes = ProtoLoader::loadDescriptorBytes($protoPath);
+        $codeIterator = CodeGenerator::generateFromDescriptor(
+            $descBytes,
+            $package,
+            null, // transport
+            true, // generateGapicMetadata
+            null, // grpcServiceConfigJson
+            null, // gapicYaml
+            null, // serviceYaml
+            true, // numericEnums
+            2022, // licenseYear
+            true, // generateSnippets
+        );
+        foreach ($codeIterator as $ignored) {
+        }
+    }
+
+    public function testRepeatedPageSizeIsRejected(): void
+    {
+        // The page_size guard was a dead store, overwritten by both branches of the type
+        // check below it, so a `repeated int32 page_size` passed validation and produced a
+        // client treating a RepeatedField as an int.
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('page_size field must be of type int32.');
+        static::generate('Generation/repeated-page-size.proto', 'testing.repeatedpagesize');
+    }
+}

--- a/tests/Unit/Generation/repeated-page-size.proto
+++ b/tests/Unit/Generation/repeated-page-size.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package testing.repeatedpagesize;
+
+option php_namespace = "Testing\\RepeatedPageSize";
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+
+service RepeatedPageSize {
+  option (google.api.default_host) = "paginated.example.com";
+  option (google.api.oauth_scopes) = "scope1,scope2";
+
+  rpc MethodPaginated(Request) returns(Response) {
+    option (google.api.http) = {
+      post: "/path:methodPaginated"
+      body: "*"
+    };
+  }
+}
+
+message Request {
+  string a_field = 1 [(google.api.field_behavior) = REQUIRED];
+  // A repeated page_size is not a page size. The generator must reject it rather than
+  // emit a client that treats a RepeatedField as an int.
+  repeated int32 page_size = 2;
+  string page_token = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+message Response {
+  repeated string the_results = 1;
+  string next_page_token = 2;
+}

--- a/tests/Unit/ProtoTests/Basic/out/samples/BasicClient/a_method.php
+++ b/tests/Unit/ProtoTests/Basic/out/samples/BasicClient/a_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/Basic/out/samples/BasicClient/method_with_args.php
+++ b/tests/Unit/ProtoTests/Basic/out/samples/BasicClient/method_with_args.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/Client/BasicClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -55,19 +56,29 @@ final class BasicClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basic.Basic';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'basic.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
-    /** The api version of the service */
+    /**
+     * The api version of the service
+     */
     private string $apiVersion = 'v1_20240418';
 
     /**
@@ -178,7 +189,9 @@ final class BasicClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {
@@ -241,7 +254,9 @@ final class BasicClient
         return $this->startApiCall('MethodWithArgs', $request, $callOptions)->wait();
     }
 
-    /** Configure the gapic configuration to use a service emulator. */
+    /**
+     * Configure the gapic configuration to use a service emulator.
+     */
     private function setDefaultEmulatorConfig(array $options): array
     {
         $emulatorHost = getenv('BASIC_EMULATOR_HOST');

--- a/tests/Unit/ProtoTests/Basic/out/src/resources/basic_descriptor_config.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/resources/basic_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/Basic/out/src/resources/basic_rest_client_config.php
+++ b/tests/Unit/ProtoTests/Basic/out/src/resources/basic_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/Basic/out/tests/Unit/Client/BasicClientTest.php
+++ b/tests/Unit/ProtoTests/Basic/out/tests/Unit/Client/BasicClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class BasicClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicClient */
+    /**
+     * @return BasicClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class BasicClientTest extends GeneratedTest
         return new BasicClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aMethodTest()
     {
         $transport = $this->createTransport();
@@ -83,7 +92,9 @@ class BasicClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -115,7 +126,9 @@ class BasicClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodWithArgsTest()
     {
         $transport = $this->createTransport();
@@ -150,7 +163,9 @@ class BasicClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodWithArgsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -189,7 +204,9 @@ class BasicClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aMethodAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/samples/BasicAutoPopulationClient/create_foo.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/samples/BasicAutoPopulationClient/create_foo.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -28,7 +29,9 @@ use Testing\BasicAutoPopulation\Client\BasicAutoPopulationClient;
 use Testing\BasicAutoPopulation\Request;
 use Testing\BasicAutoPopulation\Response;
 
-/** @param string $aField  */
+/**
+ * @param string $aField
+ */
 function create_foo_sample(string $aField): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/samples/BasicAutoPopulationClient/get_foo.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/samples/BasicAutoPopulationClient/get_foo.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -28,7 +29,9 @@ use Testing\BasicAutoPopulation\Client\BasicAutoPopulationClient;
 use Testing\BasicAutoPopulation\Request;
 use Testing\BasicAutoPopulation\Response;
 
-/** @param string $aField  */
+/**
+ * @param string $aField
+ */
 function get_foo_sample(string $aField): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/Client/BasicAutoPopulationClient.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/Client/BasicAutoPopulationClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -50,16 +51,24 @@ final class BasicAutoPopulationClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicautopopulation.BasicAutoPopulation';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'autopopulation.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -165,7 +174,9 @@ final class BasicAutoPopulationClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/resources/basic_auto_population_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/resources/basic_auto_population_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/resources/basic_auto_population_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/src/resources/basic_auto_population_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicAutoPopulation/out/tests/Unit/Client/BasicAutoPopulationClientTest.php
+++ b/tests/Unit/ProtoTests/BasicAutoPopulation/out/tests/Unit/Client/BasicAutoPopulationClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class BasicAutoPopulationClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicAutoPopulationClient */
+    /**
+     * @return BasicAutoPopulationClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class BasicAutoPopulationClientTest extends GeneratedTest
         return new BasicAutoPopulationClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFooTest()
     {
         $transport = $this->createTransport();
@@ -87,7 +96,9 @@ class BasicAutoPopulationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFooExceptionTest()
     {
         $transport = $this->createTransport();
@@ -122,7 +133,9 @@ class BasicAutoPopulationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getFooTest()
     {
         $transport = $this->createTransport();
@@ -149,7 +162,9 @@ class BasicAutoPopulationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getFooExceptionTest()
     {
         $transport = $this->createTransport();
@@ -184,7 +199,9 @@ class BasicAutoPopulationClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFooAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_bidi.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_bidi.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -29,7 +30,9 @@ use Testing\BasicBidiStreaming\Client\BasicBidiStreamingClient;
 use Testing\BasicBidiStreaming\Request;
 use Testing\BasicBidiStreaming\Response;
 
-/** @param int $aNumber  */
+/**
+ * @param int $aNumber
+ */
 function method_bidi_sample(int $aNumber): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_empty.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/samples/BasicBidiStreamingClient/method_empty.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BasicBidiStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/Client/BasicBidiStreamingClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -44,16 +45,24 @@ final class BasicBidiStreamingClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicbidistreaming.BasicBidiStreaming';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'bidi.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/src/resources/basic_bidi_streaming_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicBidiStreaming/out/tests/Unit/Client/BasicBidiStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicBidiStreaming/out/tests/Unit/Client/BasicBidiStreamingClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -41,19 +42,25 @@ use stdClass;
  */
 class BasicBidiStreamingClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicBidiStreamingClient */
+    /**
+     * @return BasicBidiStreamingClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -62,7 +69,9 @@ class BasicBidiStreamingClientTest extends GeneratedTest
         return new BasicBidiStreamingClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodBidiTest()
     {
         $transport = $this->createTransport();
@@ -123,7 +132,9 @@ class BasicBidiStreamingClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodBidiExceptionTest()
     {
         $transport = $this->createTransport();
@@ -156,7 +167,9 @@ class BasicBidiStreamingClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodEmptyTest()
     {
         $transport = $this->createTransport();
@@ -211,7 +224,9 @@ class BasicBidiStreamingClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodEmptyExceptionTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_client.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_client.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -29,7 +30,9 @@ use Testing\BasicClientStreaming\Client\BasicClientStreamingClient;
 use Testing\BasicClientStreaming\Request;
 use Testing\BasicClientStreaming\Response;
 
-/** @param int $aNumber  */
+/**
+ * @param int $aNumber
+ */
 function method_client_sample(int $aNumber): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_empty.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/samples/BasicClientStreamingClient/method_empty.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BasicClientStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/Client/BasicClientStreamingClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -44,16 +45,24 @@ final class BasicClientStreamingClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicclientstreaming.BasicClientStreaming';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'clientstreaming.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/src/resources/basic_client_streaming_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicClientStreaming/out/tests/Unit/Client/BasicClientStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicClientStreaming/out/tests/Unit/Client/BasicClientStreamingClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -33,19 +34,25 @@ use Google\ApiCore\Testing\MockTransport;
  */
 class BasicClientStreamingClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicClientStreamingClient */
+    /**
+     * @return BasicClientStreamingClient
+     */
     private function createClient(array $options = [])
     {
         $options += [

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/add_comments.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/add_comments.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/add_tag.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/add_tag.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/archive_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/archive_books.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_inventory.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_inventory.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_shelf.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/create_shelf.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/delete_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/delete_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/delete_shelf.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/delete_shelf.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/find_related_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/find_related_books.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_big_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_big_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_big_nothing.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_big_nothing.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book_from_absolutely_anywhere.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book_from_absolutely_anywhere.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book_from_anywhere.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book_from_anywhere.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book_from_archive.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_book_from_archive.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_shelf.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/get_shelf.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_aggregated_shelves.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_aggregated_shelves.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_books.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_shelves.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_shelves.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_strings.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/list_strings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/long_running_archive_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/long_running_archive_books.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/merge_shelves.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/merge_shelves.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/move_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/move_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/move_books.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/move_books.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/private_list_shelves.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/private_list_shelves.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/publish_series.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/publish_series.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/save_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/save_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book_index.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/samples/LibraryClient/update_book_index.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/LibraryClient.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/Client/LibraryClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -137,7 +138,9 @@ final class LibraryClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'google.example.library.v1.Library';
 
     /**
@@ -147,13 +150,19 @@ final class LibraryClient
      */
     private const SERVICE_ADDRESS = 'library-example.googleapis.com:1234';
 
-    /** The address template of the service. */
+    /**
+     * The address template of the service.
+     */
     private const SERVICE_ADDRESS_TEMPLATE = 'library-example.UNIVERSE_DOMAIN:1234';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -187,13 +196,17 @@ final class LibraryClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -656,7 +669,9 @@ final class LibraryClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/src/resources/library_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/Client/LibraryClientTest.php
+++ b/tests/Unit/ProtoTests/BasicDiregapic/out/tests/Unit/Client/LibraryClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -81,19 +82,25 @@ use stdClass;
  */
 class LibraryClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return LibraryClient */
+    /**
+     * @return LibraryClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -102,7 +109,9 @@ class LibraryClientTest extends GeneratedTest
         return new LibraryClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addCommentsTest()
     {
         $transport = $this->createTransport();
@@ -132,7 +141,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addCommentsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -169,7 +180,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addTagTest()
     {
         $transport = $this->createTransport();
@@ -200,7 +213,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addTagExceptionTest()
     {
         $transport = $this->createTransport();
@@ -237,7 +252,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function archiveBooksTest()
     {
         $transport = $this->createTransport();
@@ -261,7 +278,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function archiveBooksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -293,7 +312,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBookTest()
     {
         $transport = $this->createTransport();
@@ -336,7 +357,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createBookExceptionTest()
     {
         $transport = $this->createTransport();
@@ -375,7 +398,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createInventoryTest()
     {
         $transport = $this->createTransport();
@@ -416,7 +441,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createInventoryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -457,7 +484,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createShelfTest()
     {
         $transport = $this->createTransport();
@@ -492,7 +521,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createShelfExceptionTest()
     {
         $transport = $this->createTransport();
@@ -529,7 +560,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBookTest()
     {
         $transport = $this->createTransport();
@@ -555,7 +588,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteBookExceptionTest()
     {
         $transport = $this->createTransport();
@@ -590,7 +625,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteShelfTest()
     {
         $transport = $this->createTransport();
@@ -616,7 +653,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteShelfExceptionTest()
     {
         $transport = $this->createTransport();
@@ -651,7 +690,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function findRelatedBooksTest()
     {
         $transport = $this->createTransport();
@@ -696,7 +737,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function findRelatedBooksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -737,7 +780,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBigBookTest()
     {
         $operationsTransport = $this->createTransport();
@@ -811,7 +856,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBigBookExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -868,7 +915,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBigNothingTest()
     {
         $operationsTransport = $this->createTransport();
@@ -932,7 +981,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBigNothingExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -989,7 +1040,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookTest()
     {
         $transport = $this->createTransport();
@@ -1026,7 +1079,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1061,7 +1116,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookFromAbsolutelyAnywhereTest()
     {
         $transport = $this->createTransport();
@@ -1096,7 +1153,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookFromAbsolutelyAnywhereExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1131,7 +1190,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookFromAnywhereTest()
     {
         $transport = $this->createTransport();
@@ -1178,7 +1239,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookFromAnywhereExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1219,7 +1282,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookFromArchiveTest()
     {
         $transport = $this->createTransport();
@@ -1258,7 +1323,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getBookFromArchiveExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1295,7 +1362,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getShelfTest()
     {
         $transport = $this->createTransport();
@@ -1332,7 +1401,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getShelfExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1369,7 +1440,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAggregatedShelvesTest()
     {
         $transport = $this->createTransport();
@@ -1401,7 +1474,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listAggregatedShelvesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1433,7 +1508,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBooksTest()
     {
         $transport = $this->createTransport();
@@ -1470,7 +1547,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listBooksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1505,7 +1584,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listShelvesTest()
     {
         $transport = $this->createTransport();
@@ -1529,7 +1610,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listShelvesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1561,7 +1644,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listStringsTest()
     {
         $transport = $this->createTransport();
@@ -1593,7 +1678,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listStringsExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1625,7 +1712,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function longRunningArchiveBooksTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1686,7 +1775,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function longRunningArchiveBooksExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -1740,7 +1831,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function mergeShelvesTest()
     {
         $transport = $this->createTransport();
@@ -1777,7 +1870,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function mergeShelvesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1814,7 +1909,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function moveBookTest()
     {
         $transport = $this->createTransport();
@@ -1855,7 +1952,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function moveBookExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1892,7 +1991,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function moveBooksTest()
     {
         $transport = $this->createTransport();
@@ -1916,7 +2017,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function moveBooksExceptionTest()
     {
         $transport = $this->createTransport();
@@ -1948,7 +2051,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function privateListShelvesTest()
     {
         $transport = $this->createTransport();
@@ -1980,7 +2085,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function privateListShelvesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2012,7 +2119,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function publishSeriesTest()
     {
         $transport = $this->createTransport();
@@ -2053,7 +2162,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function publishSeriesExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2096,7 +2207,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function saveBookTest()
     {
         $transport = $this->createTransport();
@@ -2122,7 +2235,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function saveBookExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2157,7 +2272,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBookTest()
     {
         $transport = $this->createTransport();
@@ -2200,7 +2317,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBookExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2239,7 +2358,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBookIndexTest()
     {
         $transport = $this->createTransport();
@@ -2276,7 +2397,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function updateBookIndexExceptionTest()
     {
         $transport = $this->createTransport();
@@ -2318,7 +2441,9 @@ class LibraryClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function addCommentsAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/samples/BasicExplicitPaginatedClient/method_explicit_paginated.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/samples/BasicExplicitPaginatedClient/method_explicit_paginated.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Client/BasicExplicitPaginatedClient.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/Client/BasicExplicitPaginatedClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -49,16 +50,24 @@ final class BasicExplicitPaginatedClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicexplicitpaginated.BasicExplicitPaginated';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'explicitpaginated.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -164,7 +173,9 @@ final class BasicExplicitPaginatedClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/resources/basic_explicit_paginated_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/resources/basic_explicit_paginated_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/resources/basic_explicit_paginated_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/src/resources/basic_explicit_paginated_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicExplicitPaginated/out/tests/Unit/Client/BasicExplicitPaginatedClientTest.php
+++ b/tests/Unit/ProtoTests/BasicExplicitPaginated/out/tests/Unit/Client/BasicExplicitPaginatedClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class BasicExplicitPaginatedClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicExplicitPaginatedClient */
+    /**
+     * @return BasicExplicitPaginatedClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class BasicExplicitPaginatedClientTest extends GeneratedTest
         return new BasicExplicitPaginatedClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodExplicitPaginatedTest()
     {
         $transport = $this->createTransport();
@@ -113,7 +122,9 @@ class BasicExplicitPaginatedClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodExplicitPaginatedExceptionTest()
     {
         $transport = $this->createTransport();
@@ -152,7 +163,9 @@ class BasicExplicitPaginatedClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodExplicitPaginatedAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/Client/BasicGrpcOnlyClient.php
+++ b/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/Client/BasicGrpcOnlyClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -42,16 +43,24 @@ final class BasicGrpcOnlyClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicgrpconly.BasicGrpcOnly';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'basicgrpconly.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -75,7 +84,9 @@ final class BasicGrpcOnlyClient
         ];
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [

--- a/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/resources/basic_grpc_only_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicGrpcOnly/out/src/resources/basic_grpc_only_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicGrpcOnly/out/tests/Unit/Client/BasicGrpcOnlyClientTest.php
+++ b/tests/Unit/ProtoTests/BasicGrpcOnly/out/tests/Unit/Client/BasicGrpcOnlyClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -33,19 +34,25 @@ use Google\ApiCore\Testing\MockTransport;
  */
 class BasicGrpcOnlyClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicGrpcOnlyClient */
+    /**
+     * @return BasicGrpcOnlyClient
+     */
     private function createClient(array $options = [])
     {
         $options += [

--- a/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method1.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method1.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method_non_lro1.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method_non_lro1.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method_non_lro2.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/samples/BasicLroClient/method_non_lro2.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicLro/out/src/Client/BasicLroClient.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/Client/BasicLroClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -54,16 +55,24 @@ final class BasicLroClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basiclro.BasicLro';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'lro.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -220,7 +229,9 @@ final class BasicLroClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/src/resources/basic_lro_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicLro/out/tests/Unit/Client/BasicLroClientTest.php
+++ b/tests/Unit/ProtoTests/BasicLro/out/tests/Unit/Client/BasicLroClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -43,19 +44,25 @@ use stdClass;
  */
 class BasicLroClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicLroClient */
+    /**
+     * @return BasicLroClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -64,7 +71,9 @@ class BasicLroClientTest extends GeneratedTest
         return new BasicLroClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1Test()
     {
         $operationsTransport = $this->createTransport();
@@ -125,7 +134,9 @@ class BasicLroClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1ExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -179,7 +190,9 @@ class BasicLroClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodNonLro1Test()
     {
         $transport = $this->createTransport();
@@ -201,7 +214,9 @@ class BasicLroClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodNonLro1ExceptionTest()
     {
         $transport = $this->createTransport();
@@ -233,7 +248,9 @@ class BasicLroClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodNonLro2Test()
     {
         $transport = $this->createTransport();
@@ -255,7 +272,9 @@ class BasicLroClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodNonLro2ExceptionTest()
     {
         $transport = $this->createTransport();
@@ -287,7 +306,9 @@ class BasicLroClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1AsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicOneof/out/samples/BasicOneofClient/a_method.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/samples/BasicOneofClient/a_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BasicOneofClient.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/Client/BasicOneofClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -49,16 +50,24 @@ final class BasicOneofClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basiconeof.BasicOneof';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'basic.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -164,7 +173,9 @@ final class BasicOneofClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/src/resources/basic_oneof_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/Client/BasicOneofClientTest.php
+++ b/tests/Unit/ProtoTests/BasicOneof/out/tests/Unit/Client/BasicOneofClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -40,19 +41,25 @@ use stdClass;
  */
 class BasicOneofClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicOneofClient */
+    /**
+     * @return BasicOneofClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -61,7 +68,9 @@ class BasicOneofClientTest extends GeneratedTest
         return new BasicOneofClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aMethodTest()
     {
         $transport = $this->createTransport();
@@ -98,7 +107,9 @@ class BasicOneofClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -139,7 +150,9 @@ class BasicOneofClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function aMethodAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicPaginated/out/samples/BasicPaginatedClient/method_paginated.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/samples/BasicPaginatedClient/method_paginated.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BasicPaginatedClient.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/Client/BasicPaginatedClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -49,16 +50,24 @@ final class BasicPaginatedClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicpaginated.BasicPaginated';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'paginated.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -164,7 +173,9 @@ final class BasicPaginatedClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/src/resources/basic_paginated_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/Client/BasicPaginatedClientTest.php
+++ b/tests/Unit/ProtoTests/BasicPaginated/out/tests/Unit/Client/BasicPaginatedClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class BasicPaginatedClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicPaginatedClient */
+    /**
+     * @return BasicPaginatedClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class BasicPaginatedClientTest extends GeneratedTest
         return new BasicPaginatedClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodPaginatedTest()
     {
         $transport = $this->createTransport();
@@ -113,7 +122,9 @@ class BasicPaginatedClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodPaginatedExceptionTest()
     {
         $transport = $this->createTransport();
@@ -152,7 +163,9 @@ class BasicPaginatedClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodPaginatedAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/samples/BasicServerStreamingClient/method_empty.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/samples/BasicServerStreamingClient/method_empty.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/samples/BasicServerStreamingClient/method_server.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/samples/BasicServerStreamingClient/method_server.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -29,7 +30,9 @@ use Testing\BasicServerStreaming\Client\BasicServerStreamingClient;
 use Testing\BasicServerStreaming\Request;
 use Testing\BasicServerStreaming\Response;
 
-/** @param int $aNumber  */
+/**
+ * @param int $aNumber
+ */
 function method_server_sample(int $aNumber): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/Client/BasicServerStreamingClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -47,16 +48,24 @@ final class BasicServerStreamingClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.basicserverstreaming.BasicServerStreaming';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'serverstreaming.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_descriptor_config.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_rest_client_config.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/src/resources/basic_server_streaming_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/BasicServerStreaming/out/tests/Unit/Client/BasicServerStreamingClientTest.php
+++ b/tests/Unit/ProtoTests/BasicServerStreaming/out/tests/Unit/Client/BasicServerStreamingClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -41,19 +42,25 @@ use stdClass;
  */
 class BasicServerStreamingClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return BasicServerStreamingClient */
+    /**
+     * @return BasicServerStreamingClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -62,7 +69,9 @@ class BasicServerStreamingClientTest extends GeneratedTest
         return new BasicServerStreamingClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodEmptyTest()
     {
         $transport = $this->createTransport();
@@ -95,7 +104,9 @@ class BasicServerStreamingClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodEmptyExceptionTest()
     {
         $transport = $this->createTransport();
@@ -130,7 +141,9 @@ class BasicServerStreamingClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodServerTest()
     {
         $transport = $this->createTransport();
@@ -167,7 +180,9 @@ class BasicServerStreamingClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function methodServerExceptionTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroClient/create_foo.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroClient/create_foo.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroOperationsClient/cancel.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroOperationsClient/cancel.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -27,7 +28,9 @@ use Google\ApiCore\ApiException;
 use Testing\CustomLro\CancelOperationRequest;
 use Testing\CustomLro\Client\CustomLroOperationsClient;
 
-/** @param string $operation Name of th Operations resource to cancel. */
+/**
+ * @param string $operation Name of th Operations resource to cancel.
+ */
 function cancel_sample(string $operation): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroOperationsClient/delete.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroOperationsClient/delete.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -27,7 +28,9 @@ use Google\ApiCore\ApiException;
 use Testing\CustomLro\Client\CustomLroOperationsClient;
 use Testing\CustomLro\DeleteOperationRequest;
 
-/** @param string $operation Name of th Operations resource to delete. */
+/**
+ * @param string $operation Name of th Operations resource to delete.
+ */
 function delete_sample(string $operation): void
 {
     // Create a client.

--- a/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroOperationsClient/get.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/samples/CustomLroOperationsClient/get.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -49,16 +50,24 @@ final class CustomLroClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.customlro.CustomLro';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'customlro.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -92,13 +101,17 @@ final class CustomLroClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -116,7 +129,9 @@ final class CustomLroClient
         return $this->operationsClient;
     }
 
-    /** Return the default longrunning operation descriptor config. */
+    /**
+     * Return the default longrunning operation descriptor config.
+     */
     private function getDefaultOperationDescriptor()
     {
         return [
@@ -249,7 +264,9 @@ final class CustomLroClient
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroOperationsClient.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/Client/CustomLroOperationsClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -53,16 +54,24 @@ final class CustomLroOperationsClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.customlro.CustomLroOperations';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'customlro.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -94,13 +103,17 @@ final class CustomLroOperationsClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -179,7 +192,9 @@ final class CustomLroOperationsClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_descriptor_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_descriptor_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_rest_client_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_operations_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_rest_client_config.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/src/resources/custom_lro_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/Client/CustomLroClientTest.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/Client/CustomLroClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -41,19 +42,25 @@ use stdClass;
  */
 class CustomLroClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CustomLroClient */
+    /**
+     * @return CustomLroClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -62,7 +69,9 @@ class CustomLroClientTest extends GeneratedTest
         return new CustomLroClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFooTest()
     {
         $operationsTransport = $this->createTransport();
@@ -127,7 +136,9 @@ class CustomLroClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFooExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -184,7 +195,9 @@ class CustomLroClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createFooAsyncTest()
     {
         $operationsTransport = $this->createTransport();

--- a/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/Client/CustomLroOperationsClientTest.php
+++ b/tests/Unit/ProtoTests/CustomLro/out/tests/Unit/Client/CustomLroOperationsClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -41,19 +42,25 @@ use stdClass;
  */
 class CustomLroOperationsClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return CustomLroOperationsClient */
+    /**
+     * @return CustomLroOperationsClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -62,7 +69,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         return new CustomLroOperationsClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelTest()
     {
         $transport = $this->createTransport();
@@ -88,7 +97,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelExceptionTest()
     {
         $transport = $this->createTransport();
@@ -123,7 +134,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteTest()
     {
         $transport = $this->createTransport();
@@ -149,7 +162,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteExceptionTest()
     {
         $transport = $this->createTransport();
@@ -184,7 +199,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getTest()
     {
         $transport = $this->createTransport();
@@ -229,7 +246,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getExceptionTest()
     {
         $transport = $this->createTransport();
@@ -270,7 +289,9 @@ class CustomLroOperationsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function cancelAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/DeprecatedService/out/samples/DeprecatedServiceClient/fast_fibonacci.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/samples/DeprecatedServiceClient/fast_fibonacci.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/DeprecatedService/out/samples/DeprecatedServiceClient/slow_fibonacci.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/samples/DeprecatedServiceClient/slow_fibonacci.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/DeprecatedServiceClient.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/Client/DeprecatedServiceClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -52,16 +53,24 @@ final class DeprecatedServiceClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.deprecated_service.DeprecatedService';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'localhost:7469';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -166,7 +175,9 @@ final class DeprecatedServiceClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_descriptor_config.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_rest_client_config.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/src/resources/deprecated_service_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/DeprecatedService/out/tests/Unit/Client/DeprecatedServiceClientTest.php
+++ b/tests/Unit/ProtoTests/DeprecatedService/out/tests/Unit/Client/DeprecatedServiceClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class DeprecatedServiceClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return DeprecatedServiceClient */
+    /**
+     * @return DeprecatedServiceClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class DeprecatedServiceClientTest extends GeneratedTest
         return new DeprecatedServiceClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fastFibonacciTest()
     {
         $transport = $this->createTransport();
@@ -81,7 +90,9 @@ class DeprecatedServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fastFibonacciExceptionTest()
     {
         $transport = $this->createTransport();
@@ -113,7 +124,9 @@ class DeprecatedServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function slowFibonacciTest()
     {
         $transport = $this->createTransport();
@@ -134,7 +147,9 @@ class DeprecatedServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function slowFibonacciExceptionTest()
     {
         $transport = $this->createTransport();
@@ -166,7 +181,9 @@ class DeprecatedServiceClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fastFibonacciAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/list_method.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/list_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/map_method.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/map_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/multiple_list_method.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/multiple_list_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/non_paginated_method.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/samples/HeuristicPaginationClientClient/non_paginated_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Client/HeuristicPaginationClientClient.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/src/Client/HeuristicPaginationClientClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -58,16 +59,24 @@ final class HeuristicPaginationClientClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.diregapicpaginated.HeuristicPaginationClient';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'diregapic.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -99,13 +108,17 @@ final class HeuristicPaginationClientClient
         ];
     }
 
-    /** Implements GapicClientTrait::defaultTransport. */
+    /**
+     * Implements GapicClientTrait::defaultTransport.
+     */
     private static function defaultTransport()
     {
         return 'rest';
     }
 
-    /** Implements ClientOptionsTrait::supportedTransports. */
+    /**
+     * Implements ClientOptionsTrait::supportedTransports.
+     */
     private static function supportedTransports()
     {
         return [
@@ -184,7 +197,9 @@ final class HeuristicPaginationClientClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/src/resources/heuristic_pagination_client_descriptor_config.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/src/resources/heuristic_pagination_client_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/src/resources/heuristic_pagination_client_rest_client_config.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/src/resources/heuristic_pagination_client_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/DiregapicPaginated/out/tests/Unit/Client/HeuristicPaginationClientClientTest.php
+++ b/tests/Unit/ProtoTests/DiregapicPaginated/out/tests/Unit/Client/HeuristicPaginationClientClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -43,19 +44,25 @@ use stdClass;
  */
 class HeuristicPaginationClientClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return HeuristicPaginationClientClient */
+    /**
+     * @return HeuristicPaginationClientClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -64,7 +71,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         return new HeuristicPaginationClientClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMethodTest()
     {
         $transport = $this->createTransport();
@@ -96,7 +105,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -128,7 +139,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function mapMethodTest()
     {
         $transport = $this->createTransport();
@@ -161,7 +174,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function mapMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -193,7 +208,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function multipleListMethodTest()
     {
         $transport = $this->createTransport();
@@ -225,7 +242,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function multipleListMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -257,7 +276,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nonPaginatedMethodTest()
     {
         $transport = $this->createTransport();
@@ -281,7 +302,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nonPaginatedMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -313,7 +336,9 @@ class HeuristicPaginationClientClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function listMethodAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/DisableSnippetsClient.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/Client/DisableSnippetsClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -49,16 +50,24 @@ final class DisableSnippetsClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.disablesnippets.DisableSnippets';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'disablesnippets.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -161,7 +170,9 @@ final class DisableSnippetsClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/resources/disable_snippets_descriptor_config.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/resources/disable_snippets_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/DisableSnippets/out/src/resources/disable_snippets_rest_client_config.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/src/resources/disable_snippets_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/DisableSnippets/out/tests/Unit/Client/DisableSnippetsClientTest.php
+++ b/tests/Unit/ProtoTests/DisableSnippets/out/tests/Unit/Client/DisableSnippetsClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -39,19 +40,25 @@ use stdClass;
  */
 class DisableSnippetsClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return DisableSnippetsClient */
+    /**
+     * @return DisableSnippetsClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -60,7 +67,9 @@ class DisableSnippetsClientTest extends GeneratedTest
         return new DisableSnippetsClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1Test()
     {
         $transport = $this->createTransport();
@@ -87,7 +96,9 @@ class DisableSnippetsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1ExceptionTest()
     {
         $transport = $this->createTransport();
@@ -122,7 +133,9 @@ class DisableSnippetsClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1AsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_a.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_a.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_b_lro.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_b_lro.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_bidi_streaming.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_bidi_streaming.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_c_service_level_retry.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_c_service_level_retry.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_d_timeout_only_retry.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_d_timeout_only_retry.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_server_streaming.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/samples/GrpcServiceConfigWithRetry1Client/method1_server_streaming.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/GrpcServiceConfigWithRetry1Client.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/Client/GrpcServiceConfigWithRetry1Client.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -58,16 +59,24 @@ final class GrpcServiceConfigWithRetry1Client
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.grpcserviceconfig.GrpcServiceConfigWithRetry1';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'grpcserviceconfig.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -221,7 +230,9 @@ final class GrpcServiceConfigWithRetry1Client
         $this->operationsClient = $this->createOperationsClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_descriptor_config.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_rest_client_config.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/src/resources/grpc_service_config_with_retry1_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/GrpcServiceConfig/out/tests/Unit/Client/GrpcServiceConfigWithRetry1ClientTest.php
+++ b/tests/Unit/ProtoTests/GrpcServiceConfig/out/tests/Unit/Client/GrpcServiceConfigWithRetry1ClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -46,19 +47,25 @@ use stdClass;
  */
 class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return GrpcServiceConfigWithRetry1Client */
+    /**
+     * @return GrpcServiceConfigWithRetry1Client
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -67,7 +74,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         return new GrpcServiceConfigWithRetry1Client($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1ATest()
     {
         $transport = $this->createTransport();
@@ -89,7 +98,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1AExceptionTest()
     {
         $transport = $this->createTransport();
@@ -121,7 +132,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1BLroTest()
     {
         $operationsTransport = $this->createTransport();
@@ -180,7 +193,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1BLroExceptionTest()
     {
         $operationsTransport = $this->createTransport();
@@ -234,7 +249,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($operationsTransport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1BidiStreamingTest()
     {
         $transport = $this->createTransport();
@@ -289,7 +306,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1BidiStreamingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -322,7 +341,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1CServiceLevelRetryTest()
     {
         $transport = $this->createTransport();
@@ -344,7 +365,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1CServiceLevelRetryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -376,7 +399,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1DTimeoutOnlyRetryTest()
     {
         $transport = $this->createTransport();
@@ -398,7 +423,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1DTimeoutOnlyRetryExceptionTest()
     {
         $transport = $this->createTransport();
@@ -430,7 +457,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1ServerStreamingTest()
     {
         $transport = $this->createTransport();
@@ -463,7 +492,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1ServerStreamingExceptionTest()
     {
         $transport = $this->createTransport();
@@ -498,7 +529,9 @@ class GrpcServiceConfigWithRetry1ClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function method1AAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/file_level_child_type_ref_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/file_level_child_type_ref_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/file_level_type_ref_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/file_level_type_ref_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/multi_pattern_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/multi_pattern_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/nested_reference_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/nested_reference_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/single_pattern_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/single_pattern_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_child_reference_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_child_reference_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_multi_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_multi_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_reference_method.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/samples/ResourceNamesClient/wildcard_reference_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/Client/ResourceNamesClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -72,16 +73,24 @@ final class ResourceNamesClient
     use GapicClientTrait;
     use ResourceHelperTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.resourcenames.ResourceNames';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'resourcenames.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -513,7 +522,9 @@ final class ResourceNamesClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_descriptor_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/src/resources/resource_names_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/Client/ResourceNamesClientTest.php
+++ b/tests/Unit/ProtoTests/ResourceNames/out/tests/Unit/Client/ResourceNamesClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -47,19 +48,25 @@ use stdClass;
  */
 class ResourceNamesClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ResourceNamesClient */
+    /**
+     * @return ResourceNamesClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -68,7 +75,9 @@ class ResourceNamesClientTest extends GeneratedTest
         return new ResourceNamesClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fileLevelChildTypeRefMethodTest()
     {
         $transport = $this->createTransport();
@@ -111,7 +120,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fileLevelChildTypeRefMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -154,7 +165,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fileLevelTypeRefMethodTest()
     {
         $transport = $this->createTransport();
@@ -176,7 +189,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fileLevelTypeRefMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -208,7 +223,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function multiPatternMethodTest()
     {
         $transport = $this->createTransport();
@@ -230,7 +247,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function multiPatternMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -262,7 +281,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nestedReferenceMethodTest()
     {
         $transport = $this->createTransport();
@@ -284,7 +305,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nestedReferenceMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -316,7 +339,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function singlePatternMethodTest()
     {
         $transport = $this->createTransport();
@@ -338,7 +363,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function singlePatternMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -370,7 +397,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardChildReferenceMethodTest()
     {
         $transport = $this->createTransport();
@@ -392,7 +421,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardChildReferenceMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -424,7 +455,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardMethodTest()
     {
         $transport = $this->createTransport();
@@ -446,7 +479,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -478,7 +513,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardMultiMethodTest()
     {
         $transport = $this->createTransport();
@@ -500,7 +537,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardMultiMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -532,7 +571,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardReferenceMethodTest()
     {
         $transport = $this->createTransport();
@@ -554,7 +595,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function wildcardReferenceMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -586,7 +629,9 @@ class ResourceNamesClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function fileLevelChildTypeRefMethodAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/ResumableUpload/out/samples/ResumableUploadClient/create_you_tube_video_upload.php
+++ b/tests/Unit/ProtoTests/ResumableUpload/out/samples/ResumableUploadClient/create_you_tube_video_upload.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResumableUpload/out/src/Client/ResumableUploadClient.php
+++ b/tests/Unit/ProtoTests/ResumableUpload/out/src/Client/ResumableUploadClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -49,16 +50,24 @@ final class ResumableUploadClient
     use GapicClientTrait;
     use ResumableUploadTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.resumableupload.ResumableUpload';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'resumableupload.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -162,7 +171,9 @@ final class ResumableUploadClient
         $this->resumableUploadClient = $this->createResumableUploadClient($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/ResumableUpload/out/src/resources/resumable_upload_descriptor_config.php
+++ b/tests/Unit/ProtoTests/ResumableUpload/out/src/resources/resumable_upload_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResumableUpload/out/src/resources/resumable_upload_rest_client_config.php
+++ b/tests/Unit/ProtoTests/ResumableUpload/out/src/resources/resumable_upload_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/ResumableUpload/out/tests/Unit/Client/ResumableUploadClientTest.php
+++ b/tests/Unit/ProtoTests/ResumableUpload/out/tests/Unit/Client/ResumableUploadClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -37,19 +38,25 @@ use Testing\Resumableupload\CreateYouTubeVideoUploadRequest;
  */
 class ResumableUploadClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return ResumableUploadClient */
+    /**
+     * @return ResumableUploadClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -58,7 +65,9 @@ class ResumableUploadClientTest extends GeneratedTest
         return new ResumableUploadClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function createYouTubeVideoUploadTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/delete_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/delete_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/get_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/get_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/get_no_placeholders_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/get_no_placeholders_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/get_no_template_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/get_no_template_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/nested_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/nested_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/nested_multi_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/nested_multi_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/ordering_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/ordering_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/patch_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/patch_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/post_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/post_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/put_method.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/put_method.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/routing_rule_with_out_parameters.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/routing_rule_with_out_parameters.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/routing_rule_with_parameters.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/samples/RoutingHeadersClient/routing_rule_with_parameters.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/Client/RoutingHeadersClient.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -62,16 +63,24 @@ final class RoutingHeadersClient
 {
     use GapicClientTrait;
 
-    /** The name of the service. */
+    /**
+     * The name of the service.
+     */
     private const SERVICE_NAME = 'testing.routingheaders.RoutingHeaders';
 
-    /** The default address of the service. */
+    /**
+     * The default address of the service.
+     */
     private const SERVICE_ADDRESS = 'routingheaders.example.com';
 
-    /** The default port of the service. */
+    /**
+     * The default port of the service.
+     */
     private const DEFAULT_SERVICE_PORT = 443;
 
-    /** The name of the code generator, to be included in the agent header. */
+    /**
+     * The name of the code generator, to be included in the agent header.
+     */
     private const CODEGEN_NAME = 'gapic';
 
     /**
@@ -174,7 +183,9 @@ final class RoutingHeadersClient
         $this->setClientOptions($clientOptions);
     }
 
-    /** Handles execution of the async variants for each documented method. */
+    /**
+     * Handles execution of the async variants for each documented method.
+     */
     public function __call($method, $args)
     {
         if (substr($method, -5) !== 'Async') {

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_descriptor_config.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_descriptor_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_rest_client_config.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/src/resources/routing_headers_rest_client_config.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2026 Google LLC
  *

--- a/tests/Unit/ProtoTests/RoutingHeaders/out/tests/Unit/Client/RoutingHeadersClientTest.php
+++ b/tests/Unit/ProtoTests/RoutingHeaders/out/tests/Unit/Client/RoutingHeadersClientTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2022 Google LLC
  *
@@ -43,19 +44,25 @@ use stdClass;
  */
 class RoutingHeadersClientTest extends GeneratedTest
 {
-    /** @return TransportInterface */
+    /**
+     * @return TransportInterface
+     */
     private function createTransport($deserialize = null)
     {
         return new MockTransport($deserialize);
     }
 
-    /** @return CredentialsWrapper */
+    /**
+     * @return CredentialsWrapper
+     */
     private function createCredentials()
     {
         return $this->getMockBuilder(CredentialsWrapper::class)->disableOriginalConstructor()->getMock();
     }
 
-    /** @return RoutingHeadersClient */
+    /**
+     * @return RoutingHeadersClient
+     */
     private function createClient(array $options = [])
     {
         $options += [
@@ -64,7 +71,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         return new RoutingHeadersClient($options);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMethodTest()
     {
         $transport = $this->createTransport();
@@ -86,7 +95,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -118,7 +129,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getMethodTest()
     {
         $transport = $this->createTransport();
@@ -140,7 +153,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -172,7 +187,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNoPlaceholdersMethodTest()
     {
         $transport = $this->createTransport();
@@ -194,7 +211,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNoPlaceholdersMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -226,7 +245,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNoTemplateMethodTest()
     {
         $transport = $this->createTransport();
@@ -248,7 +269,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function getNoTemplateMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -280,7 +303,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nestedMethodTest()
     {
         $transport = $this->createTransport();
@@ -315,7 +340,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nestedMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -356,7 +383,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nestedMultiMethodTest()
     {
         $transport = $this->createTransport();
@@ -391,7 +420,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function nestedMultiMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -432,7 +463,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function orderingMethodTest()
     {
         $transport = $this->createTransport();
@@ -475,7 +508,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function orderingMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -518,7 +553,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function patchMethodTest()
     {
         $transport = $this->createTransport();
@@ -540,7 +577,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function patchMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -572,7 +611,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function postMethodTest()
     {
         $transport = $this->createTransport();
@@ -594,7 +635,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function postMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -626,7 +669,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function putMethodTest()
     {
         $transport = $this->createTransport();
@@ -648,7 +693,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function putMethodExceptionTest()
     {
         $transport = $this->createTransport();
@@ -680,7 +727,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function routingRuleWithOutParametersTest()
     {
         $transport = $this->createTransport();
@@ -715,7 +764,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function routingRuleWithOutParametersExceptionTest()
     {
         $transport = $this->createTransport();
@@ -756,7 +807,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function routingRuleWithParametersTest()
     {
         $transport = $this->createTransport();
@@ -791,7 +844,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function routingRuleWithParametersExceptionTest()
     {
         $transport = $this->createTransport();
@@ -832,7 +887,9 @@ class RoutingHeadersClientTest extends GeneratedTest
         $this->assertTrue($transport->isExhausted());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function deleteMethodAsyncTest()
     {
         $transport = $this->createTransport();

--- a/tests/Unit/Utils/FormatterTest.php
+++ b/tests/Unit/Utils/FormatterTest.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+declare(strict_types=1);
+
+namespace Google\Generator\Tests\Unit\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Google\Generator\Utils\Formatter;
+
+final class FormatterTest extends TestCase
+{
+    /**
+     * One case per fixer that appears in the second half of Formatter::format()'s fixer
+     * list. Appending that half with the array union operator instead of a merge dropped
+     * as many entries as the first half contains, so none of these fixers ran. The
+     * dropped count depended on whether the optional line-length fixer was added, so
+     * every case is exercised on both call paths.
+     *
+     * @return array
+     */
+    public function droppedFixerProvider(): array
+    {
+        return [
+            'NoSpacesAfterFunctionNameFixer' => [
+                "<?php\nfoo ();\n",
+                'foo();',
+            ],
+            'NoSpacesInsideParenthesisFixer' => [
+                "<?php\nfoo( 1 );\n",
+                'foo(1);',
+            ],
+            'NoEmptyCommentFixer' => [
+                "<?php\n//\n\$a = 1;\n",
+                '$a = 1;',
+            ],
+            'SingleImportPerStatementFixer' => [
+                "<?php\nuse Foo\\A, Foo\\B;\n\$a = new A();\n\$b = new B();\n",
+                "use Foo\\A;\nuse Foo\\B;",
+            ],
+            'PhpdocLineSpanFixer' => [
+                "<?php\nclass C\n{\n    /** @var int */\n    private \$a = 1;\n}\n",
+                "/**\n     * @var int\n     */",
+            ],
+            'ElseifFixer' => [
+                "<?php\nif (\$a) {\n    \$b = 1;\n} else if (\$c) {\n    \$b = 2;\n}\n",
+                '} elseif',
+            ],
+            'NoTrailingWhitespaceFixer' => [
+                "<?php\n\$a = 1;   \n\$b = 2;\n",
+                "\$a = 1;\n\$b = 2;",
+            ],
+            'NoTrailingWhitespaceInCommentFixer' => [
+                "<?php\n// a comment   \n\$a = 1;\n",
+                "// a comment\n",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider droppedFixerProvider
+     */
+    public function testDroppedFixerRuns(string $code, string $expectedSubstring): void
+    {
+        $this->assertStringContainsString($expectedSubstring, Formatter::format($code));
+        // The snippet call path passes a line length, which changes the length of the
+        // first half of the list and so used to drop a different number of fixers.
+        $this->assertStringContainsString($expectedSubstring, Formatter::format($code, 100));
+    }
+
+    public function testBlankLineAfterOpeningTag(): void
+    {
+        // Annotated in Formatter as "Critical to preserving sample code".
+        $formatted = Formatter::format("<?php\n\$a = 1;\n");
+        $this->assertStringStartsWith("<?php\n\n\$a = 1;", $formatted);
+        $formatted = Formatter::format("<?php\n\$a = 1;\n", 100);
+        $this->assertStringStartsWith("<?php\n\n\$a = 1;", $formatted);
+    }
+
+    public function testLinebreakAfterOpeningTag(): void
+    {
+        // This one was only dropped on the line-length (snippet) call path.
+        $this->assertStringStartsWith("<?php\n", Formatter::format("<?php \$a = 1;\n"));
+        $this->assertStringStartsWith("<?php\n", Formatter::format("<?php \$a = 1;\n", 100));
+    }
+
+    public function testLineEndingFixer(): void
+    {
+        $formatted = Formatter::format("<?php\r\n\$a = 1;\r\n");
+        $this->assertStringNotContainsString("\r", $formatted);
+        $formatted = Formatter::format("<?php\r\n\$a = 1;\r\n", 100);
+        $this->assertStringNotContainsString("\r", $formatted);
+    }
+
+    public function testLineLengthFixerStillRuns(): void
+    {
+        // The line-length fixer sits between the two halves of the list; check the merge
+        // did not displace it.
+        $code = "<?php\nfoo('" . str_repeat('a', 200) . "', 'b');\n";
+        $this->assertStringNotContainsString("\n", trim(substr(Formatter::format($code), 6)));
+        $this->assertStringContainsString("\n    '" . str_repeat('a', 200), Formatter::format($code, 100));
+    }
+}


### PR DESCRIPTION
Three independent defects found while reading `src/`, each in its own commit, ordered lowest-risk first so the last one can be dropped on its own. Tests and regenerated goldens follow in their own commits at the end.

## 1. `Formatter::format()` silently discards 11–12 of its code fixers

`src/Utils/Formatter.php` appends the second half of the fixer list with the array **union** operator instead of a merge:

```php
$fixers = [ /* 11 fixers, keys 0..10 */ ];
if ($lineLength) {
    $fixers[] = self::buildLineLengthFixer($lineLength);   // key 11
}
$fixers += [ /* 25 fixers, keys 0..24 */ ];   // <-- union, not merge
```

`+` keeps the left operand's keys and adopts only right-hand keys that do not already exist. Both operands are 0-indexed lists, so the second list's leading entries collide and are dropped.

Because the optional `LineLengthFixer` changes the left operand's length, the two call paths run **different** pipelines:

| call site | fixers dropped |
|---|---|
| `format($code)` at `CodeGenerator.php:310,317,336,342`, `PhpDoc.php:425` | 11 |
| `format($code, 100)` at `CodeGenerator.php:302` (snippets) | 12 |

Dropped on both paths: `NoSpacesAfterFunctionNameFixer`, `NoEmptyCommentFixer`, `NoSpacesInsideParenthesisFixer`, `BlankLineAfterOpeningTagFixer`, `SingleImportPerStatementFixer`, `PhpdocLineSpanFixer`, `ElseifFixer`, `LineEndingFixer`, `NoTrailingWhitespaceFixer`, `NoTrailingWhitespaceInCommentFixer`, `NoBreakCommentFixer`. The snippet path additionally drops `LinebreakAfterOpeningTagFixer`.

Note that `BlankLineAfterOpeningTagFixer` is annotated in this very file as `// 1, Critical to preserving sample code.`, and it has never run. Consistent with that, none of the 82 golden snippet files under `tests/Unit/ProtoTests/*/out/samples/` has a blank line after `<?php`.

Confirmed on `php:8.2-cli` with a standalone script mirroring the exact list construction (string stand-ins for the fixer objects):

```
lineLength=NULL -> 25 fixers actually run (expected 36)  | DROPPED: 11
lineLength=120  -> 25 fixers actually run (expected 37)  | DROPPED: 12
```

Introduced by #483 (Oct 2022), the change that split the single literal in two to insert the conditional line-length fixer.

Fix: `array_merge($fixers, [...])`.

## 2. Two dead validity checks in `MethodDetails::maybeCreatePaginated()`

**`page_size` repeated-field guard is a dead store.** `$isValidPageSize = !$pageSize->isRepeated()` was immediately overwritten by both branches of the following `if/else`, so the guard never applied. A `repeated int32 page_size` passed validation and produced a client treating a `RepeatedField` as an int. The sibling `page_token` and `next_page_token` checks both include `isRepeated()`, so this reads as an omission rather than a deliberate relaxation.

**The malformed-resource-field diagnostic is unreachable, and is now deleted.** `!$resourceFieldValid` is part of the early `return null`, so the later `if (!$resourceFieldValid)` branch and its two exceptions can never be reached. Per review this takes the conservative route: the early return keeps its `!$resourceFieldValid` condition and the dead branch below is deleted. A response message whose resource field is a map, or is not first by both number and position, still generates as non-paginated, exactly as today. The dead code goes without changing what the generator accepts.

Also replaces the bitwise `&=` on a boolean with `&&` so `$resourceFieldValid` stays a bool rather than becoming int `0`/`1`.

## 3. `Map` exception messages crash on object keys

`Map` documents that keys may be any type supporting equality, and `Equality` requires only `getHash()`/`isEqualTo()`, not `__toString()`. Both error paths interpolated the key directly, so a lookup miss or duplicate-key collision on an object-keyed map raised

```
Error: Object of class X could not be converted to string
```

masking the diagnostic being reported. `ProtoCatalog::filesByService` is keyed by `ServiceDescriptorProto` and is looked up at `ResourcesGenerator.php:253`, so this is reachable. Keys are now rendered through a helper that falls back to the class name.

## Tests

Each defect now has a test that fails on `main` and passes here. 13 of them fail on `main`.

- `tests/Unit/Utils/FormatterTest.php`: one case per fixer the union operator was discarding, each asserted on both call paths, because `format($code)` and `format($code, 100)` dropped a different number of fixers. Also a case checking the line length fixer itself still runs after the merge, so the fix did not displace it.
- `tests/Unit/Generation/MethodDetailsTest.php` with `repeated-page-size.proto`: a `repeated int32 page_size` is now rejected. Before the fix the dead store let it through and the generator emitted a client treating a `RepeatedField` as an int.
- `tests/Unit/Collections/MapTest.php`: exception messages for a missing object key, a duplicate object key, a key with `__toString`, and scalar keys.

## Goldens

Regenerated, both sets.

- 162 unit golden files, via `tests/Unit/ProtoTests/GoldenUpdateMain.php`.
- 611 integration golden files, via `bazelisk run //tests/Integration:<api>_update` for all 15 APIs.

The entire diff across both sets is two things: `PhpdocLineSpanFixer` expanding one line docblocks, and `BlankLineAfterOpeningTagFixer` adding a blank line after `<?php`. No changed line in either set is anything other than a comment or a blank line, so no generated behaviour moves.

Before trusting that, I checked the regeneration is faithful. On `upstream/main` with an expunged bazel cache, regenerating all 15 integration golden sets gives a zero diff, so the toolchain I used reproduces the checked in goldens byte for byte. The same holds for the unit goldens.

One trap worth recording for whoever regenerates next. `bazel run //tests/Integration:<api>_update` will silently reuse a stale generator, because `src/` reaches the build through the `php_gapic_generator_composer_install` repository rule, and repository rules do not re-run when workspace files change. My first regeneration on `main` reproduced this branch's diff exactly, which is how I caught it. Run `bazelisk clean --expunge` first, which is what the `--expunge` flag on `run_bazel_updates.sh` is for.

## Verification

- Unit suite: 311 tests pass. Baseline on `upstream/main` is 293, and the 18 added tests account for the difference.
- Bazel integration tests: 15 of 15 pass.

An earlier revision of this description said the test suite could not be run here. That was outbound network failing to reach packagist, and it is fixed, so please disregard it. Full working setup, in case it saves anyone else the same detour:

```
composer install --prefer-dist && composer dump-autoload
git submodule update --init --recursive
USE_TOOLS_PROTOC=true vendor/bin/phpunit --bootstrap tests/Unit/autoload.php tests/Unit
```

Two things that bit me. PHP needs `ext-bcmath`, or `testGrpcServiceConfig` errors out with `Call to undefined function bccomp()`. And do not pass `--ignore-platform-reqs` to `composer install`, because it resolves Symfony 8.x, which is a parse error on PHP 8.2 and kills the run before any test reports.

## Behaviour

No commit on this branch changes what input the generator accepts.

Commit 2 is dead code removal only. The first revision revived the malformed resource field exception, which would have turned a silent fallback into a hard failure for any proto whose resource field is not first by both number and position. Following review, the unreachable branch is deleted instead. A response message whose resource field is a map, or is not first by both number and position, still generates as non paginated, exactly as today.

Commit 1's formatters do change generated output, which is why the goldens are regenerated above.
