### PR TITLE
feat: recursively search for proto/src in ProtobufNoCheckInHeaderProcessor

### DIFF
--- a/src/PostProcessor/ProtobufNoCheckInHeaderProcessor.php
+++ b/src/PostProcessor/ProtobufNoCheckInHeaderProcessor.php
@@ -22,15 +22,18 @@ class ProtobufNoCheckInHeaderProcessor implements ProcessorInterface
 {
     public static function run(string $inputDir): void
     {
-        $protoSrcDir = $inputDir . '/proto/src';
-        if (!is_dir($protoSrcDir)) {
+        if (!is_dir($inputDir)) {
             return;
         }
-        $protoDir = new \RecursiveDirectoryIterator($protoSrcDir);
+        $protoDir = new \RecursiveDirectoryIterator($inputDir);
         $protoDirItr = new \RecursiveIteratorIterator($protoDir);
         $protoItr = new \RegexIterator($protoDirItr, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH);
         foreach ($protoItr as $finding) {
-            self::inject($finding[0]);
+            $classFile = $finding[0];
+            if (!str_contains(dirname($classFile), '/proto/src')) {
+                continue;
+            }
+            self::inject($classFile);
         }
     }
 

--- a/tests/Unit/PostProcessor/ProtobufNoCheckInHeaderProcessorTest.php
+++ b/tests/Unit/PostProcessor/ProtobufNoCheckInHeaderProcessorTest.php
@@ -112,6 +112,47 @@ EOL;
         $this->assertTrue(true); // If we reach here, no exception was thrown.
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRunDoesNotFailWhenInputDirectoryDoesNotExist()
+    {
+        $tmpDir = sys_get_temp_dir() . '/test-nonexistent-dir-' . rand();
+
+        // This should not throw an exception.
+        ProtobufNoCheckInHeaderProcessor::run($tmpDir);
+
+        $this->assertTrue(true); // If we reach here, no exception was thrown.
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testProtobufProcessorRecursivelyFiltersProtoSrc()
+    {
+        $tmpDir = sys_get_temp_dir() . '/test-recursive-proto-src-' . rand();
+        $nestedProtoSrcDir = $tmpDir . '/nested/dir/proto/src/Google/Api';
+        $nonProtoDir = $tmpDir . '/nested/dir/src/Google/Api';
+        mkdir($nestedProtoSrcDir, 0777, true);
+        mkdir($nonProtoDir, 0777, true);
+
+        file_put_contents($protoFile = $nestedProtoSrcDir . '/Bar.php', $this->classContents);
+        file_put_contents($nonProtoFile = $nonProtoDir . '/Baz.php', $this->classContents);
+
+        ProtobufNoCheckInHeaderProcessor::run($tmpDir);
+
+        // Verify the proto file had the header removed
+        $protoFileContents = file_get_contents($protoFile);
+        $this->assertFalse($this->classContainsNoCheckInHeader($protoFileContents));
+
+        // Verify the non-proto file was untouched
+        $nonProtoFileContents = file_get_contents($nonProtoFile);
+        $this->assertTrue($this->classContainsNoCheckInHeader($nonProtoFileContents));
+
+        // Verify post-processor output only logged the proto file
+        $this->expectOutputString('No Check-In Header removed in ' . $protoFile . PHP_EOL);
+    }
+
     private function classContainsNoCheckInHeader(string $classContents): bool
     {
         $tokens = token_get_all($classContents);


### PR DESCRIPTION
Updates `ProtobufNoCheckInHeaderProcessor` to search the input directory recursively rather than expecting `proto/src` to be at the top level. Filters findings so only PHP files whose directory path contains `/proto/src` are processed.

- Traverse inputDir recursively using RecursiveDirectoryIterator
- Filter files based on whether their directory contains '/proto/src'
- Add unit tests for recursive traversal and filtering
